### PR TITLE
Add explicit embed config and remote Ollama support

### DIFF
--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -29,22 +29,22 @@ type CompileOpts struct {
 
 // CompileResult summarizes what happened during compilation.
 type CompileResult struct {
-	Added              int
-	Modified           int
-	Removed            int
-	Summarized         int
-	ConceptsExtracted  int
-	ArticlesWritten    int
-	Errors             int
+	Added             int
+	Modified          int
+	Removed           int
+	Summarized        int
+	ConceptsExtracted int
+	ArticlesWritten   int
+	Errors            int
 }
 
 // CompileState tracks progress for checkpoint/resume (ADR-018).
 type CompileState struct {
-	CompileID string   `json:"compile_id"`
-	StartedAt string   `json:"started_at"`
-	Pass      int      `json:"pass"`
-	Completed []string `json:"completed"`
-	Pending   []string `json:"pending"`
+	CompileID string         `json:"compile_id"`
+	StartedAt string         `json:"started_at"`
+	Pass      int            `json:"pass"`
+	Completed []string       `json:"completed"`
+	Pending   []string       `json:"pending"`
 	Failed    []FailedSource `json:"failed,omitempty"`
 }
 
@@ -128,7 +128,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 
 	// Initialize checkpoint state
 	if state == nil {

--- a/internal/compiler/reembed.go
+++ b/internal/compiler/reembed.go
@@ -20,7 +20,7 @@ func ReEmbed(projectDir string) (int, error) {
 		return 0, fmt.Errorf("re-embed: load config: %w", err)
 	}
 
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 	if embedder == nil {
 		return 0, fmt.Errorf("re-embed: no embedding provider available")
 	}

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -76,7 +76,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
 	ontStore := ontology.NewStore(db)
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 
 	// Pass 2: Concept extraction
 	extractModel := cfg.Models.Extract

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,16 +11,16 @@ import (
 
 // Config represents the sage-wiki project configuration.
 type Config struct {
-	Version     int          `yaml:"version"`
-	Project     string       `yaml:"project"`
-	Description string       `yaml:"description"`
-	Vault       *VaultConfig `yaml:"vault,omitempty"`
-	Sources     []Source     `yaml:"sources"`
-	Output      string       `yaml:"output"`
-	Ignore      []string     `yaml:"ignore,omitempty"`
-	API         APIConfig    `yaml:"api"`
-	Models      ModelsConfig `yaml:"models"`
-	Embed       *EmbedConfig `yaml:"embed,omitempty"`
+	Version     int            `yaml:"version"`
+	Project     string         `yaml:"project"`
+	Description string         `yaml:"description"`
+	Vault       *VaultConfig   `yaml:"vault,omitempty"`
+	Sources     []Source       `yaml:"sources"`
+	Output      string         `yaml:"output"`
+	Ignore      []string       `yaml:"ignore,omitempty"`
+	API         APIConfig      `yaml:"api"`
+	Models      ModelsConfig   `yaml:"models"`
+	Embed       *EmbedConfig   `yaml:"embed,omitempty"`
 	Compiler    CompilerConfig `yaml:"compiler"`
 	Search      SearchConfig   `yaml:"search"`
 	Linting     LintingConfig  `yaml:"linting"`
@@ -89,6 +89,10 @@ func Defaults() Config {
 		Version: 1,
 		Output:  "wiki",
 		Sources: []Source{{Path: "raw", Type: "auto", Watch: true}},
+		Embed: &EmbedConfig{
+			Provider: "auto",
+			Model:    "",
+		},
 		Compiler: CompilerConfig{
 			MaxParallel:      4,
 			DebounceSeconds:  2,
@@ -161,6 +165,14 @@ func (c *Config) Validate() error {
 		}
 		if !validProviders[c.API.Provider] {
 			return fmt.Errorf("config: invalid provider %q (valid: anthropic, openai, gemini, ollama, openai-compatible)", c.API.Provider)
+		}
+	}
+	if c.Embed != nil && c.Embed.Provider != "" {
+		validEmbedProviders := map[string]bool{
+			"auto": true, "openai": true, "gemini": true, "ollama": true, "openai-compatible": true, "voyage": true, "mistral": true,
+		}
+		if !validEmbedProviders[c.Embed.Provider] {
+			return fmt.Errorf("config: invalid embed provider %q (valid: auto, openai, gemini, ollama, openai-compatible, voyage, mistral)", c.Embed.Provider)
 		}
 	}
 	if c.Serve.Transport != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,12 @@ func TestDefaults(t *testing.T) {
 	if cfg.Search.HybridWeightBM25 != 0.7 {
 		t.Errorf("expected bm25 weight 0.7, got %f", cfg.Search.HybridWeightBM25)
 	}
+	if cfg.Embed == nil {
+		t.Fatal("expected default embed config")
+	}
+	if cfg.Embed.Provider != "auto" {
+		t.Errorf("expected default embed provider 'auto', got %q", cfg.Embed.Provider)
+	}
 }
 
 func TestLoadGreenfield(t *testing.T) {
@@ -172,6 +178,11 @@ func TestValidation(t *testing.T) {
 			name:    "invalid transport",
 			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Serve: ServeConfig{Transport: "websocket"}},
 			wantErr: "invalid transport",
+		},
+		{
+			name:    "invalid embed provider",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Embed: &EmbedConfig{Provider: "bad-provider"}},
+			wantErr: "invalid embed provider",
 		},
 		{
 			name: "valid minimal",

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/log"
 )
 
@@ -28,11 +30,22 @@ var defaultModels = map[string]string{
 
 // Default dimensions per model.
 var defaultDimensions = map[string]int{
-	"text-embedding-3-small": 1536,
+	"text-embedding-3-small":     1536,
 	"gemini-embedding-2-preview": 768,
-	"voyage-3-lite":          1024,
-	"mistral-embed":          1024,
-	"nomic-embed-text":       768,
+	"voyage-3-lite":              1024,
+	"mistral-embed":              1024,
+	"nomic-embed-text":           768,
+}
+
+const defaultOllamaBaseURL = "http://localhost:11434"
+const defaultOllamaEmbedModel = "nomic-embed-text"
+
+// NewForConfig creates an embedder using config-driven overrides when present.
+func NewForConfig(cfg *config.Config) Embedder {
+	if cfg == nil {
+		return nil
+	}
+	return newWithConfig(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, cfg.Embed)
 }
 
 // NewCascade auto-detects the best available embedding provider.
@@ -40,31 +53,153 @@ var defaultDimensions = map[string]int{
 // Tier 2: Ollama local (if running).
 // Returns nil if no embedding provider is available.
 func NewCascade(provider string, apiKey string, baseURL string) Embedder {
+	return newWithConfig(provider, apiKey, baseURL, nil)
+}
+
+func newWithConfig(apiProvider string, apiKey string, baseURL string, embedCfg *config.EmbedConfig) Embedder {
+	if embedCfg == nil {
+		return cascadeEmbedder(apiProvider, apiKey, baseURL)
+	}
+
+	provider := strings.TrimSpace(embedCfg.Provider)
+	model := strings.TrimSpace(embedCfg.Model)
+	dims := embedCfg.Dimensions
+
+	if provider == "" {
+		provider = "auto"
+	}
+
+	if provider == "auto" && model == "" && dims == 0 {
+		return cascadeEmbedder(apiProvider, apiKey, baseURL)
+	}
+
+	if provider == "auto" {
+		provider = autoEmbedProvider(apiProvider, apiKey, baseURL, model)
+		if provider == "" {
+			log.Warn("no embedding provider available â€” vector search disabled. Install Ollama or configure an embedding-capable provider.")
+			return nil
+		}
+	}
+
+	return newConfiguredEmbedder(provider, model, dims, apiProvider, apiKey, baseURL)
+}
+
+func cascadeEmbedder(provider string, apiKey string, baseURL string) Embedder {
 	// Tier 1: Provider embedding API
 	if model, ok := defaultModels[provider]; ok && apiKey != "" {
-		dims := defaultDimensions[model]
-		embedder := &APIEmbedder{
-			provider: provider,
-			model:    model,
-			apiKey:   apiKey,
-			baseURL:  baseURL,
-			dims:     dims,
-		}
-		log.Info("embedding provider detected", "tier", 1, "provider", provider, "model", model, "dims", dims)
-		return embedder
+		return newAPIEmbedder(provider, model, defaultDimensions[model], apiKey, baseURL, 1, true)
 	}
 
-	// Tier 2: Ollama local
-	if ollamaAvailable() {
-		log.Info("embedding provider detected", "tier", 2, "provider", "ollama", "model", "nomic-embed-text", "dims", 768)
-		return &OllamaEmbedder{
-			model: "nomic-embed-text",
-			dims:  768,
-		}
+	// Tier 2: Ollama
+	ollamaBaseURL := ResolveOllamaBaseURL(provider, baseURL)
+	if ollamaAvailable(ollamaBaseURL) {
+		return newOllamaEmbedder(defaultOllamaEmbedModel, defaultDimensions[defaultOllamaEmbedModel], ollamaBaseURL, 2, true)
 	}
 
-	log.Warn("no embedding provider available — vector search disabled. Install Ollama or configure an embedding-capable provider.")
+	log.Warn("no embedding provider available â€” vector search disabled. Install Ollama or configure an embedding-capable provider.")
 	return nil
+}
+
+func autoEmbedProvider(apiProvider string, apiKey string, baseURL string, model string) string {
+	if apiProvider == "openai-compatible" && model != "" && baseURL != "" {
+		return apiProvider
+	}
+	if _, ok := defaultModels[apiProvider]; ok && apiKey != "" {
+		return apiProvider
+	}
+	if ollamaAvailable(ResolveOllamaBaseURL(apiProvider, baseURL)) {
+		return "ollama"
+	}
+	return ""
+}
+
+func newConfiguredEmbedder(provider string, model string, dims int, apiProvider string, apiKey string, baseURL string) Embedder {
+	switch provider {
+	case "ollama":
+		if model == "" {
+			model = defaultOllamaEmbedModel
+		}
+		if dims == 0 {
+			dims = defaultDimensions[model]
+		}
+
+		ollamaBaseURL := defaultOllamaBaseURL
+		if apiProvider == "ollama" {
+			ollamaBaseURL = ResolveOllamaBaseURL(apiProvider, baseURL)
+		}
+		if !ollamaAvailable(ollamaBaseURL) {
+			log.Warn("configured Ollama embedding provider unavailable", "base_url", ollamaBaseURL)
+			return nil
+		}
+		return newOllamaEmbedder(model, dims, ollamaBaseURL, 0, false)
+	case "openai", "gemini", "voyage", "mistral", "openai-compatible":
+		if model == "" {
+			model = defaultModels[provider]
+		}
+		if model == "" {
+			log.Warn("embedding provider requires a model", "provider", provider)
+			return nil
+		}
+		if dims == 0 {
+			dims = defaultDimensions[model]
+		}
+		if provider == "openai-compatible" && baseURL == "" {
+			log.Warn("openai-compatible embedding provider requires api.base_url")
+			return nil
+		}
+		if provider != "openai-compatible" && apiKey == "" {
+			log.Warn("embedding provider requires an API key", "provider", provider)
+			return nil
+		}
+		return newAPIEmbedder(provider, model, dims, apiKey, baseURL, 0, false)
+	default:
+		log.Warn("unsupported embedding provider configured", "provider", provider)
+		return nil
+	}
+}
+
+func newAPIEmbedder(provider string, model string, dims int, apiKey string, baseURL string, tier int, detected bool) Embedder {
+	if detected {
+		log.Info("embedding provider detected", "tier", tier, "provider", provider, "model", model, "dims", dims)
+	} else {
+		log.Info("embedding provider configured", "provider", provider, "model", model, "dims", dims)
+	}
+
+	return &APIEmbedder{
+		provider: provider,
+		model:    model,
+		apiKey:   apiKey,
+		baseURL:  baseURL,
+		dims:     dims,
+	}
+}
+
+func newOllamaEmbedder(model string, dims int, baseURL string, tier int, detected bool) Embedder {
+	if detected {
+		log.Info("embedding provider detected", "tier", tier, "provider", "ollama", "model", model, "dims", dims)
+	} else {
+		log.Info("embedding provider configured", "provider", "ollama", "model", model, "dims", dims)
+	}
+
+	return &OllamaEmbedder{
+		model:   model,
+		dims:    dims,
+		baseURL: baseURL,
+	}
+}
+
+// ResolveOllamaBaseURL returns the Ollama base URL to use for the current
+// provider. We only honor api.base_url when the configured provider is Ollama.
+func ResolveOllamaBaseURL(provider string, baseURL string) string {
+	if provider == "ollama" && baseURL != "" {
+		return strings.TrimRight(baseURL, "/")
+	}
+	return defaultOllamaBaseURL
+}
+
+// OllamaAvailable probes the resolved Ollama endpoint for availability.
+func OllamaAvailable(provider string, baseURL string) bool {
+	return ollamaAvailable(ResolveOllamaBaseURL(provider, baseURL))
 }
 
 // APIEmbedder calls a provider's embedding API.
@@ -77,8 +212,8 @@ type APIEmbedder struct {
 	client   http.Client
 }
 
-func (e *APIEmbedder) Name() string     { return fmt.Sprintf("%s/%s", e.provider, e.model) }
-func (e *APIEmbedder) Dimensions() int  { return e.dims }
+func (e *APIEmbedder) Name() string    { return fmt.Sprintf("%s/%s", e.provider, e.model) }
+func (e *APIEmbedder) Dimensions() int { return e.dims }
 
 func (e *APIEmbedder) Embed(text string) ([]float32, error) {
 	if e.provider == "gemini" {
@@ -102,7 +237,9 @@ func (e *APIEmbedder) embedOpenAI(text string) ([]float32, error) {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	if e.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	}
 
 	resp, err := e.client.Do(req)
 	if err != nil {
@@ -197,15 +334,16 @@ func (e *APIEmbedder) embeddingURL() string {
 	return base + "/embeddings"
 }
 
-// OllamaEmbedder uses a local Ollama instance.
+// OllamaEmbedder uses an Ollama instance.
 type OllamaEmbedder struct {
-	model  string
-	dims   int
-	client http.Client
+	model   string
+	dims    int
+	baseURL string
+	client  http.Client
 }
 
-func (e *OllamaEmbedder) Name() string     { return fmt.Sprintf("ollama/%s", e.model) }
-func (e *OllamaEmbedder) Dimensions() int  { return e.dims }
+func (e *OllamaEmbedder) Name() string    { return fmt.Sprintf("ollama/%s", e.model) }
+func (e *OllamaEmbedder) Dimensions() int { return e.dims }
 
 func (e *OllamaEmbedder) Embed(text string) ([]float32, error) {
 	body, _ := json.Marshal(map[string]any{
@@ -213,7 +351,12 @@ func (e *OllamaEmbedder) Embed(text string) ([]float32, error) {
 		"prompt": text,
 	})
 
-	resp, err := e.client.Post("http://localhost:11434/api/embeddings", "application/json", bytes.NewReader(body))
+	baseURL := e.baseURL
+	if baseURL == "" {
+		baseURL = defaultOllamaBaseURL
+	}
+
+	resp, err := e.client.Post(baseURL+"/api/embeddings", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("ollama embed: %w", err)
 	}
@@ -239,10 +382,13 @@ func (e *OllamaEmbedder) Embed(text string) ([]float32, error) {
 	return result.Embedding, nil
 }
 
-// ollamaAvailable probes localhost:11434 for a running Ollama instance.
-func ollamaAvailable() bool {
+// ollamaAvailable probes the given endpoint for a running Ollama instance.
+func ollamaAvailable(baseURL string) bool {
+	if baseURL == "" {
+		baseURL = defaultOllamaBaseURL
+	}
 	client := http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get("http://localhost:11434/api/tags")
+	resp, err := client.Get(baseURL + "/api/tags")
 	if err != nil {
 		return false
 	}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/xoai/sage-wiki/internal/config"
 )
 
 func TestCascadeTier1(t *testing.T) {
@@ -111,5 +113,104 @@ func TestDefaultModels(t *testing.T) {
 		if dims <= 0 {
 			t.Errorf("invalid dimensions %d for %s", dims, model)
 		}
+	}
+}
+
+func TestResolveOllamaBaseURL(t *testing.T) {
+	if got := ResolveOllamaBaseURL("ollama", "http://example:11434/"); got != "http://example:11434" {
+		t.Fatalf("expected trimmed ollama URL, got %q", got)
+	}
+
+	if got := ResolveOllamaBaseURL("openai-compatible", "http://example:11434"); got != defaultOllamaBaseURL {
+		t.Fatalf("expected localhost fallback for non-ollama provider, got %q", got)
+	}
+}
+
+func TestOllamaEmbedderUsesConfiguredBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "nomic-embed-text:latest"}},
+			})
+		case "/api/embeddings":
+			json.NewEncoder(w).Encode(map[string]any{
+				"embedding": []float32{0.1, 0.2, 0.3},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	e := NewCascade("ollama", "", server.URL)
+	if e == nil {
+		t.Fatal("expected embedder for remote ollama")
+	}
+
+	ollama, ok := e.(*OllamaEmbedder)
+	if !ok {
+		t.Fatalf("expected OllamaEmbedder, got %T", e)
+	}
+	if ollama.baseURL != server.URL {
+		t.Fatalf("expected base URL %q, got %q", server.URL, ollama.baseURL)
+	}
+
+	vec, err := ollama.Embed("test text")
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vec) != 3 {
+		t.Fatalf("expected 3 dimensions, got %d", len(vec))
+	}
+}
+
+func TestNewForConfigAutoKeepsCurrentBehavior(t *testing.T) {
+	cfg := &config.Config{
+		API: config.APIConfig{
+			Provider: "openai",
+			APIKey:   "sk-test",
+		},
+		Embed: &config.EmbedConfig{
+			Provider: "auto",
+		},
+	}
+
+	e := NewForConfig(cfg)
+	if e == nil {
+		t.Fatal("expected embedder")
+	}
+	if e.Name() != "openai/text-embedding-3-small" {
+		t.Fatalf("unexpected embedder name %q", e.Name())
+	}
+}
+
+func TestNewForConfigUsesExplicitEmbedModel(t *testing.T) {
+	cfg := &config.Config{
+		API: config.APIConfig{
+			Provider: "openai",
+			APIKey:   "sk-test",
+		},
+		Embed: &config.EmbedConfig{
+			Provider:   "openai",
+			Model:      "text-embedding-3-small",
+			Dimensions: 1536,
+		},
+	}
+
+	e := NewForConfig(cfg)
+	if e == nil {
+		t.Fatal("expected embedder")
+	}
+
+	api, ok := e.(*APIEmbedder)
+	if !ok {
+		t.Fatalf("expected APIEmbedder, got %T", e)
+	}
+	if api.model != "text-embedding-3-small" {
+		t.Fatalf("unexpected model %q", api.model)
+	}
+	if api.dims != 1536 {
+		t.Fatalf("unexpected dimensions %d", api.dims)
 	}
 }

--- a/internal/mcp/tools_write.go
+++ b/internal/mcp/tools_write.go
@@ -294,7 +294,7 @@ func (s *Server) handleCompileDiff(ctx context.Context, req mcplib.CallToolReque
 }
 
 func (s *Server) tryEmbed(id string, content string) {
-	embedder := embed.NewCascade(s.cfg.API.Provider, s.cfg.API.APIKey, s.cfg.API.BaseURL)
+	embedder := embed.NewForConfig(s.cfg)
 	if embedder != nil {
 		if vec, err := embedder.Embed(content); err == nil {
 			s.vec.Upsert(id, vec)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -20,11 +20,11 @@ import (
 
 // QueryResult holds the answer and metadata.
 type QueryResult struct {
-	Question    string
-	Answer      string
-	Sources     []string // article paths used
-	Format      string   // markdown, terminal, marp
-	OutputPath  string   // if auto-filed
+	Question   string
+	Answer     string
+	Sources    []string // article paths used
+	Format     string   // markdown, terminal, marp
+	OutputPath string   // if auto-filed
 }
 
 // QueryOpts allows callers to pass shared resources.
@@ -69,7 +69,7 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
 	// Get query embedding for hybrid search
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 	var queryVec []float32
 	if embedder != nil {
 		queryVec, _ = embedder.Embed(question)

--- a/internal/wiki/doctor.go
+++ b/internal/wiki/doctor.go
@@ -2,10 +2,8 @@ package wiki
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/embed"
@@ -87,7 +85,7 @@ func RunDoctor(projectDir string) *DoctorResult {
 	}
 
 	// Check embedding
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 	if embedder != nil {
 		result.add("embedding", "ok", fmt.Sprintf("Embedding: %s (%d-dim)", embedder.Name(), embedder.Dimensions()))
 	} else {
@@ -95,13 +93,11 @@ func RunDoctor(projectDir string) *DoctorResult {
 	}
 
 	// Check Ollama
-	ollamaClient := http.Client{Timeout: 2 * time.Second}
-	resp, err := ollamaClient.Get("http://localhost:11434/api/tags")
-	if err != nil {
-		result.add("ollama", "info", "Ollama not running (optional)")
+	ollamaBaseURL := embed.ResolveOllamaBaseURL(cfg.API.Provider, cfg.API.BaseURL)
+	if embed.OllamaAvailable(cfg.API.Provider, cfg.API.BaseURL) {
+		result.add("ollama", "ok", fmt.Sprintf("Ollama running at %s", ollamaBaseURL))
 	} else {
-		resp.Body.Close()
-		result.add("ollama", "ok", "Ollama running at localhost:11434")
+		result.add("ollama", "info", fmt.Sprintf("Ollama not running at %s (optional)", ollamaBaseURL))
 	}
 
 	// Check git

--- a/internal/wiki/doctor_test.go
+++ b/internal/wiki/doctor_test.go
@@ -1,0 +1,69 @@
+package wiki
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunDoctorUsesConfiguredOllamaBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{{"name": "gemma4:e4b-it-q8_0"}},
+			})
+		case "/v1/chat/completions":
+			json.NewEncoder(w).Encode(map[string]any{
+				"choices": []map[string]any{
+					{"message": map[string]any{"content": "ok"}},
+				},
+				"model": "gemma4:e4b-it-q8_0",
+				"usage": map[string]any{"total_tokens": 3},
+			})
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	if err := InitGreenfield(dir, "doctor-ollama"); err != nil {
+		t.Fatalf("InitGreenfield: %v", err)
+	}
+
+	cfg := `project: doctor-ollama
+api:
+  provider: ollama
+  base_url: ` + server.URL + `
+models:
+  summarize: gemma4:e4b-it-q8_0
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := RunDoctor(dir)
+
+	var ollamaMessage string
+	var connectivityOK bool
+	for _, check := range result.Checks {
+		if check.Name == "ollama" {
+			ollamaMessage = check.Message
+		}
+		if check.Name == "connectivity" && check.Status == "ok" {
+			connectivityOK = true
+		}
+	}
+
+	if !connectivityOK {
+		t.Fatalf("expected connectivity check to succeed, got %+v", result.Checks)
+	}
+	if !strings.Contains(ollamaMessage, server.URL) {
+		t.Fatalf("expected ollama message to mention %q, got %q", server.URL, ollamaMessage)
+	}
+}

--- a/internal/wiki/init_test.go
+++ b/internal/wiki/init_test.go
@@ -3,6 +3,7 @@ package wiki
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -35,6 +36,16 @@ func TestInitGreenfield(t *testing.T) {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		t.Error("config.yaml should exist")
+	}
+	cfgData, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	if !strings.Contains(string(cfgData), "embed:") {
+		t.Error("config.yaml should include embed section")
+	}
+	if !strings.Contains(string(cfgData), "provider: auto") {
+		t.Error("config.yaml should include default embed provider")
 	}
 
 	// Verify .gitignore
@@ -98,6 +109,14 @@ func TestInitVaultOverlay(t *testing.T) {
 	clippingsTest := filepath.Join(dir, "Clippings", "test.md")
 	if _, err := os.Stat(clippingsTest); os.IsNotExist(err) {
 		t.Error("source files should not be modified")
+	}
+
+	cfgData, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	if !strings.Contains(string(cfgData), "embed:") {
+		t.Error("config.yaml should include embed section")
 	}
 }
 

--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -16,23 +16,23 @@ import (
 
 // StatusInfo holds wiki stats for display.
 type StatusInfo struct {
-	Project        string
-	Mode           string // greenfield or vault-overlay
-	SourceCount    int
-	PendingCount   int
-	ConceptCount   int
-	EntryCount     int
-	VectorCount    int
-	VectorDims     int
-	EntityCount    int
-	RelationCount  int
-	LearningCount  int
-	EmbedProvider  string
-	EmbedDims      int
-	DimMismatch    bool
-	GitClean       bool
-	LastCommit     string
-	LastMessage    string
+	Project       string
+	Mode          string // greenfield or vault-overlay
+	SourceCount   int
+	PendingCount  int
+	ConceptCount  int
+	EntryCount    int
+	VectorCount   int
+	VectorDims    int
+	EntityCount   int
+	RelationCount int
+	LearningCount int
+	EmbedProvider string
+	EmbedDims     int
+	DimMismatch   bool
+	GitClean      bool
+	LastCommit    string
+	LastMessage   string
 }
 
 // Stores holds shared store references to avoid re-opening the DB.
@@ -101,7 +101,7 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 	info.RelationCount, _ = ontStore.RelationCount()
 
 	// Embedding provider
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	embedder := embed.NewForConfig(cfg)
 	if embedder != nil {
 		info.EmbedProvider = embedder.Name()
 		info.EmbedDims = embedder.Dimensions()


### PR DESCRIPTION
## Summary

I updated the embedding setup so it is visible in generated `config.yaml`, actually honored at runtime, and works correctly with remote Ollama instances.

## Problems

There were a few related issues:

1. `sage-wiki init` created a `config.yaml` without embedding configuration, even though the codebase already had an `embed` config type.
2. The runtime mostly ignored `embed.*` settings and still relied on the main API provider for embedding behavior.
3. Remote Ollama worked for chat completions via `api.base_url`, but embedding calls and `doctor` checks still assumed `http://localhost:11434`.
4. This made it hard to use a remote Ollama host with a separate embedding model, and the generated config did not make that workflow obvious.

## What Changed

### 1. `init` now writes embedding config
Generated `config.yaml` now includes:

```yaml
embed:
  provider: auto
  model: ""
