### PR TITLE
feat: strip <think> tags from LLM responses

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -108,6 +110,7 @@ func (c *Client) chatCompletionDirect(messages []Message, opts CallOpts) (*Respo
 			if err != nil {
 				return nil, fmt.Errorf("llm: parse response: %w", err)
 			}
+			result.Content = stripThinkTags(result.Content)
 			c.trackUsage(result.Model, result.Usage)
 			return result, nil
 		}
@@ -238,6 +241,15 @@ func (r *rateLimiter) wait() {
 		time.Sleep(r.interval - elapsed)
 	}
 	r.lastCall = time.Now()
+}
+
+// stripThinkTags removes <think>...</think> blocks from LLM responses.
+// Some models (e.g. MiniMax) include reasoning traces that should not appear in output.
+var thinkTagRe = regexp.MustCompile(`(?s)<think>.*?</think>\s*`)
+
+func stripThinkTags(s string) string {
+	s = thinkTagRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(s)
 }
 
 // jsonBody creates a JSON request body. Panics on marshal failure


### PR DESCRIPTION
## Summary
- Adds `stripThinkTags()` to remove `<think>...</think>` reasoning traces from LLM output
- Applied after response parsing, before usage tracking
- Fixes issue where OpenAI-compatible providers (MiniMax, DeepSeek, etc.) leak reasoning traces into wiki content

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/llm/` passes
- [x] Verified with MiniMax M2.5-highspeed — think tags no longer appear in summaries/articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)