### PR TITLE
feat: wire up embedder for hybrid vector search

### DIFF
--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/xoai/sage-wiki/internal/compiler"
 	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/embed"
 	"github.com/xoai/sage-wiki/internal/hybrid"
 	"github.com/xoai/sage-wiki/internal/linter"
 	"github.com/xoai/sage-wiki/internal/llm"
@@ -372,11 +373,24 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	vecStore := vectors.NewStore(db)
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
+	var queryVec []float32
+	cfg, cfgErr := config.Load(filepath.Join(dir, "config.yaml"))
+	if cfgErr == nil {
+		embedder := embed.NewFromConfig(cfg)
+		if embedder != nil {
+			var embedErr error
+			queryVec, embedErr = embedder.Embed(queryStr)
+			if embedErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: embed failed, using BM25-only: %v\n", embedErr)
+			}
+		}
+	}
+
 	results, err := searcher.Search(hybrid.SearchOpts{
 		Query: queryStr,
 		Tags:  tags,
 		Limit: limit,
-	}, nil)
+	}, queryVec)
 	if err != nil {
 		return err
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/embed"
 	"github.com/xoai/sage-wiki/internal/hybrid"
 	"github.com/xoai/sage-wiki/internal/manifest"
 	"github.com/xoai/sage-wiki/internal/memory"
@@ -29,6 +30,7 @@ type Server struct {
 	vec        *vectors.Store
 	ont        *ontology.Store
 	searcher   *hybrid.Searcher
+	embedder   embed.Embedder
 	cfg        *config.Config
 }
 
@@ -58,6 +60,7 @@ func NewServer(projectDir string) (*Server, error) {
 		vec:        vec,
 		ont:        ont,
 		searcher:   searcher,
+		embedder:   embed.NewFromConfig(cfg),
 		cfg:        cfg,
 	}
 
@@ -203,11 +206,19 @@ func (s *Server) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*mc
 		}
 	}
 
+	var queryVec []float32
+	if s.embedder != nil {
+		var embedErr error
+		queryVec, embedErr = s.embedder.Embed(query)
+		if embedErr != nil {
+			fmt.Fprintf(os.Stderr, "warn: search embed failed, falling back to BM25-only: %v\n", embedErr)
+		}
+	}
 	results, err := s.searcher.Search(hybrid.SearchOpts{
 		Query: query,
 		Tags:  tags,
 		Limit: limit,
-	}, nil)
+	}, queryVec)
 	if err != nil {
 		return errorResult(err.Error()), nil
 	}


### PR DESCRIPTION
## Summary

- The hybrid search infrastructure (RRF fusion of BM25 + vector) was already implemented in `internal/hybrid`, but neither the MCP server nor the CLI `search` command passed query embeddings — both always sent `nil`, making search BM25-only in practice.
- **MCP server**: add `embedder` field, embed query at search time, log errors instead of silently falling back
- **CLI search**: load config, create embedder, embed query before search

## Test plan

- [x] `go test ./...` — all packages pass
- [x] CLI `search` with semantic query returns vector-ranked results
- [x] Graceful fallback to BM25-only when embedding fails or is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)