### PR TITLE
fix: use []rune for formatConceptName to handle CJK characters

### DIFF
--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"unicode"
 
 	"github.com/xoai/sage-wiki/internal/embed"
 	"github.com/xoai/sage-wiki/internal/llm"
@@ -271,8 +272,10 @@ func quoteYAMLList(items []string) string {
 func formatConceptName(name string) string {
 	words := strings.Split(name, "-")
 	for i, w := range words {
-		if len(w) > 0 {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		runes := []rune(w)
+		if len(runes) > 0 {
+			runes[0] = unicode.ToUpper(runes[0])
+			words[i] = string(runes)
 		}
 	}
 	return strings.Join(words, " ")


### PR DESCRIPTION
## Summary
- `formatConceptName` uses `w[:1]` byte slice which truncates multi-byte UTF-8 characters
- Chinese characters like '液' (3 bytes in UTF-8) get corrupted to garbled text in entity names and LLM prompts
- Fix: use `[]rune` conversion to correctly handle all Unicode code points

## Impact
- Entity `Name` field in database
- LLM prompts that include concept names
- Does NOT affect entity IDs, file paths, or article content (those use the raw hyphenated slug)

## Test
Compile a wiki with CJK concept names and verify entity names display correctly.