### PR TITLE
fix: update deprecated gemini-2.0-flash model, add --model flag

### DIFF
--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -111,6 +111,7 @@ func init() {
 	// Init flags
 	initCmd.Flags().Bool("vault", false, "Initialize as vault overlay on existing Obsidian vault")
 	initCmd.Flags().Bool("prompts", false, "Scaffold prompt templates for customization")
+	initCmd.Flags().String("model", "gemini-2.5-flash", "Default LLM model for all tasks (e.g. gemini-2.5-flash, gemini-3.1-flash-lite)")
 
 	// Compile flags
 	compileCmd.Flags().Bool("watch", false, "Watch for changes and recompile")
@@ -141,6 +142,7 @@ func init() {
 
 func runInit(cmd *cobra.Command, args []string) error {
 	vaultMode, _ := cmd.Flags().GetBool("vault")
+	model, _ := cmd.Flags().GetString("model")
 	dir, _ := filepath.Abs(projectDir)
 
 	// Derive project name from directory
@@ -181,11 +183,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Ignored folders: %v\n", ignoreFolders)
 		fmt.Println("\nEdit config.yaml to adjust source/ignore folders.")
 
-		if err := wiki.InitVaultOverlay(dir, project, sourceFolders, ignoreFolders, "_wiki"); err != nil {
+		if err := wiki.InitVaultOverlay(dir, project, sourceFolders, ignoreFolders, "_wiki", model); err != nil {
 			return err
 		}
 	} else {
-		if err := wiki.InitGreenfield(dir, project); err != nil {
+		if err := wiki.InitGreenfield(dir, project, model); err != nil {
 			return err
 		}
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -21,7 +21,7 @@ func TestIntegrationM1(t *testing.T) {
 
 	// Step 1: Initialize greenfield project
 	t.Run("init", func(t *testing.T) {
-		if err := wiki.InitGreenfield(dir, "integration-test"); err != nil {
+		if err := wiki.InitGreenfield(dir, "integration-test", "gemini-2.5-flash"); err != nil {
 			t.Fatalf("init: %v", err)
 		}
 

--- a/internal/compiler/diff_test.go
+++ b/internal/compiler/diff_test.go
@@ -13,7 +13,7 @@ import (
 func setupProject(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := wiki.InitGreenfield(dir, "test"); err != nil {
+	if err := wiki.InitGreenfield(dir, "test", "gemini-2.5-flash"); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 	return dir
@@ -110,6 +110,7 @@ func TestDiffRespectsIgnore(t *testing.T) {
 		[]string{"Clippings"},
 		[]string{"Personal"},
 		"_wiki",
+		"gemini-2.5-flash",
 	)
 
 	cfg, _ := config.Load(filepath.Join(dir, "config.yaml"))

--- a/internal/compiler/pipeline_test.go
+++ b/internal/compiler/pipeline_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCompileDryRun(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Add source files
 	os.WriteFile(filepath.Join(dir, "raw", "a.md"), []byte("# Test A\nContent A."), 0644)
@@ -36,7 +36,7 @@ func TestCompileDryRun(t *testing.T) {
 
 func TestCompileNothingToDo(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	result, err := Compile(dir, CompileOpts{})
 	if err != nil {
@@ -86,7 +86,7 @@ func TestCompileWithMockLLM(t *testing.T) {
 	defer server.Close()
 
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Update config to use mock server
 	cfgContent := `
@@ -150,7 +150,7 @@ compiler:
 
 func TestCompileCheckpointResume(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Create a checkpoint with article2 already completed
 	statePath := filepath.Join(dir, ".sage", "compile-state.json")

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -12,7 +12,7 @@ import (
 func setupLintProject(t *testing.T) (string, *LintContext) {
 	t.Helper()
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	ctx := &LintContext{
 		ProjectDir: dir,

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -126,7 +126,7 @@ func TestGeminiFormat(t *testing.T) {
 				}},
 			},
 			"usageMetadata":  map[string]int{"totalTokenCount": 15},
-			"modelVersion": "gemini-2.0-flash",
+			"modelVersion": "gemini-2.5-flash",
 		})
 	}))
 	defer server.Close()
@@ -139,7 +139,7 @@ func TestGeminiFormat(t *testing.T) {
 	resp, err := client.ChatCompletion([]Message{
 		{Role: "system", Content: "System prompt"},
 		{Role: "user", Content: "Hello"},
-	}, CallOpts{Model: "gemini-2.0-flash"})
+	}, CallOpts{Model: "gemini-2.5-flash"})
 
 	if err != nil {
 		t.Fatalf("ChatCompletion: %v", err)

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -85,7 +85,7 @@ func (p *geminiProvider) formatBody(messages []Message, opts CallOpts) (map[stri
 
 	model := opts.Model
 	if model == "" {
-		model = "gemini-2.0-flash"
+		model = "gemini-2.5-flash"
 	}
 
 	return body, model

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,7 +18,7 @@ func setupTestProject(t *testing.T) string {
 	dir := t.TempDir()
 
 	// Initialize a greenfield project
-	if err := wiki.InitGreenfield(dir, "test-project"); err != nil {
+	if err := wiki.InitGreenfield(dir, "test-project", "gemini-2.5-flash"); err != nil {
 		t.Fatalf("init: %v", err)
 	}
 

--- a/internal/mcp/tools_write_test.go
+++ b/internal/mcp/tools_write_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestWriteSummary(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, err := NewServer(dir)
 	if err != nil {
@@ -58,7 +58,7 @@ func TestWriteSummary(t *testing.T) {
 
 func TestWriteArticle(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -98,7 +98,7 @@ func TestWriteArticle(t *testing.T) {
 
 func TestAddOntologyEntity(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -126,7 +126,7 @@ func TestAddOntologyEntity(t *testing.T) {
 
 func TestAddOntologyRelation(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -158,7 +158,7 @@ func TestAddOntologyRelation(t *testing.T) {
 
 func TestLearn(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -188,7 +188,7 @@ func TestLearn(t *testing.T) {
 
 func TestCommit(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -214,7 +214,7 @@ func TestCommit(t *testing.T) {
 
 func TestCompileDiff(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()
@@ -238,7 +238,7 @@ func TestCompileDiff(t *testing.T) {
 
 func TestAddSourceWithPathTraversal(t *testing.T) {
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	srv, _ := NewServer(dir)
 	defer srv.Close()

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -17,7 +17,7 @@ import (
 func setupTestProject(t *testing.T) *WebServer {
 	t.Helper()
 	dir := t.TempDir()
-	wiki.InitGreenfield(dir, "test")
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Create some test articles
 	conceptsDir := filepath.Join(dir, "wiki", "concepts")

--- a/internal/wiki/ingest_test.go
+++ b/internal/wiki/ingest_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestIngestLocalFile(t *testing.T) {
 	dir := t.TempDir()
-	InitGreenfield(dir, "test")
+	InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Create a source file to ingest
 	srcFile := filepath.Join(t.TempDir(), "article.md")
@@ -42,7 +42,7 @@ func TestIngestLocalFile(t *testing.T) {
 
 func TestIngestURL(t *testing.T) {
 	dir := t.TempDir()
-	InitGreenfield(dir, "test")
+	InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	// Disable SSRF check for test (mock server is on localhost)
 	SkipSSRFCheck = true

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -12,7 +12,7 @@ import (
 )
 
 // InitGreenfield creates a new sage-wiki project from scratch.
-func InitGreenfield(dir string, project string) error {
+func InitGreenfield(dir string, project string, model string) error {
 	// Create directories
 	dirs := []string{
 		filepath.Join(dir, "raw"),
@@ -32,7 +32,7 @@ func InitGreenfield(dir string, project string) error {
 
 	// Write config template with comments
 	cfgPath := filepath.Join(dir, "config.yaml")
-	cfgContent := configTemplate(project, fmt.Sprintf("sage-wiki project: %s", project), false)
+	cfgContent := configTemplate(project, fmt.Sprintf("sage-wiki project: %s", project), false, model)
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0644); err != nil {
 		return fmt.Errorf("init: save config: %w", err)
 	}
@@ -69,7 +69,7 @@ func InitGreenfield(dir string, project string) error {
 }
 
 // InitVaultOverlay initializes sage-wiki on an existing Obsidian vault.
-func InitVaultOverlay(dir string, project string, sourceFolders []string, ignoreFolders []string, output string) error {
+func InitVaultOverlay(dir string, project string, sourceFolders []string, ignoreFolders []string, output string, model string) error {
 	if output == "" {
 		output = "_wiki"
 	}
@@ -101,7 +101,7 @@ func InitVaultOverlay(dir string, project string, sourceFolders []string, ignore
 		ignoreYAML += fmt.Sprintf("  - %s\n", ig)
 	}
 
-	cfgContent := configTemplateVault(project, output, sourcesYAML, ignoreYAML)
+	cfgContent := configTemplateVault(project, output, sourcesYAML, ignoreYAML, model)
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0644); err != nil {
 		return fmt.Errorf("init: save config: %w", err)
@@ -172,7 +172,7 @@ func ScanFolders(dir string) ([]FolderInfo, error) {
 	return folders, nil
 }
 
-func configTemplate(project, description string, isVault bool) string {
+func configTemplate(project, description string, isVault bool, model string) string {
 	return fmt.Sprintf(`# sage-wiki configuration
 # Docs: https://github.com/xoai/sage-wiki
 
@@ -201,11 +201,11 @@ api:
 # Model selection per task
 # Use faster/cheaper models for high-volume tasks, quality models for writing
 models:
-  summarize: gemini-2.5-flash
-  extract: gemini-2.5-flash
-  write: gemini-2.5-flash
-  lint: gemini-2.5-flash
-  query: gemini-2.5-flash
+  summarize: %s
+  extract: %s
+  write: %s
+  lint: %s
+  query: %s
 
 # Embedding configuration (optional — auto-detected from api provider)
 # Override to use a different provider/model for embeddings
@@ -231,10 +231,10 @@ search:
 serve:
   transport: stdio      # stdio or sse
   port: 3333            # SSE mode only
-`, project, description)
+`, project, description, model, model, model, model, model)
 }
 
-func configTemplateVault(project, output, sourcesYAML, ignoreYAML string) string {
+func configTemplateVault(project, output, sourcesYAML, ignoreYAML, model string) string {
 	return fmt.Sprintf(`# sage-wiki configuration (vault overlay)
 # Docs: https://github.com/xoai/sage-wiki
 
@@ -263,11 +263,11 @@ api:
   # rate_limit: 60      # requests per minute
 
 models:
-  summarize: gemini-2.5-flash
-  extract: gemini-2.5-flash
-  write: gemini-2.5-flash
-  lint: gemini-2.5-flash
-  query: gemini-2.5-flash
+  summarize: %s
+  extract: %s
+  write: %s
+  lint: %s
+  query: %s
 
 # Embedding configuration (optional — auto-detected from api provider)
 embed:
@@ -287,5 +287,5 @@ search:
 
 serve:
   transport: stdio
-`, project, project, sourcesYAML, output, ignoreYAML)
+`, project, project, sourcesYAML, output, ignoreYAML, model, model, model, model, model)
 }

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -201,11 +201,11 @@ api:
 # Model selection per task
 # Use faster/cheaper models for high-volume tasks, quality models for writing
 models:
-  summarize: gemini-2.0-flash
-  extract: gemini-2.0-flash
-  write: gemini-2.0-flash
-  lint: gemini-2.0-flash
-  query: gemini-2.0-flash
+  summarize: gemini-2.5-flash
+  extract: gemini-2.5-flash
+  write: gemini-2.5-flash
+  lint: gemini-2.5-flash
+  query: gemini-2.5-flash
 
 # Embedding configuration (optional — auto-detected from api provider)
 # Override to use a different provider/model for embeddings
@@ -263,11 +263,11 @@ api:
   # rate_limit: 60      # requests per minute
 
 models:
-  summarize: gemini-2.0-flash
-  extract: gemini-2.0-flash
-  write: gemini-2.0-flash
-  lint: gemini-2.0-flash
-  query: gemini-2.0-flash
+  summarize: gemini-2.5-flash
+  extract: gemini-2.5-flash
+  write: gemini-2.5-flash
+  lint: gemini-2.5-flash
+  query: gemini-2.5-flash
 
 # Embedding configuration (optional — auto-detected from api provider)
 embed:

--- a/internal/wiki/init_test.go
+++ b/internal/wiki/init_test.go
@@ -9,7 +9,7 @@ import (
 func TestInitGreenfield(t *testing.T) {
 	dir := t.TempDir()
 
-	if err := InitGreenfield(dir, "test-wiki"); err != nil {
+	if err := InitGreenfield(dir, "test-wiki", "gemini-2.5-flash"); err != nil {
 		t.Fatalf("InitGreenfield: %v", err)
 	}
 
@@ -72,6 +72,7 @@ func TestInitVaultOverlay(t *testing.T) {
 		[]string{"Clippings", "Papers"},
 		[]string{"Personal", "Daily Notes"},
 		"_wiki",
+		"gemini-2.5-flash",
 	)
 	if err != nil {
 		t.Fatalf("InitVaultOverlay: %v", err)


### PR DESCRIPTION
## Summary
- `gemini-2.0-flash` is no longer available to new users (returns 404), breaking all LLM operations (summarize, extract, write, lint, query)
- Updated default model to `gemini-2.5-flash` across codebase
- Added `--model` flag to `sage-wiki init` so users can choose their preferred model at setup time (e.g. `sage-wiki init --model gemini-3.1-flash-lite`)
- The chosen model is written into `config.yaml` for all five task types

## Changes
- `internal/llm/gemini.go` — updated fallback default from `gemini-2.0-flash` to `gemini-2.5-flash`
- `internal/wiki/init.go` — `InitGreenfield` and `InitVaultOverlay` now accept a `model` parameter; config templates use `%s` format verbs instead of hardcoded model names
- `cmd/sage-wiki/main.go` — added `--model` flag to `init` command, passed through to init functions
- All test files updated to match new function signatures

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -short` — all 21 packages pass
- [ ] E2E test with `GEMINI_API_KEY` set and `sage-wiki compile --watch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)