### PR TITLE
feat: support custom entity types in ontology

### DIFF
--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -337,12 +337,14 @@ func runLint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
 	ctx := &linter.LintContext{
-		ProjectDir:     dir,
-		OutputDir:      cfg.Output,
-		DBPath:         filepath.Join(dir, ".sage", "wiki.db"),
-		ValidRelations: ontology.ValidRelationNames(merged),
+		ProjectDir:       dir,
+		OutputDir:        cfg.Output,
+		DBPath:           filepath.Join(dir, ".sage", "wiki.db"),
+		ValidRelations:   ontology.ValidRelationNames(mergedRels),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
 	}
 
 	runner := linter.NewRunner()

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -356,7 +356,8 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 				}
 
 				merged := ontology.MergedRelations(cfg.Ontology.Relations)
-				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+				mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 
 				client.SetPass("write")
 				var writeCacheID string
@@ -758,7 +759,8 @@ func resumeBatch(
 				}
 
 				merged := ontology.MergedRelations(cfg.Ontology.Relations)
-				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+				mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 				client.SetPass("write")
 				writeCacheID, _ := client.SetupCache("You are a knowledge base article writer. Write comprehensive, well-structured wiki articles.", writeModel)
 				relPatterns := ontology.RelationPatterns(merged)

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -82,7 +82,8 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
 	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 	embedder := embed.NewFromConfig(cfg)
 
 	// Pass 2: Concept extraction

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var relationNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+var typeNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Config represents the sage-wiki project configuration.
 type Config struct {
@@ -99,15 +99,22 @@ type ServeConfig struct {
 	Port      int    `yaml:"port"`
 }
 
-// OntologyConfig configures ontology relation types.
+// OntologyConfig configures ontology relation and entity types.
 type OntologyConfig struct {
-	Relations []RelationConfig `yaml:"relations,omitempty"`
+	Relations   []RelationConfig   `yaml:"relations,omitempty"`
+	EntityTypes []EntityTypeConfig `yaml:"entity_types,omitempty"`
 }
 
 // RelationConfig defines a custom or extended relation type.
 type RelationConfig struct {
 	Name     string   `yaml:"name"`
 	Synonyms []string `yaml:"synonyms"`
+}
+
+// EntityTypeConfig defines a custom or extended entity type.
+type EntityTypeConfig struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
 }
 
 // Defaults returns a Config with sensible defaults for greenfield mode.
@@ -233,8 +240,16 @@ func (c *Config) Validate() error {
 		if r.Name == "" {
 			return fmt.Errorf("config: ontology.relations: name is required")
 		}
-		if !relationNameRe.MatchString(r.Name) {
+		if !typeNameRe.MatchString(r.Name) {
 			return fmt.Errorf("config: ontology.relations: invalid name %q (must match [a-z][a-z0-9_]*)", r.Name)
+		}
+	}
+	for _, et := range c.Ontology.EntityTypes {
+		if et.Name == "" {
+			return fmt.Errorf("config: ontology.entity_types: name is required")
+		}
+		if !typeNameRe.MatchString(et.Name) {
+			return fmt.Errorf("config: ontology.entity_types: invalid name %q (must match [a-z][a-z0-9_]*)", et.Name)
 		}
 	}
 	if c.Compiler.Timezone != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,6 +202,20 @@ func TestValidation(t *testing.T) {
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{Relations: []RelationConfig{{Name: "regulates", Synonyms: []string{"regulates"}}, {Name: "implements"}}}},
 		},
 		{
+			name:    "invalid entity type name uppercase",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: "Concept"}}}},
+			wantErr: "invalid name",
+		},
+		{
+			name:    "invalid entity type name empty",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: ""}}}},
+			wantErr: "name is required",
+		},
+		{
+			name: "valid entity type names",
+			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: "conversation"}, {Name: "decision"}}}},
+		},
+		{
 			name: "valid empty ontology",
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{}},
 		},

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -16,10 +16,11 @@ func setupLintProject(t *testing.T) (string, *LintContext) {
 	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	ctx := &LintContext{
-		ProjectDir:     dir,
-		OutputDir:      "wiki",
-		DBPath:         filepath.Join(dir, ".sage", "wiki.db"),
-		ValidRelations: ontology.ValidRelationNames(ontology.BuiltinRelations),
+		ProjectDir:       dir,
+		OutputDir:        "wiki",
+		DBPath:           filepath.Join(dir, ".sage", "wiki.db"),
+		ValidRelations:   ontology.ValidRelationNames(ontology.BuiltinRelations),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(ontology.BuiltinEntityTypes),
 	}
 	return dir, ctx
 }

--- a/internal/linter/passes.go
+++ b/internal/linter/passes.go
@@ -145,7 +145,7 @@ func (p *OrphansPass) Run(ctx *LintContext) ([]Finding, error) {
 		return nil, nil
 	}
 
-	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations)
+	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations, ctx.ValidEntityTypes)
 
 	entities, err := ontStore.ListEntities("")
 	if err != nil {
@@ -228,7 +228,7 @@ func (p *ConnectionsPass) Run(ctx *LintContext) ([]Finding, error) {
 	}
 
 	vecStore := vectors.NewStore(ctx.DB)
-	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations)
+	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations, ctx.ValidEntityTypes)
 
 	// Get all concept entities with vectors
 	concepts, err := ontStore.ListEntities("concept")

--- a/internal/linter/runner.go
+++ b/internal/linter/runner.go
@@ -41,7 +41,8 @@ type LintContext struct {
 	OutputDir      string
 	DBPath         string
 	DB             *storage.DB // shared DB connection (optional — opened from DBPath if nil)
-	ValidRelations []string    // valid ontology relation type names
+	ValidRelations   []string // valid ontology relation type names
+	ValidEntityTypes []string // valid ontology entity type names
 }
 
 // LintResult holds the aggregated output of a lint run.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -50,8 +50,9 @@ func NewServer(projectDir string) (*Server, error) {
 
 	mem := memory.NewStore(db)
 	vec := vectors.NewStore(db)
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ont := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	searcher := hybrid.NewSearcher(mem, vec)
 
 	s := &Server{

--- a/internal/mcp/tools_compound.go
+++ b/internal/mcp/tools_compound.go
@@ -56,13 +56,15 @@ func (s *Server) handleLint(ctx context.Context, req mcplib.CallToolRequest) (*m
 	passName, _ := args["pass"].(string)
 	fix, _ := args["fix"].(bool)
 
-	merged := ontology.MergedRelations(s.cfg.Ontology.Relations)
+	mergedRels := ontology.MergedRelations(s.cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(s.cfg.Ontology.EntityTypes)
 	lintCtx := &linter.LintContext{
-		ProjectDir:     s.projectDir,
-		OutputDir:      s.cfg.Output,
-		DBPath:         filepath.Join(s.projectDir, ".sage", "wiki.db"),
-		DB:             s.db,
-		ValidRelations: ontology.ValidRelationNames(merged),
+		ProjectDir:       s.projectDir,
+		OutputDir:        s.cfg.Output,
+		DBPath:           filepath.Join(s.projectDir, ".sage", "wiki.db"),
+		DB:               s.db,
+		ValidRelations:   ontology.ValidRelationNames(mergedRels),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
 	}
 
 	runner := linter.NewRunner()

--- a/internal/ontology/entities.go
+++ b/internal/ontology/entities.go
@@ -1,0 +1,58 @@
+package ontology
+
+import "github.com/xoai/sage-wiki/internal/config"
+
+// EntityTypeDef defines an entity type with optional description.
+type EntityTypeDef struct {
+	Name        string
+	Description string
+}
+
+// BuiltinEntityTypes defines the 5 immutable entity types.
+var BuiltinEntityTypes = []EntityTypeDef{
+	{Name: TypeConcept, Description: "An abstract idea or principle"},
+	{Name: TypeTechnique, Description: "A method or algorithm"},
+	{Name: TypeSource, Description: "A reference document or data source"},
+	{Name: TypeClaim, Description: "An assertion that may be true or false"},
+	{Name: TypeArtifact, Description: "A concrete output or deliverable"},
+}
+
+// MergedEntityTypes merges user config with built-in defaults.
+// Built-in types are always present even if not in config.
+// Config can extend built-in descriptions or add custom types.
+func MergedEntityTypes(cfgTypes []config.EntityTypeConfig) []EntityTypeDef {
+	// Start with copies of builtins
+	result := make([]EntityTypeDef, len(BuiltinEntityTypes))
+	copy(result, BuiltinEntityTypes)
+
+	builtinIdx := make(map[string]int, len(result))
+	for i, e := range result {
+		builtinIdx[e.Name] = i
+	}
+
+	for _, ct := range cfgTypes {
+		if idx, ok := builtinIdx[ct.Name]; ok {
+			// Override description for built-in type
+			if ct.Description != "" {
+				result[idx].Description = ct.Description
+			}
+		} else {
+			// New custom type
+			result = append(result, EntityTypeDef{
+				Name:        ct.Name,
+				Description: ct.Description,
+			})
+		}
+	}
+
+	return result
+}
+
+// ValidEntityTypeNames returns the names from a merged entity type list.
+func ValidEntityTypeNames(defs []EntityTypeDef) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}

--- a/internal/ontology/entities_test.go
+++ b/internal/ontology/entities_test.go
@@ -1,0 +1,200 @@
+package ontology
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+func TestMergedEntityTypesEmptyConfig(t *testing.T) {
+	merged := MergedEntityTypes(nil)
+	if len(merged) != len(BuiltinEntityTypes) {
+		t.Fatalf("expected %d builtins, got %d", len(BuiltinEntityTypes), len(merged))
+	}
+	for i, b := range BuiltinEntityTypes {
+		if merged[i].Name != b.Name {
+			t.Errorf("index %d: expected %q, got %q", i, b.Name, merged[i].Name)
+		}
+	}
+}
+
+func TestMergedEntityTypesExtendBuiltin(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "concept", Description: "Custom description for concept"},
+	}
+	merged := MergedEntityTypes(cfg)
+
+	// Should still be 5 total (no new types)
+	if len(merged) != len(BuiltinEntityTypes) {
+		t.Fatalf("expected %d, got %d", len(BuiltinEntityTypes), len(merged))
+	}
+
+	// Description should be overridden
+	if merged[0].Description != "Custom description for concept" {
+		t.Errorf("expected custom description, got %q", merged[0].Description)
+	}
+}
+
+func TestMergedEntityTypesAddCustom(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "conversation", Description: "A dialogue or discussion"},
+	}
+	merged := MergedEntityTypes(cfg)
+
+	if len(merged) != len(BuiltinEntityTypes)+1 {
+		t.Fatalf("expected %d, got %d", len(BuiltinEntityTypes)+1, len(merged))
+	}
+
+	last := merged[len(merged)-1]
+	if last.Name != "conversation" {
+		t.Errorf("expected conversation, got %q", last.Name)
+	}
+	if last.Description != "A dialogue or discussion" {
+		t.Errorf("expected description, got %q", last.Description)
+	}
+}
+
+func TestMergedEntityTypesDoesNotMutateBuiltins(t *testing.T) {
+	originalDesc := BuiltinEntityTypes[0].Description
+	cfg := []config.EntityTypeConfig{
+		{Name: "concept", Description: "Overridden"},
+	}
+	MergedEntityTypes(cfg)
+	if BuiltinEntityTypes[0].Description != originalDesc {
+		t.Error("MergedEntityTypes mutated BuiltinEntityTypes")
+	}
+}
+
+func TestValidEntityTypeNames(t *testing.T) {
+	defs := []EntityTypeDef{
+		{Name: "concept"},
+		{Name: "conversation"},
+	}
+	names := ValidEntityTypeNames(defs)
+	if len(names) != 2 || names[0] != "concept" || names[1] != "conversation" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+// Integration: zero config produces identical behavior to hardcoded builtins
+func TestZeroEntityConfigSameBehavior(t *testing.T) {
+	merged := MergedEntityTypes(nil)
+	names := ValidEntityTypeNames(merged)
+
+	// 5 built-in names
+	if len(names) != 5 {
+		t.Fatalf("expected 5 names, got %d", len(names))
+	}
+
+	// Store accepts all built-in types
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+	for _, name := range names {
+		err := store.AddEntity(Entity{
+			ID:   "e-" + name,
+			Type: name,
+			Name: "Entity " + name,
+		})
+		if err != nil {
+			t.Errorf("built-in entity type %q rejected: %v", name, err)
+		}
+	}
+}
+
+// Integration: custom entity type works end-to-end
+func TestCustomEntityTypeEndToEnd(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "conversation", Description: "A dialogue"},
+	}
+	merged := MergedEntityTypes(cfg)
+	names := ValidEntityTypeNames(merged)
+
+	// 6 names (5 builtins + 1 custom)
+	if len(names) != 6 {
+		t.Fatalf("expected 6 names, got %d", len(names))
+	}
+
+	// Store accepts the custom type
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+	err = store.AddEntity(Entity{
+		ID:   "conv-1",
+		Type: "conversation",
+		Name: "Design Discussion",
+	})
+	if err != nil {
+		t.Fatalf("custom entity type should be accepted: %v", err)
+	}
+
+	// Verify it was stored
+	entity, err := store.GetEntity("conv-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entity == nil {
+		t.Fatal("expected entity, got nil")
+	}
+	if entity.Type != "conversation" {
+		t.Errorf("expected type conversation, got %q", entity.Type)
+	}
+}
+
+// Integration: AddEntity with invalid type returns error
+func TestAddEntityInvalidTypeError(t *testing.T) {
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	names := ValidEntityTypeNames(MergedEntityTypes(nil))
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+
+	err = store.AddEntity(Entity{
+		ID:   "e1",
+		Type: "nonexistent_type",
+		Name: "Test",
+	})
+	if err == nil {
+		t.Error("expected error for invalid entity type")
+	}
+	if err != nil && !strings.Contains(err.Error(), "unknown entity type") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Integration: nil validEntityTypes accepts all types (permissive mode)
+func TestNilValidEntityTypesAcceptsAll(t *testing.T) {
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, nil, nil)
+	err = store.AddEntity(Entity{
+		ID:   "e1",
+		Type: "anything_goes",
+		Name: "Test",
+	})
+	if err != nil {
+		t.Errorf("nil validEntityTypes should accept all types: %v", err)
+	}
+}

--- a/internal/ontology/ontology.go
+++ b/internal/ontology/ontology.go
@@ -67,13 +67,15 @@ type TraverseOpts struct {
 
 // Store manages ontology entities and relations.
 type Store struct {
-	db             *storage.DB
-	validRelations map[string]bool
+	db               *storage.DB
+	validRelations   map[string]bool
+	validEntityTypes map[string]bool
 }
 
-// NewStore creates an ontology store with application-layer relation validation.
+// NewStore creates an ontology store with application-layer type validation.
 // validRelations lists the allowed relation type names. If nil, all types are accepted.
-func NewStore(db *storage.DB, validRelations []string) *Store {
+// validEntityTypes lists the allowed entity type names. If nil, all types are accepted.
+func NewStore(db *storage.DB, validRelations []string, validEntityTypes []string) *Store {
 	s := &Store{db: db}
 	if validRelations != nil {
 		s.validRelations = make(map[string]bool, len(validRelations))
@@ -81,11 +83,20 @@ func NewStore(db *storage.DB, validRelations []string) *Store {
 			s.validRelations[r] = true
 		}
 	}
+	if validEntityTypes != nil {
+		s.validEntityTypes = make(map[string]bool, len(validEntityTypes))
+		for _, t := range validEntityTypes {
+			s.validEntityTypes[t] = true
+		}
+	}
 	return s
 }
 
 // AddEntity creates a new entity.
 func (s *Store) AddEntity(e Entity) error {
+	if s.validEntityTypes != nil && !s.validEntityTypes[e.Type] {
+		return fmt.Errorf("ontology: unknown entity type %q", e.Type)
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	if e.CreatedAt == "" {
 		e.CreatedAt = now

--- a/internal/ontology/ontology_test.go
+++ b/internal/ontology/ontology_test.go
@@ -15,7 +15,7 @@ func setupTestDB(t *testing.T) *Store {
 		t.Fatalf("open db: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	return NewStore(db, ValidRelationNames(BuiltinRelations))
+	return NewStore(db, ValidRelationNames(BuiltinRelations), ValidEntityTypeNames(BuiltinEntityTypes))
 }
 
 func TestAddAndGetEntity(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCustomRelationAccepted(t *testing.T) {
 
 	// Include a custom relation type
 	validNames := append(ValidRelationNames(BuiltinRelations), "regulates")
-	store := NewStore(db, validNames)
+	store := NewStore(db, validNames, ValidEntityTypeNames(BuiltinEntityTypes))
 
 	store.AddEntity(Entity{ID: "e1", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "e2", Type: TypeConcept, Name: "B"})
@@ -158,7 +158,7 @@ func TestNilValidRelationsAcceptsAll(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, nil)
+	store := NewStore(db, nil, nil)
 	store.AddEntity(Entity{ID: "e1", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "e2", Type: TypeConcept, Name: "B"})
 

--- a/internal/ontology/relations_test.go
+++ b/internal/ontology/relations_test.go
@@ -155,7 +155,7 @@ func TestZeroConfigSameBehavior(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "a", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "b", Type: TypeConcept, Name: "B"})
 
@@ -199,7 +199,7 @@ func TestCustomRelationEndToEnd(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "gene-a", Type: TypeConcept, Name: "Gene A"})
 	store.AddEntity(Entity{ID: "gene-b", Type: TypeConcept, Name: "Gene B"})
 
@@ -257,7 +257,7 @@ func TestAddRelationInvalidTypeError(t *testing.T) {
 	defer db.Close()
 
 	names := ValidRelationNames(MergedRelations(nil))
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "a", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "b", Type: TypeConcept, Name: "B"})
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -117,7 +117,7 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 	// Auto-file to outputs/
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)), ontology.ValidEntityTypeNames(ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)))
 	embedder := embed.NewFromConfig(cfg)
 	outputPath, err := autoFile(projectDir, cfg.Output, result, memStore, vecStore, ontStore, embedder, cfg.Compiler.UserNow())
 	if err != nil {
@@ -134,7 +134,7 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 func buildQueryContext(projectDir string, question string, topK int, cfg *config.Config, db *storage.DB) (string, []string, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)), ontology.ValidEntityTypeNames(ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)))
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
 	embedder := embed.NewFromConfig(cfg)
@@ -208,7 +208,7 @@ func SaveAnswer(projectDir string, question string, answer string, sources []str
 	}
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)), ontology.ValidEntityTypeNames(ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)))
 	embedder := embed.NewFromConfig(cfg)
 	result := &QueryResult{
 		Question: question,
@@ -348,7 +348,7 @@ func StreamQuery(ctx context.Context, projectDir string, question string, topK i
 		}
 		memStore := memory.NewStore(db)
 		vecStore := vectors.NewStore(db)
-		ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+		ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)), ontology.ValidEntityTypeNames(ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)))
 		embedder := embed.NewFromConfig(cfg)
 		if outputPath, err := autoFile(projectDir, cfg.Output, result, memStore, vecStore, ontStore, embedder, cfg.Compiler.UserNow()); err != nil {
 			log.Warn("stream auto-filing failed", "error", err)

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -138,6 +138,7 @@ func (db *DB) migrate() error {
 	migrations := []string{
 		migrationV1,
 		migrationV2,
+		migrationV3,
 	}
 
 	for i := version; i < len(migrations); i++ {
@@ -230,6 +231,44 @@ CREATE TABLE IF NOT EXISTS relations_new (
 INSERT OR IGNORE INTO relations_new SELECT * FROM relations;
 DROP TABLE IF EXISTS relations;
 ALTER TABLE relations_new RENAME TO relations;
+
+CREATE INDEX IF NOT EXISTS idx_relations_source ON relations(source_id);
+CREATE INDEX IF NOT EXISTS idx_relations_target ON relations(target_id);
+CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(relation);
+`
+
+// migrationV3 removes the CHECK constraint on entities.type to support custom entity types.
+// Same pattern as migrationV2: recreate table without constraint, migrate data, rebuild indexes.
+const migrationV3 = `
+CREATE TABLE IF NOT EXISTS entities_new (
+	id TEXT PRIMARY KEY,
+	type TEXT NOT NULL,
+	name TEXT NOT NULL,
+	definition TEXT,
+	article_path TEXT,
+	metadata JSON,
+	created_at TEXT,
+	updated_at TEXT
+);
+
+INSERT OR IGNORE INTO entities_new SELECT * FROM entities;
+DROP TABLE IF EXISTS entities;
+ALTER TABLE entities_new RENAME TO entities;
+
+-- Recreate relations table to restore CASCADE DELETE on the new entities table
+CREATE TABLE IF NOT EXISTS relations_rebuild (
+	id TEXT PRIMARY KEY,
+	source_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+	target_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+	relation TEXT NOT NULL,
+	metadata JSON,
+	created_at TEXT,
+	UNIQUE(source_id, target_id, relation)
+);
+
+INSERT OR IGNORE INTO relations_rebuild SELECT * FROM relations;
+DROP TABLE IF EXISTS relations;
+ALTER TABLE relations_rebuild RENAME TO relations;
 
 CREATE INDEX IF NOT EXISTS idx_relations_source ON relations(source_id);
 CREATE INDEX IF NOT EXISTS idx_relations_target ON relations(target_id);

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -239,7 +239,12 @@ CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(relation);
 
 // migrationV3 removes the CHECK constraint on entities.type to support custom entity types.
 // Same pattern as migrationV2: recreate table without constraint, migrate data, rebuild indexes.
+// Foreign keys are disabled during the migration to prevent data loss when
+// dropping and recreating the entities table (relations FK references become
+// temporarily invalid).
 const migrationV3 = `
+PRAGMA foreign_keys = OFF;
+
 CREATE TABLE IF NOT EXISTS entities_new (
 	id TEXT PRIMARY KEY,
 	type TEXT NOT NULL,
@@ -273,4 +278,6 @@ ALTER TABLE relations_rebuild RENAME TO relations;
 CREATE INDEX IF NOT EXISTS idx_relations_source ON relations(source_id);
 CREATE INDEX IF NOT EXISTS idx_relations_target ON relations(target_id);
 CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(relation);
+
+PRAGMA foreign_keys = ON;
 `

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -23,8 +23,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query schema_version: %v", err)
 	}
-	if version != 2 {
-		t.Errorf("expected schema version 2, got %d", version)
+	if version != 3 {
+		t.Errorf("expected schema version 3, got %d", version)
 	}
 
 	// Verify tables exist
@@ -62,8 +62,8 @@ func TestIdempotentMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 2 {
-		t.Errorf("expected 2 schema_version rows, got %d", count)
+	if count != 3 {
+		t.Errorf("expected 3 schema_version rows, got %d", count)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -55,8 +55,9 @@ func NewWebServer(projectDir string) (*WebServer, error) {
 
 	mem := memory.NewStore(db)
 	vec := vectors.NewStore(db)
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ont := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	searcher := hybrid.NewSearcher(mem, vec)
 
 	return &WebServer{

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -236,16 +236,24 @@ serve:
   transport: stdio      # stdio or sse
   port: 3333            # SSE mode only
 
-# Ontology relation types (optional)
+# Ontology types (optional)
 # Extend built-in types with additional synonyms or add custom types.
-# Built-in types: implements, extends, optimizes, contradicts, cites,
-#                 prerequisite_of, trades_off, derived_from
+#
+# Built-in relation types: implements, extends, optimizes, contradicts, cites,
+#                          prerequisite_of, trades_off, derived_from
+# Built-in entity types: concept, technique, source, claim, artifact
+#
 # ontology:
 #   relations:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]   # add Vietnamese synonyms
 #     - name: regulates
 #       synonyms: ["regulates", "regulated by", "调控", "调节"]
+#   entity_types:
+#     - name: conversation
+#       description: "A dialogue or discussion"
+#     - name: decision
+#       description: "A recorded decision with rationale"
 `, project, description, model, model, model, model, model)
 }
 
@@ -303,12 +311,15 @@ search:
 serve:
   transport: stdio
 
-# Ontology relation types (optional)
+# Ontology types (optional)
 # ontology:
 #   relations:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]
 #     - name: regulates
 #       synonyms: ["regulates", "regulated by"]
+#   entity_types:
+#     - name: conversation
+#     - name: decision
 `, project, project, sourcesYAML, output, ignoreYAML, model, model, model, model, model)
 }

--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -91,7 +91,7 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 
 		memStore = memory.NewStore(db)
 		vecStore = vectors.NewStore(db)
-		ontStore = ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+		ontStore = ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)), ontology.ValidEntityTypeNames(ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)))
 	}
 
 	info.EntryCount, _ = memStore.Count()


### PR DESCRIPTION
## Summary

Support custom entity types in the ontology, following the same two-tier pattern as configurable relation types (#19):
- Built-in defaults (concept, technique, source, claim, artifact) are always present
- Custom types added via `config.yaml` under `ontology.entity_types`
- Application-layer validation replaces the SQL CHECK constraint

## Changes

- **Config**: Add `EntityTypeConfig` to `OntologyConfig` with name validation (`[a-z][a-z0-9_]*`)
- **Ontology**: New `entities.go` with `BuiltinEntityTypes`, `MergedEntityTypes`, `ValidEntityTypeNames` (mirrors `relations.go`)
- **Store**: Add `validEntityTypes` map to `Store`, validate in `AddEntity()`
- **Migration**: `migrationV3` removes CHECK on `entities.type`, rebuilds relations table to verify CASCADE DELETE
- **Wiring**: Updated all callers (MCP, web server, compiler, query, linter) to merge and pass entity types
- **Tests**: Comprehensive test suite mirroring `relations_test.go` patterns
- **Templates**: Updated config templates with `entity_types` example

## Config example

```yaml
ontology:
  entity_types:
    - name: conversation
      description: "A dialogue or discussion"
    - name: decision
      description: "A recorded decision with rationale"
```

## Addresses review feedback

- ✅ Rebased on current main (v0.1.2) — migration is now `migrationV3`
- ✅ Follows configurable relations two-tier pattern (built-in defaults + config-driven custom)
- ✅ CASCADE DELETE verified — relations table rebuilt in migrationV3 with new FK reference
- ✅ Name validation uses same regex as relation types
- ✅ All existing tests pass, new tests added

## Test plan

- [x] All existing tests pass (`go test ./...` — 28 packages)
- [x] New entity type tests: merge, validation, end-to-end, immutability
- [x] Config validation tests: invalid names rejected, valid names accepted
- [x] Migration test: schema version 3, idempotent re-open
- [x] Store integration: custom type accepted, invalid type rejected, nil permissive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)