### PR TITLE
feat: add content-aware type detection with configurable signals

### DIFF
--- a/internal/compiler/diff.go
+++ b/internal/compiler/diff.go
@@ -70,7 +70,7 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 			current[relPath] = SourceInfo{
 				Path: relPath,
 				Hash: hash,
-				Type: extract.DetectSourceType(path),
+				Type: extract.DetectSourceType(path, extract.ReadHead(path, 500), cfg.TypeSignals),
 				Size: info.Size(),
 			}
 			return nil

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -288,7 +288,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 		memStore.Add(memory.Entry{
 			ID:          sr.SourcePath,
 			Content:     sr.Summary,
-			Tags:        []string{extractType(sr.SourcePath)},
+			Tags:        []string{extractType(sr.SourcePath, cfg.TypeSignals)},
 			ArticlePath: sr.SummaryPath,
 		})
 
@@ -679,7 +679,7 @@ func resumeBatch(
 
 		// Update manifest — ensure source entry exists, then mark compiled
 		if _, exists := mf.Sources[br.CustomID]; !exists {
-			mf.AddSource(br.CustomID, "", extractType(br.CustomID), 0)
+			mf.AddSource(br.CustomID, "", extractType(br.CustomID, cfg.TypeSignals), 0)
 		}
 		mf.MarkCompiled(br.CustomID, summaryPath, nil)
 
@@ -687,7 +687,7 @@ func resumeBatch(
 		memStore.Add(memory.Entry{
 			ID:          br.CustomID,
 			Content:     summaryText,
-			Tags:        []string{extractType(br.CustomID)},
+			Tags:        []string{extractType(br.CustomID, cfg.TypeSignals)},
 			ArticlePath: summaryPath,
 		})
 
@@ -852,8 +852,8 @@ func removeFromPending(state *CompileState, path string) {
 	}
 }
 
-func extractType(path string) string {
-	return extract.DetectSourceType(path)
+func extractType(path string, typeSignals []config.TypeSignal) string {
+	return extract.DetectSourceType(path, extract.ReadHead(path, 500), typeSignals)
 }
 
 // timeNow returns the current time in RFC3339 using the given timezone.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,15 @@ type Config struct {
 	Linting     LintingConfig  `yaml:"linting"`
 	Serve       ServeConfig    `yaml:"serve"`
 	Ontology    OntologyConfig `yaml:"ontology,omitempty"`
+	TypeSignals []TypeSignal   `yaml:"type_signals,omitempty"`
+}
+
+// TypeSignal defines keywords for content-type detection.
+type TypeSignal struct {
+	Type             string   `yaml:"type"`
+	FilenameKeywords []string `yaml:"filename_keywords"`
+	ContentKeywords  []string `yaml:"content_keywords"`
+	MinContentHits   int      `yaml:"min_content_hits"`
 }
 
 type VaultConfig struct {
@@ -243,6 +252,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: invalid compiler.timezone %q: %w", c.Compiler.Timezone, err)
 		}
 		c.Compiler.resolvedTZ = loc
+	}
+	if len(c.TypeSignals) > 10 {
+		return fmt.Errorf("config: type_signals count %d exceeds maximum 10", len(c.TypeSignals))
 	}
 	return nil
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"unicode"
+
+	"github.com/xoai/sage-wiki/internal/config"
 )
 
 // SourceContent holds extracted text from a source file.
@@ -33,7 +35,11 @@ func Extract(path string, sourceType string) (*SourceContent, error) {
 	case ext == ".md":
 		return extractMarkdown(path, sourceType)
 	case ext == ".pdf":
-		return extractPDF(path)
+		sc, err := extractPDF(path)
+		if err == nil && sourceType != "" {
+			sc.Type = sourceType
+		}
+		return sc, err
 	case ext == ".docx":
 		return extractDocx(path)
 	case ext == ".xlsx":
@@ -285,8 +291,18 @@ func splitByParagraphs(text string, maxTokens int) []Chunk {
 	return chunks
 }
 
-// DetectSourceType guesses source type from file extension.
-func DetectSourceType(path string) string {
+// DetectSourceType detects the source type from file path, optional content
+// head text, and optional config-driven type signals.
+// When typeSignals is nil or empty, falls back to extension-only detection.
+func DetectSourceType(path string, contentHead string, typeSignals []config.TypeSignal) string {
+	// Try config-driven signals first
+	for _, sig := range typeSignals {
+		if matchesSignal(path, contentHead, sig) {
+			return sig.Type
+		}
+	}
+
+	// Fallback to extension-based detection
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".pdf":
@@ -313,4 +329,33 @@ func DetectSourceType(path string) string {
 		}
 		return "article"
 	}
+}
+
+// matchesSignal checks if a file matches a type signal by filename keywords
+// or content keywords (first 500 chars, including PDF first-page text).
+func matchesSignal(path, contentHead string, sig config.TypeSignal) bool {
+	filenameLower := strings.ToLower(filepath.Base(path))
+
+	// Filename keyword match — any one keyword is enough
+	for _, kw := range sig.FilenameKeywords {
+		if strings.Contains(filenameLower, strings.ToLower(kw)) {
+			return true
+		}
+	}
+
+	// Content keyword match — must hit MinContentHits threshold
+	if contentHead != "" && sig.MinContentHits > 0 {
+		contentLower := strings.ToLower(contentHead)
+		hits := 0
+		for _, kw := range sig.ContentKeywords {
+			if strings.Contains(contentLower, strings.ToLower(kw)) {
+				hits++
+			}
+		}
+		if hits >= sig.MinContentHits {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/xoai/sage-wiki/internal/config"
 )
 
 func TestExtractMarkdown(t *testing.T) {
@@ -247,9 +249,46 @@ func TestDetectSourceType(t *testing.T) {
 		{"transcript.vtt", "article"},
 	}
 	for _, tt := range tests {
-		got := DetectSourceType(tt.path)
+		got := DetectSourceType(tt.path, "", nil)
 		if got != tt.expected {
 			t.Errorf("DetectSourceType(%s) = %s, want %s", tt.path, got, tt.expected)
 		}
+	}
+}
+
+func TestDetectSourceTypeWithSignals(t *testing.T) {
+	signals := []config.TypeSignal{
+		{
+			Type:             "regulation",
+			FilenameKeywords: []string{"法规", "办法"},
+			ContentKeywords:  []string{"第一条", "第二条"},
+			MinContentHits:   2,
+		},
+		{
+			Type:             "research",
+			FilenameKeywords: []string{"研报"},
+			ContentKeywords:  []string{"投资评级"},
+			MinContentHits:   1,
+		},
+	}
+
+	// Filename match
+	if got := DetectSourceType("证券法规汇编.pdf", "", signals); got != "regulation" {
+		t.Errorf("filename match: got %s, want regulation", got)
+	}
+
+	// Content match
+	if got := DetectSourceType("unknown.pdf", "第一条 本办法 第二条", signals); got != "regulation" {
+		t.Errorf("content match: got %s, want regulation", got)
+	}
+
+	// Content below threshold
+	if got := DetectSourceType("unknown.pdf", "第一条 只有一个关键词", signals); got != "paper" {
+		t.Errorf("below threshold: got %s, want paper (fallback)", got)
+	}
+
+	// No signals — fallback
+	if got := DetectSourceType("test.pdf", "", nil); got != "paper" {
+		t.Errorf("no signals: got %s, want paper", got)
 	}
 }

--- a/internal/extract/readhead.go
+++ b/internal/extract/readhead.go
@@ -1,0 +1,110 @@
+package extract
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/ledongthuc/pdf"
+)
+
+// ReadHead reads the first maxRunes runes from a file.
+// For PDF files, extracts text from the first page using pdftotext (poppler)
+// with fallback to the Go PDF library.
+// Returns empty string on error or if file doesn't exist.
+func ReadHead(path string, maxRunes int) string {
+	if strings.ToLower(filepath.Ext(path)) == ".pdf" {
+		return readHeadPDF(path, maxRunes)
+	}
+	return readHeadText(path, maxRunes)
+}
+
+// readHeadPDF extracts text from the first page of a PDF.
+// Tries pdftotext (poppler) first for better font/encoding support,
+// falls back to the Go PDF library if pdftotext is not available.
+func readHeadPDF(path string, maxRunes int) string {
+	if text := readHeadPDFToText(path, maxRunes); text != "" {
+		return text
+	}
+	return readHeadPDFGo(path, maxRunes)
+}
+
+// readHeadPDFToText uses pdftotext (poppler) to extract first-page text.
+func readHeadPDFToText(path string, maxRunes int) string {
+	pdftotext, err := exec.LookPath("pdftotext")
+	if err != nil {
+		return "" // pdftotext not installed
+	}
+
+	// -l 1: first page only, "-": stdout
+	out, err := exec.Command(pdftotext, "-l", "1", path, "-").Output()
+	if err != nil {
+		return ""
+	}
+
+	text := strings.TrimSpace(string(out))
+	runes := []rune(text)
+	if len(runes) > maxRunes {
+		runes = runes[:maxRunes]
+	}
+	return string(runes)
+}
+
+// readHeadPDFGo extracts text using the pure Go PDF library.
+func readHeadPDFGo(path string, maxRunes int) string {
+	f, r, err := pdf.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	if r.NumPage() < 1 {
+		return ""
+	}
+
+	page := r.Page(1)
+	if page.V.IsNull() {
+		return ""
+	}
+
+	content, err := page.GetPlainText(nil)
+	if err != nil {
+		return ""
+	}
+
+	runes := []rune(content)
+	if len(runes) > maxRunes {
+		runes = runes[:maxRunes]
+	}
+	return string(runes)
+}
+
+// readHeadText reads the first maxRunes runes from a text file.
+func readHeadText(path string, maxRunes int) string {
+	maxBytes := maxRunes * 4
+	if maxBytes > 8192 {
+		maxBytes = 8192
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	buf := make([]byte, maxBytes)
+	n, _ := f.Read(buf)
+	buf = buf[:n]
+
+	count := 0
+	i := 0
+	for i < len(buf) && count < maxRunes {
+		_, size := utf8.DecodeRune(buf[i:])
+		i += size
+		count++
+	}
+
+	return string(buf[:i])
+}

--- a/internal/wiki/ingest.go
+++ b/internal/wiki/ingest.go
@@ -111,7 +111,7 @@ func IngestPath(projectDir string, srcPath string) (*IngestResult, error) {
 		return nil, fmt.Errorf("ingest: file not found: %w", err)
 	}
 
-	srcType := extract.DetectSourceType(absPath)
+	srcType := extract.DetectSourceType(absPath, extract.ReadHead(absPath, 500), cfg.TypeSignals)
 	destDir := findSourceFolder(projectDir, cfg, srcType)
 	if destDir == "" {
 		// Fallback to first source folder


### PR DESCRIPTION
## Summary

- **DetectSourceType** now accepts optional content head text and config-driven type signals, enabling semantic content detection beyond file extensions
- Adds `ReadHead` helper that extracts first-page text from PDFs (pdftotext priority + Go library fallback) for content-aware matching
- Adds `TypeSignal` config struct with filename keywords + content keywords + min hit threshold
- Threads `contentHead` + `typeSignals` through all call sites (diff.go, pipeline.go, ingest.go)
- Fixes PDF type passthrough: detected source type now correctly overrides `extractPDF`'s hardcoded "paper" default
- Fully backward compatible: nil signals = extension-only detection (current behavior)

## Motivation

Different PDF types (research reports, regulations, interview transcripts) need different summarization templates, but `DetectSourceType` currently maps all `.pdf` → "paper". This PR lets users configure keyword-based signals in `config.yaml`:

```yaml
type_signals:
  - type: regulation
    filename_keywords: ["regulation", "rules"]
    content_keywords: ["Article 1", "Article 2", "effective date"]
    min_content_hits: 2
  - type: research
    filename_keywords: ["report", "analysis"]
    content_keywords: ["investment rating", "target price"]
    min_content_hits: 1
```

Combined with the existing `prompts/` template override system, this enables per-content-type summarization (e.g., `summarize_regulation` template for regulation files).

## Test plan

- [x] `go build` passes
- [x] `go test ./...` all green
- [x] Existing `TestDetectSourceType` updated for new signature (nil signals = same behavior)
- [x] New `TestDetectSourceTypeWithSignals` covers filename match, content match, below-threshold fallback, and nil signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)