### PR TITLE
fix: support reasoning models with think-tag token overhead

### DIFF
--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -209,8 +209,11 @@ func summarizeImage(projectDir string, info SourceInfo, client *llm.Client, mode
 
 const (
 	// minChunkTokenBudget is the minimum output tokens per chunk summary.
-	// Below this, LLMs produce empty or unusable output.
-	minChunkTokenBudget = 200
+	// Reasoning models (MiniMax, DeepSeek) use ~100-200 tokens for <think>
+	// traces, so 200 is too low — the model exhausts the budget on reasoning
+	// with nothing left for actual content. 500 leaves ~300 tokens for output
+	// after think overhead, producing usable summaries (~200 CJK characters).
+	minChunkTokenBudget = 500
 
 	// synthesisGroupSize is the max number of summaries per synthesis call.
 	// Keeps each synthesis step at a manageable compression ratio (~8x).

--- a/internal/compiler/summarize_test.go
+++ b/internal/compiler/summarize_test.go
@@ -12,8 +12,8 @@ func TestGroupChunksNoGroupingNeeded(t *testing.T) {
 		chunks[i] = extract.Chunk{Index: i, Text: "content"}
 	}
 
-	// 2000 / 5 = 400 per chunk, above minChunkTokenBudget (200)
-	groups := groupChunks(chunks, 2000)
+	// 5000 / 5 = 1000 per chunk, above minChunkTokenBudget (500)
+	groups := groupChunks(chunks, 5000)
 	if len(groups) != 5 {
 		t.Errorf("expected 5 groups (no grouping), got %d", len(groups))
 	}
@@ -30,15 +30,15 @@ func TestGroupChunksNeedsGrouping(t *testing.T) {
 		chunks[i] = extract.Chunk{Index: i, Text: "content"}
 	}
 
-	// 2000 / 60 = 33 per chunk, below minChunkTokenBudget (200)
-	// maxGroups = 2000 / 200 = 10
-	// chunksPerGroup = ceil(60 / 10) = 6
+	// 2000 / 60 = 33 per chunk, below minChunkTokenBudget (500)
+	// maxGroups = 2000 / 500 = 4
+	// chunksPerGroup = ceil(60 / 4) = 15
 	groups := groupChunks(chunks, 2000)
-	if len(groups) > 10 {
-		t.Errorf("expected <= 10 groups, got %d", len(groups))
+	if len(groups) > 4 {
+		t.Errorf("expected <= 4 groups, got %d", len(groups))
 	}
-	if len(groups) < 5 {
-		t.Errorf("expected >= 5 groups, got %d", len(groups))
+	if len(groups) < 2 {
+		t.Errorf("expected >= 2 groups, got %d", len(groups))
 	}
 
 	// All chunks accounted for
@@ -57,11 +57,11 @@ func TestGroupChunksExtreme(t *testing.T) {
 		chunks[i] = extract.Chunk{Index: i, Text: "content"}
 	}
 
-	// 2000 / 200 = 10, way below minimum
+	// 2000 / 200 = 10 per chunk, way below minChunkTokenBudget (500)
+	// maxGroups = 2000 / 500 = 4, chunksPerGroup = 50
 	groups := groupChunks(chunks, 2000)
-	// maxGroups = 10, chunksPerGroup = 20
-	if len(groups) > 10 {
-		t.Errorf("expected <= 10 groups, got %d", len(groups))
+	if len(groups) > 4 {
+		t.Errorf("expected <= 4 groups, got %d", len(groups))
 	}
 
 	total := 0
@@ -94,8 +94,8 @@ func TestGroupChunksMaxTokensBelowMinBudget(t *testing.T) {
 		chunks[i] = extract.Chunk{Index: i, Text: "content"}
 	}
 
-	// maxTokens=100 < minChunkTokenBudget=200
-	// maxGroups = 100/200 = 0, clamped to 1 → all chunks in one group
+	// maxTokens=100 < minChunkTokenBudget=500
+	// maxGroups = 100/500 = 0, clamped to 1 → all chunks in one group
 	groups := groupChunks(chunks, 100)
 	if len(groups) != 1 {
 		t.Errorf("expected 1 group when maxTokens < minBudget, got %d", len(groups))
@@ -112,7 +112,7 @@ func TestGroupChunksMaxTokensZero(t *testing.T) {
 	}
 
 	// maxTokens=0 → perChunkBudget=0, triggers grouping
-	// maxGroups = 0/200 = 0, clamped to 1
+	// maxGroups = 0/500 = 0, clamped to 1
 	groups := groupChunks(chunks, 0)
 	if len(groups) != 1 {
 		t.Errorf("expected 1 group when maxTokens=0, got %d", len(groups))

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -250,6 +250,26 @@ func (r *rateLimiter) wait() {
 	r.lastCall = time.Now()
 }
 
+// stripThinkTags removes <think>...</think> blocks from LLM responses.
+// Some models (e.g. MiniMax) include reasoning traces that should not appear in output.
+// When the model puts ALL content inside think tags (common with reasoning models
+// under tight token budgets), falls back to extracting the think content rather
+// than returning empty.
+var thinkTagRe = regexp.MustCompile(`(?s)<think>.*?</think>\s*`)
+var thinkContentRe = regexp.MustCompile(`(?s)<think>(.*?)</think>`)
+
+func stripThinkTags(s string) string {
+	stripped := strings.TrimSpace(thinkTagRe.ReplaceAllString(s, ""))
+	if stripped != "" {
+		return stripped
+	}
+	// Fallback: extract content from inside first think block
+	if m := thinkContentRe.FindStringSubmatch(s); len(m) > 1 {
+		return strings.TrimSpace(m[1])
+	}
+	return stripped
+}
+
 // jsonBody creates a JSON request body. Panics on marshal failure
 // since we only marshal known map structures.
 func jsonBody(v any) *bytes.Buffer {
@@ -258,12 +278,4 @@ func jsonBody(v any) *bytes.Buffer {
 		panic(fmt.Sprintf("llm: failed to marshal request body: %v", err))
 	}
 	return bytes.NewBuffer(data)
-}
-
-// stripThinkTags removes <think>...</think> reasoning traces from LLM responses.
-// Some models (DeepSeek, MiniMax) include these in output.
-var thinkTagRe = regexp.MustCompile(`(?s)<think>.*?</think>\s*`)
-
-func stripThinkTags(s string) string {
-	return strings.TrimSpace(thinkTagRe.ReplaceAllString(s, ""))
 }

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -244,8 +244,16 @@ func TestStripThinkTags(t *testing.T) {
 		{"multiline tag", "<think>\nstep 1\nstep 2\n</think>\nResult", "Result"},
 		{"tag with trailing whitespace", "<think>internal</think>  \n\nContent here", "Content here"},
 		{"multiple tags", "<think>first</think>A<think>second</think>B", "AB"},
-		{"empty after strip", "<think>only reasoning</think>", ""},
 		{"no think tags just content", "plain text without tags", "plain text without tags"},
+		// Fallback: when strip produces empty, extract think content
+		{"fallback single think", "<think>only reasoning</think>", "only reasoning"},
+		{"fallback with whitespace", "<think>  content  </think>   ", "content"},
+		{"fallback multiline think", "<think>\nline 1\nline 2\n</think>", "line 1\nline 2"},
+		{"fallback first of multiple", "<think>first</think><think>second</think>", "first"},
+		// Edge cases
+		{"empty string", "", ""},
+		{"just whitespace", "   ", ""},
+		{"nested angle brackets", "<think>a<b>c</b>d</think>Real", "Real"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Raise `minChunkTokenBudget` from 200 to 500 — reasoning models (MiniMax, DeepSeek) use ~100-200 tokens for `<think>` traces, leaving no room for actual content at 200
- Add fallback in `stripThinkTags` — when strip produces empty but raw response had think content, extract the think content instead of returning empty

## Root Cause
With `minChunkTokenBudget=200`, the API `max_tokens` is set to 200 for chunk summaries. Reasoning models spend ~150 tokens on `<think>` reasoning, leaving ~50 tokens for actual output. The model often produces nothing useful outside `</think>`, and `stripThinkTags` deletes the think block, resulting in an empty string. The compile pipeline then reports "LLM returned empty summary" for every file.

## Verification
- Tested with MiniMax M2.5-highspeed: 27/27 files that previously failed now compile successfully
- Token budget experiments: max_tokens=200 → empty output, max_tokens=500 → 407 chars, max_tokens=2000 → 783 chars
- Direct API tests confirmed the issue is budget-related: same prompt with adequate budget consistently produces non-empty output
- 5x consistency test: API never returns empty with sufficient budget

## Changes
1. `internal/compiler/summarize.go`: `minChunkTokenBudget` 200 → 500. Also reduces max groups (from 10 to 4 with default 2000 summary_max_tokens), giving each group more context for better summaries. Total cost unchanged.
2. `internal/llm/client.go`: `stripThinkTags` now falls back to extracting think content when stripping produces empty. Adds `thinkContentRe` regex for extraction.
3. `internal/llm/client_test.go`: Updated tests — 4 new fallback test cases, 3 edge case tests.
4. `internal/compiler/summarize_test.go`: Updated groupChunks tests for new constant value.

## Test plan
- [x] `TestStripThinkTags` — 14 cases including 4 fallback scenarios
- [x] `TestGroupChunks*` — all 7 cases updated for minChunkTokenBudget=500
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Fresh compile with 44 source files, 0 errors (was 27/27 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)