### PR TITLE
feat: respect embed config block for custom model/credentials

### DIFF
--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -130,11 +130,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 
 	// Initialize checkpoint state
 	if state == nil {

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -130,7 +130,11 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 
 	// Initialize checkpoint state
 	if state == nil {

--- a/internal/compiler/reembed.go
+++ b/internal/compiler/reembed.go
@@ -20,11 +20,7 @@ func ReEmbed(projectDir string) (int, error) {
 		return 0, fmt.Errorf("re-embed: load config: %w", err)
 	}
 
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 	if embedder == nil {
 		return 0, fmt.Errorf("re-embed: no embedding provider available")
 	}

--- a/internal/compiler/reembed.go
+++ b/internal/compiler/reembed.go
@@ -20,7 +20,11 @@ func ReEmbed(projectDir string) (int, error) {
 		return 0, fmt.Errorf("re-embed: load config: %w", err)
 	}
 
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 	if embedder == nil {
 		return 0, fmt.Errorf("re-embed: no embedding provider available")
 	}

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -76,11 +76,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
 	ontStore := ontology.NewStore(db)
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 
 	// Pass 2: Concept extraction
 	extractModel := cfg.Models.Extract

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -76,7 +76,11 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
 	ontStore := ontology.NewStore(db)
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 
 	// Pass 2: Concept extraction
 	extractModel := cfg.Models.Extract

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,8 @@ type EmbedConfig struct {
 	Provider   string `yaml:"provider"`
 	Model      string `yaml:"model"`
 	Dimensions int    `yaml:"dimensions,omitempty"`
+	APIKey     string `yaml:"api_key,omitempty"`
+	BaseURL    string `yaml:"base_url,omitempty"`
 }
 
 type CompilerConfig struct {

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/log"
 )
 
@@ -44,6 +45,22 @@ type EmbedOverride struct {
 	BaseURL    string
 }
 
+// NewFromConfig creates an Embedder from the project config, using embed
+// overrides when present and falling back to auto-detection from api config.
+func NewFromConfig(cfg *config.Config) Embedder {
+	var ov *EmbedOverride
+	if cfg.Embed != nil {
+		ov = &EmbedOverride{
+			Provider:   cfg.Embed.Provider,
+			Model:      cfg.Embed.Model,
+			Dimensions: cfg.Embed.Dimensions,
+			APIKey:     cfg.Embed.APIKey,
+			BaseURL:    cfg.Embed.BaseURL,
+		}
+	}
+	return NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+}
+
 // NewCascade auto-detects the best available embedding provider.
 // Tier 0: Explicit embed config override (if model + credentials provided).
 // Tier 1: Provider embedding API (if available).
@@ -70,6 +87,7 @@ func NewCascade(provider string, apiKey string, baseURL string, override *EmbedO
 				dims = defaultDimensions[override.Model]
 				if dims == 0 {
 					dims = 1536
+					log.Warn("unknown model dimensions, falling back to 1536", "model", override.Model)
 				}
 			}
 			embedder := &APIEmbedder{

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -35,11 +35,55 @@ var defaultDimensions = map[string]int{
 	"nomic-embed-text":       768,
 }
 
+// EmbedOverride holds optional overrides from the embed config block.
+type EmbedOverride struct {
+	Provider   string
+	Model      string
+	Dimensions int
+	APIKey     string
+	BaseURL    string
+}
+
 // NewCascade auto-detects the best available embedding provider.
+// Tier 0: Explicit embed config override (if model + credentials provided).
 // Tier 1: Provider embedding API (if available).
 // Tier 2: Ollama local (if running).
 // Returns nil if no embedding provider is available.
-func NewCascade(provider string, apiKey string, baseURL string) Embedder {
+func NewCascade(provider string, apiKey string, baseURL string, override *EmbedOverride) Embedder {
+	// Tier 0: Explicit embed config — user specified model/credentials
+	if override != nil && override.Model != "" {
+		p := override.Provider
+		if p == "" {
+			p = provider
+		}
+		key := override.APIKey
+		if key == "" {
+			key = apiKey
+		}
+		url := override.BaseURL
+		if url == "" {
+			url = baseURL
+		}
+		if key != "" {
+			dims := override.Dimensions
+			if dims == 0 {
+				dims = defaultDimensions[override.Model]
+				if dims == 0 {
+					dims = 1536
+				}
+			}
+			embedder := &APIEmbedder{
+				provider: p,
+				model:    override.Model,
+				apiKey:   key,
+				baseURL:  url,
+				dims:     dims,
+			}
+			log.Info("embedding provider detected", "tier", 0, "provider", p, "model", override.Model, "dims", dims)
+			return embedder
+		}
+	}
+
 	// Tier 1: Provider embedding API
 	if model, ok := defaultModels[provider]; ok && apiKey != "" {
 		dims := defaultDimensions[model]

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -95,6 +95,60 @@ func TestAPIEmbedderErrorResponse(t *testing.T) {
 	}
 }
 
+func TestCascadeTier0Override(t *testing.T) {
+	// Tier 0 override should take priority over tier 1 auto-detection
+	ov := &EmbedOverride{
+		Provider:   "openai",
+		Model:      "custom-embed-model",
+		Dimensions: 1024,
+		APIKey:     "sk-custom",
+		BaseURL:    "https://custom.example.com/v1",
+	}
+	e := NewCascade("openai", "sk-default", "", ov)
+	if e == nil {
+		t.Fatal("expected embedder with override")
+	}
+	if e.Name() != "openai/custom-embed-model" {
+		t.Errorf("expected override model, got: %s", e.Name())
+	}
+	if e.Dimensions() != 1024 {
+		t.Errorf("expected 1024 dims, got %d", e.Dimensions())
+	}
+}
+
+func TestCascadeTier0InheritsAPICredentials(t *testing.T) {
+	// Override with model but no api_key should inherit from top-level api config
+	ov := &EmbedOverride{
+		Model:      "custom-embed-model",
+		Dimensions: 768,
+	}
+	e := NewCascade("openai", "sk-from-api", "https://api.example.com/v1", ov)
+	if e == nil {
+		t.Fatal("expected embedder inheriting api credentials")
+	}
+	if e.Name() != "openai/custom-embed-model" {
+		t.Errorf("expected override model, got: %s", e.Name())
+	}
+	if e.Dimensions() != 768 {
+		t.Errorf("expected 768 dims, got %d", e.Dimensions())
+	}
+}
+
+func TestCascadeTier0FallbackDimensions(t *testing.T) {
+	// Unknown model with no explicit dimensions should fall back to 1536
+	ov := &EmbedOverride{
+		Model:  "unknown-model",
+		APIKey: "sk-test",
+	}
+	e := NewCascade("openai", "sk-test", "", ov)
+	if e == nil {
+		t.Fatal("expected embedder")
+	}
+	if e.Dimensions() != 1536 {
+		t.Errorf("expected fallback 1536 dims, got %d", e.Dimensions())
+	}
+}
+
 func TestDefaultModels(t *testing.T) {
 	providers := []string{"openai", "gemini", "voyage", "mistral"}
 	for _, p := range providers {

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCascadeTier1(t *testing.T) {
-	e := NewCascade("openai", "sk-test", "")
+	e := NewCascade("openai", "sk-test", "", nil)
 	if e == nil {
 		t.Fatal("expected embedder for openai")
 	}
@@ -22,14 +22,14 @@ func TestCascadeTier1(t *testing.T) {
 
 func TestCascadeAnthropicFallsThrough(t *testing.T) {
 	// Anthropic has no embedding API — should fall through
-	e := NewCascade("anthropic", "sk-ant-test", "")
+	e := NewCascade("anthropic", "sk-ant-test", "", nil)
 	// This will return nil unless Ollama is running
 	// We can't control Ollama in tests, so just verify no panic
 	_ = e
 }
 
 func TestCascadeNoProvider(t *testing.T) {
-	e := NewCascade("", "", "")
+	e := NewCascade("", "", "", nil)
 	// Should return nil (no provider, no Ollama assumed)
 	// Can't guarantee nil because Ollama might be running locally
 	_ = e

--- a/internal/mcp/tools_write.go
+++ b/internal/mcp/tools_write.go
@@ -294,11 +294,7 @@ func (s *Server) handleCompileDiff(ctx context.Context, req mcplib.CallToolReque
 }
 
 func (s *Server) tryEmbed(id string, content string) {
-	var ov *embed.EmbedOverride
-	if s.cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: s.cfg.Embed.Provider, Model: s.cfg.Embed.Model, Dimensions: s.cfg.Embed.Dimensions, APIKey: s.cfg.Embed.APIKey, BaseURL: s.cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(s.cfg.API.Provider, s.cfg.API.APIKey, s.cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(s.cfg)
 	if embedder != nil {
 		if vec, err := embedder.Embed(content); err == nil {
 			s.vec.Upsert(id, vec)

--- a/internal/mcp/tools_write.go
+++ b/internal/mcp/tools_write.go
@@ -294,7 +294,11 @@ func (s *Server) handleCompileDiff(ctx context.Context, req mcplib.CallToolReque
 }
 
 func (s *Server) tryEmbed(id string, content string) {
-	embedder := embed.NewCascade(s.cfg.API.Provider, s.cfg.API.APIKey, s.cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if s.cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: s.cfg.Embed.Provider, Model: s.cfg.Embed.Model, Dimensions: s.cfg.Embed.Dimensions, APIKey: s.cfg.Embed.APIKey, BaseURL: s.cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(s.cfg.API.Provider, s.cfg.API.APIKey, s.cfg.API.BaseURL, ov)
 	if embedder != nil {
 		if vec, err := embedder.Embed(content); err == nil {
 			s.vec.Upsert(id, vec)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -69,11 +69,7 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
 	// Get query embedding for hybrid search
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 	var queryVec []float32
 	if embedder != nil {
 		queryVec, _ = embedder.Embed(question)

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -69,7 +69,11 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
 	// Get query embedding for hybrid search
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 	var queryVec []float32
 	if embedder != nil {
 		queryVec, _ = embedder.Embed(question)

--- a/internal/wiki/doctor.go
+++ b/internal/wiki/doctor.go
@@ -87,11 +87,7 @@ func RunDoctor(projectDir string) *DoctorResult {
 	}
 
 	// Check embedding
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 	if embedder != nil {
 		result.add("embedding", "ok", fmt.Sprintf("Embedding: %s (%d-dim)", embedder.Name(), embedder.Dimensions()))
 	} else {

--- a/internal/wiki/doctor.go
+++ b/internal/wiki/doctor.go
@@ -87,7 +87,11 @@ func RunDoctor(projectDir string) *DoctorResult {
 	}
 
 	// Check embedding
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 	if embedder != nil {
 		result.add("embedding", "ok", fmt.Sprintf("Embedding: %s (%d-dim)", embedder.Name(), embedder.Dimensions()))
 	} else {

--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -101,11 +101,7 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 	info.RelationCount, _ = ontStore.RelationCount()
 
 	// Embedding provider
-	var ov *embed.EmbedOverride
-	if cfg.Embed != nil {
-		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
-	}
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
+	embedder := embed.NewFromConfig(cfg)
 	if embedder != nil {
 		info.EmbedProvider = embedder.Name()
 		info.EmbedDims = embedder.Dimensions()

--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -101,7 +101,11 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 	info.RelationCount, _ = ontStore.RelationCount()
 
 	// Embedding provider
-	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL)
+	var ov *embed.EmbedOverride
+	if cfg.Embed != nil {
+		ov = &embed.EmbedOverride{Provider: cfg.Embed.Provider, Model: cfg.Embed.Model, Dimensions: cfg.Embed.Dimensions, APIKey: cfg.Embed.APIKey, BaseURL: cfg.Embed.BaseURL}
+	}
+	embedder := embed.NewCascade(cfg.API.Provider, cfg.API.APIKey, cfg.API.BaseURL, ov)
 	if embedder != nil {
 		info.EmbedProvider = embedder.Name()
 		info.EmbedDims = embedder.Dimensions()


### PR DESCRIPTION
## Summary

- `NewCascade` previously ignored the `embed` config block entirely, hardcoding default models per provider (e.g. `text-embedding-3-small` for OpenAI)
- Users with OpenAI-compatible providers (SiliconFlow, BigModel, etc.) could not specify custom embedding models, API keys, or base URLs
- Added `EmbedOverride` as tier 0 priority, so `embed.model`, `embed.api_key`, and `embed.base_url` from `config.yaml` take precedence over auto-detection
- Added `api_key` and `base_url` fields to `EmbedConfig`

## Example config

```yaml
embed:
    provider: openai
    model: BAAI/bge-m3
    dimensions: 1024
    api_key: sk-xxx
    base_url: https://api.siliconflow.cn/v1
```

## Test plan

- [x] Existing tests pass with `nil` override (backward compatible)
- [x] Tested with SiliconFlow `BAAI/bge-m3` — 61 entries embedded successfully
- [x] `sage-wiki doctor` correctly reports tier 0 with custom model

🤖 Generated with [Claude Code](https://claude.com/claude-code)