### PR TITLE
feat: add Chinese keywords for ontology relation extraction

### DIFF
--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -309,12 +309,12 @@ func extractRelations(conceptID string, content string, ontStore *ontology.Store
 		keywords []string
 		relation string
 	}{
-		{[]string{"implements", "implementation of", "is an implementation"}, ontology.RelImplements},
-		{[]string{"extends", "extension of", "builds on", "builds upon"}, ontology.RelExtends},
-		{[]string{"optimizes", "optimization of", "improves upon", "faster than"}, ontology.RelOptimizes},
-		{[]string{"contradicts", "conflicts with", "disagrees with", "challenges"}, ontology.RelContradicts},
-		{[]string{"prerequisite", "requires knowledge of", "depends on", "built on top of"}, ontology.RelPrerequisiteOf},
-		{[]string{"trade-off", "tradeoff", "trades off", "at the cost of"}, ontology.RelTradesOff},
+		{[]string{"implements", "implementation of", "is an implementation", "实现了", "实现方式"}, ontology.RelImplements},
+		{[]string{"extends", "extension of", "builds on", "builds upon", "扩展了", "基于"}, ontology.RelExtends},
+		{[]string{"optimizes", "optimization of", "improves upon", "faster than", "优化了", "改进了", "提升了"}, ontology.RelOptimizes},
+		{[]string{"contradicts", "conflicts with", "disagrees with", "challenges", "矛盾", "冲突", "挑战了"}, ontology.RelContradicts},
+		{[]string{"prerequisite", "requires knowledge of", "depends on", "built on top of", "前提", "依赖于", "前置条件"}, ontology.RelPrerequisiteOf},
+		{[]string{"trade-off", "tradeoff", "trades off", "at the cost of", "取舍", "权衡", "代价是"}, ontology.RelTradesOff},
 	}
 
 	for target := range linkedConcepts {


### PR DESCRIPTION
## Summary
- Extends `extractRelations()` pattern matching with Chinese equivalents for all 6 relation types
- Keywords: 实现了, 扩展了, 优化了, 矛盾, 前提, 取舍 etc.
- Enables automatic ontology relation detection in Chinese-language wiki content
- No breaking changes — English patterns remain, Chinese keywords are additive

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/compiler/` passes
- [x] Verified with Chinese wiki corpus — relations correctly extracted from Chinese text

🤖 Generated with [Claude Code](https://claude.com/claude-code)