### PR TITLE
feat: add language config for wiki output language

### DIFF
--- a/internal/compiler/concepts.go
+++ b/internal/compiler/concepts.go
@@ -83,7 +83,7 @@ func ExtractConcepts(
 		prompt, err := prompts.Render("extract_concepts", prompts.ExtractData{
 			ExistingConcepts: strings.Join(dedup, ", "),
 			Summaries:        strings.Join(summaryTexts, "\n\n---\n\n"),
-		})
+		}, "")
 		if err != nil {
 			log.Error("render extract_concepts prompt failed", "batch", i/conceptBatchSize+1, "error", err)
 			continue

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -87,6 +87,11 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 		log.Warn("failed to load custom prompts", "error", err)
 	}
 
+	// Configure output language if set
+	if cfg.Language != "" {
+		prompts.SetLanguage(cfg.Language)
+	}
+
 	// Load manifest
 	mfPath := filepath.Join(projectDir, ".manifest.json")
 	mf, err := manifest.Load(mfPath)

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -87,11 +87,6 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 		log.Warn("failed to load custom prompts", "error", err)
 	}
 
-	// Configure output language if set
-	if cfg.Language != "" {
-		prompts.SetLanguage(cfg.Language)
-	}
-
 	// Load manifest
 	mfPath := filepath.Join(projectDir, ".manifest.json")
 	mf, err := manifest.Load(mfPath)
@@ -269,7 +264,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 		maxTokens = 2000
 	}
 
-	summaries := Summarize(projectDir, cfg.Output, toProcess, client, model, maxTokens, cfg.Compiler.MaxParallel, cfg.Compiler.UserTimeLocation())
+	summaries := Summarize(projectDir, cfg.Output, toProcess, client, model, maxTokens, cfg.Compiler.MaxParallel, cfg.Compiler.UserTimeLocation(), cfg.Language)
 
 	for _, sr := range summaries {
 		if sr.Error != nil {
@@ -400,6 +395,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 					ArticleFields:    cfg.Compiler.ArticleFields,
 					RelationPatterns: relPatterns,
 					ChunkSize:        cfg.Search.ChunkSizeOrDefault(),
+					Language:         cfg.Language,
 				}, concepts)
 
 				for _, ar := range articles {
@@ -516,7 +512,7 @@ func submitBatch(
 		}
 
 		templateName := "summarize_" + content.Type
-		if _, err := prompts.Render(templateName, prompts.SummarizeData{}); err != nil {
+		if _, err := prompts.Render(templateName, prompts.SummarizeData{}, ""); err != nil {
 			templateName = "summarize_article"
 		}
 
@@ -524,7 +520,7 @@ func submitBatch(
 			SourcePath: src.Path,
 			SourceType: content.Type,
 			MaxTokens:  maxTokens,
-		})
+		}, cfg.Language)
 		if err != nil {
 			log.Warn("batch: skip source (prompt render failed)", "path", src.Path, "error", err)
 			continue
@@ -811,6 +807,7 @@ func resumeBatch(
 					ArticleFields:    cfg.Compiler.ArticleFields,
 					RelationPatterns: relPatterns,
 					ChunkSize:        cfg.Search.ChunkSizeOrDefault(),
+					Language:         cfg.Language,
 				}, concepts)
 
 				for _, ar := range articles {

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -32,6 +32,11 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 		log.Warn("failed to load custom prompts", "error", err)
 	}
 
+	// Configure output language if set
+	if cfg.Language != "" {
+		prompts.SetLanguage(cfg.Language)
+	}
+
 	mf, err := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
 	if err != nil {
 		return nil, fmt.Errorf("re-extract: load manifest: %w", err)

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -32,11 +32,6 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 		log.Warn("failed to load custom prompts", "error", err)
 	}
 
-	// Configure output language if set
-	if cfg.Language != "" {
-		prompts.SetLanguage(cfg.Language)
-	}
-
 	mf, err := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
 	if err != nil {
 		return nil, fmt.Errorf("re-extract: load manifest: %w", err)
@@ -139,6 +134,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 			ArticleFields:    cfg.Compiler.ArticleFields,
 			RelationPatterns: relPatterns,
 			ChunkSize:        cfg.Search.ChunkSizeOrDefault(),
+			Language:         cfg.Language,
 		}, concepts)
 
 		for _, ar := range articles {

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -36,6 +36,7 @@ func Summarize(
 	maxTokens int,
 	maxParallel int,
 	userTZ *time.Location,
+	language string,
 ) []SummaryResult {
 	if maxParallel <= 0 {
 		maxParallel = 4
@@ -55,7 +56,7 @@ func Summarize(
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			result := summarizeOne(projectDir, outputDir, info, client, model, maxTokens, userTZ)
+			result := summarizeOne(projectDir, outputDir, info, client, model, maxTokens, userTZ, language)
 			results[idx] = result
 
 			n := int(done.Add(1))
@@ -79,6 +80,7 @@ func summarizeOne(
 	model string,
 	maxTokens int,
 	userTZ *time.Location,
+	language string,
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
 
@@ -109,7 +111,7 @@ func summarizeOne(
 
 	// Select prompt template — try type-specific first, fall back to article
 	templateName := "summarize_" + content.Type
-	if _, err := prompts.Render(templateName, prompts.SummarizeData{}); err != nil {
+	if _, err := prompts.Render(templateName, prompts.SummarizeData{}, ""); err != nil {
 		templateName = "summarize_article" // fallback for unknown types
 	}
 
@@ -119,7 +121,7 @@ func summarizeOne(
 			SourcePath: info.Path,
 			SourceType: content.Type,
 			MaxTokens:  maxTokens,
-		})
+		}, language)
 		if err != nil {
 			result.Error = fmt.Errorf("render prompt: %w", err)
 			return result
@@ -137,7 +139,7 @@ func summarizeOne(
 		summaryText = resp.Content
 	} else {
 		// Multi-chunk: summarize each chunk, then synthesize hierarchically
-		chunkSummaries, err := summarizeChunks(content.Chunks, info, templateName, content.Type, client, model, maxTokens)
+		chunkSummaries, err := summarizeChunks(content.Chunks, info, templateName, content.Type, client, model, maxTokens, language)
 		if err != nil {
 			result.Error = err
 			return result
@@ -228,6 +230,7 @@ func summarizeChunks(
 	client *llm.Client,
 	model string,
 	maxTokens int,
+	language string,
 ) ([]string, error) {
 	// Group chunks if per-chunk budget is too low
 	groups := groupChunks(chunks, maxTokens)
@@ -260,7 +263,7 @@ func summarizeChunks(
 			SourcePath: info.Path,
 			SourceType: sourceType,
 			MaxTokens:  perGroupBudget,
-		})
+		}, language)
 		if err != nil {
 			return nil, fmt.Errorf("group %d render prompt: %w", gi, err)
 		}

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -48,6 +48,7 @@ type ArticleWriteOpts struct {
 	ArticleFields    []string
 	RelationPatterns []ontology.RelationPattern
 	ChunkSize        int // tokens per chunk (default 800)
+	Language         string
 }
 
 // WriteArticles runs Pass 3: write concept articles with ontology edges.
@@ -111,7 +112,7 @@ func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept) ArticleRes
 		RelatedList:     strings.Join(relatedNames, ", "),
 		Confidence:      "medium",
 		MaxTokens:       opts.MaxTokens,
-	})
+	}, opts.Language)
 	if err != nil {
 		result.Error = fmt.Errorf("render write_article prompt: %w", err)
 		return result

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Version     int          `yaml:"version"`
 	Project     string       `yaml:"project"`
 	Description string       `yaml:"description"`
+	Language    string       `yaml:"language,omitempty"`
 	Vault       *VaultConfig `yaml:"vault,omitempty"`
 	Sources     []Source     `yaml:"sources"`
 	Output      string       `yaml:"output"`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/xoai/sage-wiki/internal/manifest"
 	"github.com/xoai/sage-wiki/internal/memory"
 	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/prompts"
 	"github.com/xoai/sage-wiki/internal/storage"
 	"github.com/xoai/sage-wiki/internal/vectors"
 	"github.com/xoai/sage-wiki/internal/wiki"
@@ -40,6 +41,11 @@ func NewServer(projectDir string) (*Server, error) {
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: load config: %w", err)
+	}
+
+	// Configure output language if set
+	if cfg.Language != "" {
+		prompts.SetLanguage(cfg.Language)
 	}
 
 	dbPath := filepath.Join(projectDir, ".sage", "wiki.db")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,7 +16,6 @@ import (
 	"github.com/xoai/sage-wiki/internal/manifest"
 	"github.com/xoai/sage-wiki/internal/memory"
 	"github.com/xoai/sage-wiki/internal/ontology"
-	"github.com/xoai/sage-wiki/internal/prompts"
 	"github.com/xoai/sage-wiki/internal/storage"
 	"github.com/xoai/sage-wiki/internal/vectors"
 	"github.com/xoai/sage-wiki/internal/wiki"
@@ -33,6 +32,7 @@ type Server struct {
 	searcher   *hybrid.Searcher
 	embedder   embed.Embedder
 	cfg        *config.Config
+	language   string
 }
 
 // NewServer creates an MCP server with read tools registered.
@@ -41,11 +41,6 @@ func NewServer(projectDir string) (*Server, error) {
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("mcp: load config: %w", err)
-	}
-
-	// Configure output language if set
-	if cfg.Language != "" {
-		prompts.SetLanguage(cfg.Language)
 	}
 
 	dbPath := filepath.Join(projectDir, ".sage", "wiki.db")
@@ -69,6 +64,7 @@ func NewServer(projectDir string) (*Server, error) {
 		searcher:   searcher,
 		embedder:   embed.NewFromConfig(cfg),
 		cfg:        cfg,
+		language:   cfg.Language,
 	}
 
 	mcpServer := server.NewMCPServer(

--- a/internal/mcp/tools_write.go
+++ b/internal/mcp/tools_write.go
@@ -400,7 +400,7 @@ func extractKnowledgeItems(cfg *config.Config, content, captureCtx, tags string)
 	prompt, err := prompts.Render("capture_knowledge", prompts.CaptureData{
 		Context: captureCtx,
 		Tags:    tags,
-	})
+	}, cfg.Language)
 	if err != nil {
 		return nil, fmt.Errorf("render prompt: %w", err)
 	}

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -15,6 +15,7 @@ var templateFS embed.FS
 
 var defaultTemplates *template.Template
 var activeTemplates *template.Template
+var outputLanguage string // configured via SetLanguage
 
 func init() {
 	var err error
@@ -87,14 +88,25 @@ func LoadFromDir(dir string) error {
 	return nil
 }
 
+// SetLanguage configures the output language for all prompts.
+// When set, a language instruction is appended to every rendered prompt.
+func SetLanguage(lang string) {
+	outputLanguage = lang
+}
+
 // Render renders a named template with the given data.
 // Uses user overrides if loaded, otherwise embedded defaults.
+// If a language is configured via SetLanguage, appends a language instruction.
 func Render(name string, data any) (string, error) {
 	var buf bytes.Buffer
 	if err := activeTemplates.ExecuteTemplate(&buf, name+".txt", data); err != nil {
 		return "", fmt.Errorf("prompts.Render(%s): %w", name, err)
 	}
-	return buf.String(), nil
+	result := buf.String()
+	if outputLanguage != "" {
+		result += fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.", outputLanguage)
+	}
+	return result, nil
 }
 
 // ScaffoldDefaults copies all embedded default templates to a directory
@@ -209,4 +221,5 @@ func Available() []string {
 // Reset restores embedded defaults (useful for testing).
 func Reset() {
 	activeTemplates = defaultTemplates
+	outputLanguage = ""
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -15,7 +15,6 @@ var templateFS embed.FS
 
 var defaultTemplates *template.Template
 var activeTemplates *template.Template
-var outputLanguage string // configured via SetLanguage
 
 func init() {
 	var err error
@@ -88,30 +87,28 @@ func LoadFromDir(dir string) error {
 	return nil
 }
 
-// SetLanguage configures the output language for all prompts.
-// When set, a language instruction is appended to every rendered prompt.
-func SetLanguage(lang string) {
-	outputLanguage = lang
-}
-
-// jsonOnlyTemplates lists templates that require structured output (JSON).
+// isJSONTemplate returns true if the rendered template content requires
+// structured JSON output. Detected by convention: the template must contain
+// "Output ONLY a JSON" or "Return ONLY a JSON" (case-insensitive).
 // Language instructions are skipped for these to avoid corrupting the format.
-var jsonOnlyTemplates = map[string]bool{
-	"extract_concepts": true,
+func isJSONTemplate(rendered string) bool {
+	lower := strings.ToLower(rendered)
+	return strings.Contains(lower, "output only a json") ||
+		strings.Contains(lower, "return only a json")
 }
 
 // Render renders a named template with the given data.
 // Uses user overrides if loaded, otherwise embedded defaults.
-// If a language is configured via SetLanguage, appends a language instruction
-// (except for JSON-output templates like extract_concepts).
-func Render(name string, data any) (string, error) {
+// If language is non-empty, appends a language instruction
+// (except for JSON-output templates, detected by convention).
+func Render(name string, data any, language string) (string, error) {
 	var buf bytes.Buffer
 	if err := activeTemplates.ExecuteTemplate(&buf, name+".txt", data); err != nil {
 		return "", fmt.Errorf("prompts.Render(%s): %w", name, err)
 	}
 	result := buf.String()
-	if outputLanguage != "" && !jsonOnlyTemplates[name] {
-		result += fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.", outputLanguage)
+	if language != "" && !isJSONTemplate(result) {
+		result += fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.", language)
 	}
 	return result, nil
 }
@@ -225,8 +222,7 @@ func Available() []string {
 	return names
 }
 
-// Reset restores embedded defaults (useful for testing).
+// Reset restores embedded defaults and clears all state (useful for testing).
 func Reset() {
 	activeTemplates = defaultTemplates
-	outputLanguage = ""
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -94,16 +94,23 @@ func SetLanguage(lang string) {
 	outputLanguage = lang
 }
 
+// jsonOnlyTemplates lists templates that require structured output (JSON).
+// Language instructions are skipped for these to avoid corrupting the format.
+var jsonOnlyTemplates = map[string]bool{
+	"extract_concepts": true,
+}
+
 // Render renders a named template with the given data.
 // Uses user overrides if loaded, otherwise embedded defaults.
-// If a language is configured via SetLanguage, appends a language instruction.
+// If a language is configured via SetLanguage, appends a language instruction
+// (except for JSON-output templates like extract_concepts).
 func Render(name string, data any) (string, error) {
 	var buf bytes.Buffer
 	if err := activeTemplates.ExecuteTemplate(&buf, name+".txt", data); err != nil {
 		return "", fmt.Errorf("prompts.Render(%s): %w", name, err)
 	}
 	result := buf.String()
-	if outputLanguage != "" {
+	if outputLanguage != "" && !jsonOnlyTemplates[name] {
 		result += fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.", outputLanguage)
 	}
 	return result, nil

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -31,7 +31,7 @@ func TestRenderSummarize(t *testing.T) {
 		SourcePath: "raw/articles/test.md",
 		SourceType: "article",
 		MaxTokens:  2000,
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestRenderWriteArticle(t *testing.T) {
 		RelatedConcepts: []string{"multi-head-attention", "positional-encoding"},
 		MaxTokens:       4000,
 		Confidence:      "high",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -71,11 +71,87 @@ func TestRenderWriteArticle(t *testing.T) {
 func TestRenderCaption(t *testing.T) {
 	result, err := Render("caption_image", CaptionData{
 		SourcePath: "raw/papers/figure1.png",
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	if !strings.Contains(result, "raw/papers/figure1.png") {
 		t.Error("expected source path")
+	}
+}
+
+func TestRenderLanguageInjection(t *testing.T) {
+	// Language instruction should be appended for non-JSON templates
+	result, err := Render("summarize_article", SummarizeData{
+		SourcePath: "raw/test.md",
+		SourceType: "article",
+		MaxTokens:  1000,
+	}, "Chinese")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(result, "Write your entire response in Chinese") {
+		t.Error("expected language instruction for non-JSON template")
+	}
+}
+
+func TestRenderLanguageSkippedForJSON(t *testing.T) {
+	// Language instruction should NOT be appended for JSON-output templates
+	result, err := Render("extract_concepts", ExtractData{
+		ExistingConcepts: "attention",
+		Summaries:        "test summary",
+	}, "Chinese")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(result, "Write your entire response in") {
+		t.Error("language instruction should be skipped for JSON-output templates")
+	}
+}
+
+func TestRenderLanguageSkippedForCapture(t *testing.T) {
+	// capture_knowledge also requires JSON output
+	result, err := Render("capture_knowledge", CaptureData{
+		Context: "test",
+	}, "Chinese")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(result, "Write your entire response in") {
+		t.Error("language instruction should be skipped for JSON-output templates")
+	}
+}
+
+func TestRenderNoLanguage(t *testing.T) {
+	// No language instruction when language is empty
+	result, err := Render("summarize_article", SummarizeData{
+		SourcePath: "raw/test.md",
+		SourceType: "article",
+		MaxTokens:  1000,
+	}, "")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(result, "Write your entire response in") {
+		t.Error("should not inject language when language is empty")
+	}
+}
+
+func TestIsJSONTemplate(t *testing.T) {
+	tests := []struct {
+		content string
+		want    bool
+	}{
+		{"Output ONLY a JSON array of objects.", true},
+		{"Return ONLY a JSON array.", true},
+		{"output only a json array", true},
+		{"Write a summary.", false},
+		{"Return results in markdown format.", false},
+	}
+	for _, tt := range tests {
+		got := isJSONTemplate(tt.content)
+		if got != tt.want {
+			t.Errorf("isJSONTemplate(%q) = %v, want %v", tt.content[:30], got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `language` field to `config.yaml` for controlling wiki output language
- When set, a language instruction is automatically appended to all LLM prompts
- Technical terms, code, and proper nouns are preserved in their original form
- Zero config = English output (same as current behavior)

## Usage

```yaml
# config.yaml
language: Chinese    # or Japanese, Spanish, French, etc.
```

## Changes

- `internal/config/config.go` -- add `Language` field to `Config` struct
- `internal/prompts/prompts.go` -- add `SetLanguage()` and append instruction in `Render()`
- `internal/compiler/pipeline.go` -- pass language config to prompts on compile
- `internal/compiler/reextract.go` -- pass language config on re-extract
- `internal/mcp/server.go` -- pass language config for MCP server tools

## Test plan

- [ ] Verify `go test ./internal/prompts/` passes
- [ ] Verify `go test ./internal/config/` passes
- [ ] Set `language: Chinese` in config.yaml and run `sage-wiki compile` -- output should be in Chinese
- [ ] Omit `language` field -- output should remain English (backward compatible)