### PR TITLE
feat: add multi-project hub with config extends and federated search

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See the [self-hosting guide](docs/guides/self-hosted-server.md) for Docker Compo
 | `sage-wiki list` | List wiki entities, concepts, or sources |
 | `sage-wiki write <summary\|article>` | Write a summary or article |
 | `sage-wiki ontology <query\|list\|add>` | Query, list, and manage the ontology graph |
+| `sage-wiki hub <add\|remove\|search\|status\|list\|compile>` | Multi-project hub commands |
 | `sage-wiki learn "text"` | Store a learning entry |
 | `sage-wiki capture "text"` | Capture knowledge from text |
 | `sage-wiki add-source <path>` | Register a source file in the manifest |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ See the [self-hosting guide](docs/guides/self-hosted-server.md) for Docker Compo
 | `sage-wiki status` | Wiki stats and health |
 | `sage-wiki provenance <source-or-concept>` | Show source↔article provenance mappings |
 | `sage-wiki doctor` | Validate config and connectivity |
+| `sage-wiki diff` | Show pending source changes against manifest |
+| `sage-wiki list` | List wiki entities, concepts, or sources |
+| `sage-wiki write <summary\|article>` | Write a summary or article |
+| `sage-wiki ontology <query\|list\|add>` | Query, list, and manage the ontology graph |
+| `sage-wiki learn "text"` | Store a learning entry |
+| `sage-wiki capture "text"` | Capture knowledge from text |
+| `sage-wiki add-source <path>` | Register a source file in the manifest |
 
 ## TUI
 

--- a/cmd/sage-wiki/add_source.go
+++ b/cmd/sage-wiki/add_source.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/manifest"
+)
+
+var addSourceCmd = &cobra.Command{
+	Use:   "add-source [path]",
+	Short: "Register a source file in the manifest",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAddSource,
+}
+
+func init() {
+	addSourceCmd.Flags().String("type", "auto", "Source type: article, paper, code, auto")
+}
+
+func runAddSource(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	relPath := args[0]
+	srcType, _ := cmd.Flags().GetString("type")
+
+	absPath := filepath.Join(dir, relPath)
+	info, err := os.Stat(absPath)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, fmt.Sprintf("file not found: %s", relPath)))
+			return nil
+		}
+		return fmt.Errorf("file not found: %s", relPath)
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	hash := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+
+	if srcType == "" || srcType == "auto" {
+		srcType = "article"
+	}
+
+	mf, err := manifest.Load(filepath.Join(dir, ".manifest.json"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	mf.AddSource(relPath, hash, srcType, info.Size())
+	if err := mf.Save(filepath.Join(dir, ".manifest.json")); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	msg := fmt.Sprintf("Source added: %s (type: %s, %d bytes)", relPath, srcType, info.Size())
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"path": relPath, "type": srcType}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/cmd/sage-wiki/capture.go
+++ b/cmd/sage-wiki/capture.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/config"
+)
+
+var captureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Capture knowledge from text",
+	RunE:  runCapture,
+}
+
+func init() {
+	captureCmd.Flags().String("text", "", "Text content to capture")
+	captureCmd.Flags().String("file", "", "File to read (use - for stdin)")
+	captureCmd.Flags().String("context", "", "Context description")
+	captureCmd.Flags().String("tags", "", "Comma-separated tags")
+}
+
+func runCapture(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	text, _ := cmd.Flags().GetString("text")
+	filePath, _ := cmd.Flags().GetString("file")
+	captureCtx, _ := cmd.Flags().GetString("context")
+	tagsStr, _ := cmd.Flags().GetString("tags")
+
+	var content string
+	if text != "" {
+		content = text
+	} else if filePath == "-" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		content = string(data)
+	} else if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		content = string(data)
+	} else {
+		errMsg := "provide --text or --file (use --file - for stdin)"
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, errMsg))
+			return nil
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	if len(content) > 100*1024 {
+		errMsg := fmt.Sprintf("content too large (%d bytes, max 100KB)", len(content))
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, errMsg))
+			return nil
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	// Write as raw capture file (same as MCP fallback)
+	capturesDir := filepath.Join(dir, "raw", "captures")
+	os.MkdirAll(capturesDir, 0755)
+
+	slug := fmt.Sprintf("capture-%s", cfg.Compiler.UserNow()[:10])
+	relPath := filepath.Join("raw", "captures", slug+".md")
+	absPath := filepath.Join(dir, relPath)
+	for i := 1; ; i++ {
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			break
+		}
+		relPath = filepath.Join("raw", "captures", fmt.Sprintf("%s-%d.md", slug, i))
+		absPath = filepath.Join(dir, relPath)
+	}
+
+	fm := fmt.Sprintf("---\nsource: cli-capture\ncaptured_at: %s\n", cfg.Compiler.UserNow())
+	if tagsStr != "" {
+		fm += fmt.Sprintf("tags: [%s]\n", tagsStr)
+	}
+	if captureCtx != "" {
+		fm += fmt.Sprintf("context: %q\n", captureCtx)
+	}
+	fm += "---\n\n"
+
+	if err := os.WriteFile(absPath, []byte(fm+content+"\n"), 0644); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	msg := fmt.Sprintf("Captured to %s. Run `sage-wiki compile` to process.", relPath)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"path": relPath}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/cmd/sage-wiki/diff.go
+++ b/cmd/sage-wiki/diff.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/compiler"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/manifest"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Show pending source changes against manifest",
+	RunE:  runDiff,
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	mf, err := manifest.Load(filepath.Join(dir, ".manifest.json"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	diff, err := compiler.Diff(dir, cfg, mf)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	type diffData struct {
+		Added    []string `json:"added"`
+		Modified []string `json:"modified"`
+		Removed  []string `json:"removed"`
+		Pending  int      `json:"pending"`
+		Total    int      `json:"total"`
+	}
+
+	added := make([]string, len(diff.Added))
+	for i, s := range diff.Added {
+		added[i] = s.Path
+	}
+	modified := make([]string, len(diff.Modified))
+	for i, s := range diff.Modified {
+		modified[i] = s.Path
+	}
+
+	data := diffData{
+		Added:    added,
+		Modified: modified,
+		Removed:  diff.Removed,
+		Pending:  len(diff.Added) + len(diff.Modified),
+		Total:    mf.SourceCount(),
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, data, ""))
+		return nil
+	}
+
+	if data.Pending == 0 && len(diff.Removed) == 0 {
+		fmt.Println("Nothing to compile — wiki is up to date.")
+		return nil
+	}
+	fmt.Printf("Sources: %d total, %d pending\n", data.Total, data.Pending)
+	for _, p := range added {
+		fmt.Printf("  + %s (new)\n", p)
+	}
+	for _, p := range modified {
+		fmt.Printf("  ~ %s (modified)\n", p)
+	}
+	for _, p := range diff.Removed {
+		fmt.Printf("  - %s (removed)\n", p)
+	}
+	return nil
+}

--- a/cmd/sage-wiki/hub.go
+++ b/cmd/sage-wiki/hub.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/compiler"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/hub"
+	"github.com/xoai/sage-wiki/internal/wiki"
+)
+
+var hubCmd = &cobra.Command{
+	Use:   "hub",
+	Short: "Multi-project hub commands",
+}
+
+var hubInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize hub config at ~/.sage-hub.yaml",
+	RunE:  runHubInit,
+}
+
+var hubAddCmd = &cobra.Command{
+	Use:   "add [path]",
+	Short: "Register a project in the hub",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runHubAdd,
+}
+
+var hubRemoveCmd = &cobra.Command{
+	Use:   "remove [name]",
+	Short: "Remove a project from the hub",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runHubRemove,
+}
+
+var hubListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered projects",
+	RunE:  runHubList,
+}
+
+var hubSearchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Federated search across all searchable projects",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runHubSearch,
+}
+
+var hubStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show status of all registered projects",
+	RunE:  runHubStatus,
+}
+
+var hubCompileCmd = &cobra.Command{
+	Use:   "compile [name|--all]",
+	Short: "Compile a project or all projects",
+	RunE:  runHubCompile,
+}
+
+func init() {
+	hubSearchCmd.Flags().StringP("project", "p", "", "Search only this project")
+	hubSearchCmd.Flags().Int("limit", 10, "Maximum results")
+
+	hubCompileCmd.Flags().Bool("all", false, "Compile all projects")
+
+	hubCmd.AddCommand(hubInitCmd, hubAddCmd, hubRemoveCmd, hubListCmd, hubSearchCmd, hubStatusCmd, hubCompileCmd)
+}
+
+func loadHub() (*hub.HubConfig, error) {
+	return hub.Load(hub.DefaultPath())
+}
+
+func runHubInit(cmd *cobra.Command, args []string) error {
+	path := hub.DefaultPath()
+	cfg := hub.New()
+	if err := cfg.Save(path); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	msg := fmt.Sprintf("Hub initialized: %s", path)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"path": path}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}
+
+func runHubAdd(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(args[0])
+
+	// Check project has config.yaml
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		errMsg := fmt.Sprintf("not a sage-wiki project (no config.yaml): %s", dir)
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, errMsg))
+			return nil
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	name := cfg.Project
+	overwritten := hubCfg.AddProject(name, hub.Project{
+		Path:        dir,
+		Description: cfg.Description,
+		Searchable:  true,
+	})
+	if overwritten {
+		fmt.Fprintf(cmd.ErrOrStderr(), "info: project %q already existed, overwriting\n", name)
+	}
+	if err := hubCfg.Save(hub.DefaultPath()); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	msg := fmt.Sprintf("Added project %q (%s)", name, dir)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"name": name, "path": dir}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}
+
+func runHubRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	if _, exists := hubCfg.Projects[name]; !exists {
+		errMsg := fmt.Sprintf("project %q not found", name)
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, errMsg))
+			return nil
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	hubCfg.RemoveProject(name)
+	if err := hubCfg.Save(hub.DefaultPath()); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	msg := fmt.Sprintf("Removed project %q", name)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"name": name}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}
+
+func runHubList(cmd *cobra.Command, args []string) error {
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, hubCfg, ""))
+		return nil
+	}
+
+	if len(hubCfg.Projects) == 0 {
+		fmt.Println("No projects registered. Use `sage-wiki hub add <path>` to add one.")
+		return nil
+	}
+	for name, p := range hubCfg.Projects {
+		search := "searchable"
+		if !p.Searchable {
+			search = "private"
+		}
+		fmt.Printf("  %s: %s (%s) [%s]\n", name, p.Path, p.Description, search)
+	}
+	return nil
+}
+
+func runHubSearch(cmd *cobra.Command, args []string) error {
+	query := args[0]
+	limit, _ := cmd.Flags().GetInt("limit")
+	projectFilter, _ := cmd.Flags().GetString("project")
+
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	var projects map[string]hub.Project
+	if projectFilter != "" {
+		p, exists := hubCfg.Projects[projectFilter]
+		if !exists {
+			errMsg := fmt.Sprintf("project %q not found", projectFilter)
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, errMsg))
+				return nil
+			}
+			return fmt.Errorf("%s", errMsg)
+		}
+		projects = map[string]hub.Project{projectFilter: p}
+	} else {
+		projects = hubCfg.SearchableProjects()
+	}
+
+	results, err := hub.FederatedSearch(projects, query, limit)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, results, ""))
+		return nil
+	}
+
+	if len(results) == 0 {
+		fmt.Println("No results found.")
+		return nil
+	}
+	for i, r := range results {
+		fmt.Printf("%d. [%s] [%.4f] %s\n", i+1, r.Project, r.RRFScore, r.ArticlePath)
+		content := r.Content
+		if len(content) > 120 {
+			content = content[:120] + "..."
+		}
+		fmt.Printf("   %s\n\n", content)
+	}
+	return nil
+}
+
+func runHubStatus(cmd *cobra.Command, args []string) error {
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	type projectStatus struct {
+		Name   string           `json:"name"`
+		Path   string           `json:"path"`
+		Status *wiki.StatusInfo `json:"status,omitempty"`
+		Error  string           `json:"error,omitempty"`
+	}
+
+	var statuses []projectStatus
+	for name, p := range hubCfg.Projects {
+		info, err := wiki.GetStatus(p.Path, nil)
+		if err != nil {
+			statuses = append(statuses, projectStatus{Name: name, Path: p.Path, Error: err.Error()})
+			continue
+		}
+		statuses = append(statuses, projectStatus{Name: name, Path: p.Path, Status: info})
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, statuses, ""))
+		return nil
+	}
+
+	for _, s := range statuses {
+		if s.Error != "" {
+			fmt.Printf("  %s: ERROR — %s\n", s.Name, s.Error)
+			continue
+		}
+		fmt.Printf("  %s: %d sources, %d concepts, %d pending\n",
+			s.Name, s.Status.SourceCount, s.Status.ConceptCount, s.Status.PendingCount)
+	}
+	return nil
+}
+
+func runHubCompile(cmd *cobra.Command, args []string) error {
+	all, _ := cmd.Flags().GetBool("all")
+
+	hubCfg, err := loadHub()
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	var targets map[string]hub.Project
+	if all {
+		targets = hubCfg.Projects
+	} else if len(args) > 0 {
+		name := args[0]
+		p, exists := hubCfg.Projects[name]
+		if !exists {
+			errMsg := fmt.Sprintf("project %q not found", name)
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, errMsg))
+				return nil
+			}
+			return fmt.Errorf("%s", errMsg)
+		}
+		targets = map[string]hub.Project{name: p}
+	} else {
+		errMsg := "specify project name or --all"
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, errMsg))
+			return nil
+		}
+		return fmt.Errorf("%s", errMsg)
+	}
+
+	type compileResult struct {
+		Name   string `json:"name"`
+		Error  string `json:"error,omitempty"`
+		Result any    `json:"result,omitempty"`
+	}
+
+	var results []compileResult
+	for name, p := range targets {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Compiling %s...\n", name)
+		result, err := compiler.Compile(p.Path, compiler.CompileOpts{})
+		if err != nil {
+			results = append(results, compileResult{Name: name, Error: err.Error()})
+			continue
+		}
+		results = append(results, compileResult{Name: name, Result: result})
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, results, ""))
+		return nil
+	}
+
+	for _, r := range results {
+		if r.Error != "" {
+			fmt.Printf("  %s: ERROR — %s\n", r.Name, r.Error)
+		} else {
+			fmt.Printf("  %s: OK\n", r.Name)
+		}
+	}
+	return nil
+}

--- a/cmd/sage-wiki/learn.go
+++ b/cmd/sage-wiki/learn.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/linter"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+var learnCmd = &cobra.Command{
+	Use:   "learn [content]",
+	Short: "Store a learning entry",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runLearn,
+}
+
+func init() {
+	learnCmd.Flags().String("type", "gotcha", "Learning type: gotcha, correction, convention, error-fix, api-drift")
+	learnCmd.Flags().String("tags", "", "Comma-separated tags")
+}
+
+func runLearn(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	content := strings.Join(args, " ")
+	learnType, _ := cmd.Flags().GetString("type")
+	tagsStr, _ := cmd.Flags().GetString("tags")
+
+	db, err := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	defer db.Close()
+
+	if err := linter.StoreLearning(db, learnType, content, tagsStr, "cli"); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	display := content
+	if len(display) > 80 {
+		display = display[:80] + "..."
+	}
+	msg := fmt.Sprintf("Learning stored: [%s] %s", learnType, display)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"message": msg}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/cmd/sage-wiki/list.go
+++ b/cmd/sage-wiki/list.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/manifest"
+	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List wiki entities, concepts, or sources",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().String("type", "", "Filter: concepts, sources, or entity type (concept, technique, etc.)")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	listType, _ := cmd.Flags().GetString("type")
+
+	// Sources: manifest only, no DB
+	if listType == "sources" {
+		mf, err := manifest.Load(filepath.Join(dir, ".manifest.json"))
+		if err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		type sourceItem struct {
+			Path   string `json:"path"`
+			Type   string `json:"type"`
+			Status string `json:"status"`
+		}
+		items := make([]sourceItem, 0, len(mf.Sources))
+		for path, s := range mf.Sources {
+			items = append(items, sourceItem{Path: path, Type: s.Type, Status: s.Status})
+		}
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(true, map[string]any{"items": items, "total": len(items)}, ""))
+		} else {
+			fmt.Printf("Sources: %d total\n", len(items))
+			for _, item := range items {
+				fmt.Printf("  [%s] %s (%s)\n", item.Status, item.Path, item.Type)
+			}
+		}
+		return nil
+	}
+
+	// Entities: need DB + ontology
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	db, err := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	defer db.Close()
+
+	merged := ontology.MergedRelations(cfg.Ontology.Relations)
+	ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+
+	entityType := listType
+	if listType == "concepts" {
+		entityType = "concept"
+	}
+
+	entities, err := ont.ListEntities(entityType)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	mf, _ := manifest.Load(filepath.Join(dir, ".manifest.json"))
+
+	type listItem struct {
+		ID          string `json:"id"`
+		Type        string `json:"type"`
+		Name        string `json:"name"`
+		ArticlePath string `json:"article_path,omitempty"`
+	}
+	items := make([]listItem, len(entities))
+	for i, e := range entities {
+		items[i] = listItem{ID: e.ID, Type: e.Type, Name: e.Name, ArticlePath: e.ArticlePath}
+	}
+
+	result := map[string]any{
+		"entities":      items,
+		"total":         len(items),
+		"source_count":  mf.SourceCount(),
+		"concept_count": mf.ConceptCount(),
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, result, ""))
+	} else {
+		fmt.Printf("Entities: %d (sources: %d, concepts: %d)\n", len(items), mf.SourceCount(), mf.ConceptCount())
+		for _, item := range items {
+			fmt.Printf("  [%s] %s", item.Type, item.Name)
+			if item.ArticlePath != "" {
+				fmt.Printf(" -> %s", item.ArticlePath)
+			}
+			fmt.Println()
+		}
+	}
+	return nil
+}

--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -168,7 +168,7 @@ func init() {
 	searchCmd.Flags().StringSlice("tags", nil, "Filter by tags")
 	searchCmd.Flags().Int("limit", 10, "Maximum results")
 
-	rootCmd.AddCommand(initCmd, compileCmd, serveCmd, lintCmd, searchCmd, queryCmd, statusCmd, ingestCmd, doctorCmd, tuiCmd, provenanceCmd, diffCmd, listCmd, ontologyCmd, writeCmd, learnCmd, captureCmd, addSourceCmd)
+	rootCmd.AddCommand(initCmd, compileCmd, serveCmd, lintCmd, searchCmd, queryCmd, statusCmd, ingestCmd, doctorCmd, tuiCmd, provenanceCmd, diffCmd, listCmd, ontologyCmd, writeCmd, learnCmd, captureCmd, addSourceCmd, hubCmd)
 }
 
 // Placeholder implementations — will be filled in subsequent tasks

--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xoai/sage-wiki/internal/log"
 	"strings"
 
+	"github.com/xoai/sage-wiki/internal/cli"
 	"github.com/xoai/sage-wiki/internal/compiler"
 	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/embed"
@@ -30,14 +31,22 @@ import (
 )
 
 var (
-	projectDir string
-	configPath string
-	verbosity  int
+	projectDir   string
+	configPath   string
+	verbosity    int
+	outputFormat string
 )
 
 func main() {
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+		} else {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -126,6 +135,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&projectDir, "project", ".", "Project directory")
 	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "Config file path (default: <project>/config.yaml)")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "Increase log verbosity (-v for info, -vv for debug)")
+	rootCmd.PersistentFlags().StringVar(&outputFormat, "format", "text", "Output format: text or json")
 
 	// Init flags
 	initCmd.Flags().Bool("vault", false, "Initialize as vault overlay on existing Obsidian vault")
@@ -158,7 +168,7 @@ func init() {
 	searchCmd.Flags().StringSlice("tags", nil, "Filter by tags")
 	searchCmd.Flags().Int("limit", 10, "Maximum results")
 
-	rootCmd.AddCommand(initCmd, compileCmd, serveCmd, lintCmd, searchCmd, queryCmd, statusCmd, ingestCmd, doctorCmd, tuiCmd, provenanceCmd)
+	rootCmd.AddCommand(initCmd, compileCmd, serveCmd, lintCmd, searchCmd, queryCmd, statusCmd, ingestCmd, doctorCmd, tuiCmd, provenanceCmd, diffCmd, listCmd, ontologyCmd, writeCmd, learnCmd, captureCmd, addSourceCmd)
 }
 
 // Placeholder implementations — will be filled in subsequent tasks
@@ -287,6 +297,11 @@ func runCompile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, result, ""))
+		return nil
+	}
+
 	fmt.Printf("Compile complete: +%d added, ~%d modified, -%d removed, %d summarized, %d concepts, %d articles",
 		result.Added, result.Modified, result.Removed, result.Summarized,
 		result.ConceptsExtracted, result.ArticlesWritten)
@@ -362,6 +377,11 @@ func runLint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, results, ""))
+		return nil
+	}
+
 	fmt.Print(linter.FormatFindings(results))
 
 	if err := linter.SaveReport(dir, results); err != nil {
@@ -409,6 +429,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, results, ""))
+		return nil
+	}
+
 	if len(results) == 0 {
 		fmt.Println("No results found.")
 		return nil
@@ -450,9 +475,17 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	dir, _ := filepath.Abs(projectDir)
 	info, err := wiki.GetStatus(dir, nil)
 	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
 		return err
 	}
-	fmt.Print(wiki.FormatStatus(info))
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, info, ""))
+	} else {
+		fmt.Print(wiki.FormatStatus(info))
+	}
 	return nil
 }
 

--- a/cmd/sage-wiki/ontology_cmd.go
+++ b/cmd/sage-wiki/ontology_cmd.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+var ontologyCmd = &cobra.Command{
+	Use:   "ontology",
+	Short: "Query and manage the ontology graph",
+}
+
+var ontologyQueryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Traverse the ontology from an entity",
+	RunE:  runOntologyQuery,
+}
+
+var ontologyAddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add an entity or relation",
+	RunE:  runOntologyAdd,
+}
+
+var ontologyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List entities or relations",
+	RunE:  runOntologyList,
+}
+
+func init() {
+	ontologyQueryCmd.Flags().String("entity", "", "Entity ID to start from")
+	ontologyQueryCmd.Flags().String("relation", "", "Filter by relation type")
+	ontologyQueryCmd.Flags().String("direction", "outbound", "outbound, inbound, or both")
+	ontologyQueryCmd.Flags().Int("depth", 1, "Traversal depth 1-5")
+	ontologyQueryCmd.MarkFlagRequired("entity")
+
+	ontologyAddCmd.Flags().String("from", "", "Source entity ID (for relations)")
+	ontologyAddCmd.Flags().String("to", "", "Target entity ID (for relations)")
+	ontologyAddCmd.Flags().String("relation", "", "Relation type")
+	ontologyAddCmd.Flags().String("entity-id", "", "Entity ID (for creating entities)")
+	ontologyAddCmd.Flags().String("entity-type", "concept", "Entity type")
+	ontologyAddCmd.Flags().String("entity-name", "", "Human-readable name")
+
+	ontologyListCmd.Flags().String("type", "entities", "What to list: entities or relations")
+	ontologyListCmd.Flags().String("entity-type", "", "Filter entities by type (concept, source, etc.)")
+	ontologyListCmd.Flags().String("relation-type", "", "Filter relations by type")
+	ontologyListCmd.Flags().Int("limit", 100, "Maximum results")
+
+	ontologyCmd.AddCommand(ontologyQueryCmd, ontologyAddCmd, ontologyListCmd)
+}
+
+func openOntStore(dir string) (*storage.DB, *ontology.Store, error) {
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		return nil, nil, err
+	}
+	db, err := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+	if err != nil {
+		return nil, nil, err
+	}
+	merged := ontology.MergedRelations(cfg.Ontology.Relations)
+	return db, ontology.NewStore(db, ontology.ValidRelationNames(merged)), nil
+}
+
+func runOntologyQuery(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	entityID, _ := cmd.Flags().GetString("entity")
+	relType, _ := cmd.Flags().GetString("relation")
+	dirStr, _ := cmd.Flags().GetString("direction")
+	depth, _ := cmd.Flags().GetInt("depth")
+
+	db, ont, err := openOntStore(dir)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	defer db.Close()
+
+	traverseDir := ontology.Outbound
+	switch dirStr {
+	case "inbound":
+		traverseDir = ontology.Inbound
+	case "both":
+		traverseDir = ontology.Both
+	}
+
+	entities, err := ont.Traverse(entityID, ontology.TraverseOpts{
+		Direction:    traverseDir,
+		RelationType: relType,
+		MaxDepth:     depth,
+	})
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, entities, ""))
+		return nil
+	}
+
+	if len(entities) == 0 {
+		fmt.Printf("No entities found from %q\n", entityID)
+		return nil
+	}
+	for _, e := range entities {
+		fmt.Printf("  [%s] %s (%s)\n", e.Type, e.Name, e.ID)
+	}
+	return nil
+}
+
+func runOntologyAdd(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	fromID, _ := cmd.Flags().GetString("from")
+	toID, _ := cmd.Flags().GetString("to")
+	relType, _ := cmd.Flags().GetString("relation")
+	entityID, _ := cmd.Flags().GetString("entity-id")
+
+	db, ont, err := openOntStore(dir)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	defer db.Close()
+
+	// Add relation
+	if fromID != "" && toID != "" && relType != "" {
+		relID := fromID + "-" + relType + "-" + toID
+		if err := ont.AddRelation(ontology.Relation{
+			ID: relID, SourceID: fromID, TargetID: toID, Relation: relType,
+		}); err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		msg := fmt.Sprintf("Relation: %s -[%s]-> %s", fromID, relType, toID)
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(true, map[string]string{"message": msg}, ""))
+		} else {
+			fmt.Println(msg)
+		}
+		return nil
+	}
+
+	// Add entity
+	if entityID != "" {
+		entityType, _ := cmd.Flags().GetString("entity-type")
+		entityName, _ := cmd.Flags().GetString("entity-name")
+		if entityName == "" {
+			entityName = entityID
+		}
+		if err := ont.AddEntity(ontology.Entity{
+			ID: entityID, Type: entityType, Name: entityName,
+		}); err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		msg := fmt.Sprintf("Entity created: %s (%s)", entityID, entityType)
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(true, map[string]string{"message": msg}, ""))
+		} else {
+			fmt.Println(msg)
+		}
+		return nil
+	}
+
+	errMsg := "provide --from/--to/--relation for relations, or --entity-id for entities"
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(false, nil, errMsg))
+		return nil
+	}
+	return fmt.Errorf("%s", errMsg)
+}
+
+func runOntologyList(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	listType, _ := cmd.Flags().GetString("type")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	db, ont, err := openOntStore(dir)
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+	defer db.Close()
+
+	switch listType {
+	case "entities":
+		entityType, _ := cmd.Flags().GetString("entity-type")
+		entities, err := ont.ListEntities(entityType)
+		if err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		if limit > 0 && len(entities) > limit {
+			entities = entities[:limit]
+		}
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(true, entities, ""))
+			return nil
+		}
+		fmt.Printf("Entities: %d\n", len(entities))
+		for _, e := range entities {
+			fmt.Printf("  [%s] %s (%s)\n", e.Type, e.Name, e.ID)
+		}
+
+	case "relations":
+		relType, _ := cmd.Flags().GetString("relation-type")
+		rels, err := ont.ListRelations(relType, limit)
+		if err != nil {
+			if outputFormat == "json" {
+				fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+				return nil
+			}
+			return err
+		}
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(true, rels, ""))
+			return nil
+		}
+		fmt.Printf("Relations: %d\n", len(rels))
+		for _, r := range rels {
+			fmt.Printf("  %s -[%s]-> %s\n", r.SourceID, r.Relation, r.TargetID)
+		}
+
+	default:
+		return fmt.Errorf("unknown list type %q, use 'entities' or 'relations'", listType)
+	}
+	return nil
+}

--- a/cmd/sage-wiki/write_cmd.go
+++ b/cmd/sage-wiki/write_cmd.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/xoai/sage-wiki/internal/cli"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/embed"
+	"github.com/xoai/sage-wiki/internal/manifest"
+	"github.com/xoai/sage-wiki/internal/memory"
+	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/storage"
+	"github.com/xoai/sage-wiki/internal/vectors"
+)
+
+var writeCmd = &cobra.Command{
+	Use:   "write",
+	Short: "Write a summary or article",
+}
+
+var writeSummaryCmd = &cobra.Command{
+	Use:   "summary",
+	Short: "Write a summary for a source file",
+	RunE:  runWriteSummary,
+}
+
+var writeArticleCmd = &cobra.Command{
+	Use:   "article",
+	Short: "Write an article for a concept",
+	RunE:  runWriteArticle,
+}
+
+func init() {
+	writeSummaryCmd.Flags().String("source", "", "Source file path relative to project root")
+	writeSummaryCmd.Flags().String("content", "", "Summary markdown content")
+	writeSummaryCmd.Flags().String("concepts", "", "Comma-separated concept names")
+	writeSummaryCmd.MarkFlagRequired("source")
+	writeSummaryCmd.MarkFlagRequired("content")
+
+	writeArticleCmd.Flags().String("concept", "", "Concept ID (lowercase-hyphenated)")
+	writeArticleCmd.Flags().String("content", "", "Article markdown content")
+	writeArticleCmd.MarkFlagRequired("concept")
+	writeArticleCmd.MarkFlagRequired("content")
+
+	writeCmd.AddCommand(writeSummaryCmd, writeArticleCmd)
+}
+
+func runWriteSummary(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	source, _ := cmd.Flags().GetString("source")
+	content, _ := cmd.Flags().GetString("content")
+	conceptsStr, _ := cmd.Flags().GetString("concepts")
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	baseName := strings.TrimSuffix(filepath.Base(source), filepath.Ext(source))
+	summaryPath := filepath.Join(cfg.Output, "summaries", baseName+".md")
+	absPath := filepath.Join(dir, summaryPath)
+	os.MkdirAll(filepath.Dir(absPath), 0755)
+
+	fm := fmt.Sprintf("---\nsource: %s\ncompiled_at: %s\n---\n\n", source, cfg.Compiler.UserNow())
+	if err := os.WriteFile(absPath, []byte(fm+content), 0644); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	// Index in FTS5 + embed
+	db, dbErr := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+	if dbErr == nil {
+		defer db.Close()
+		memory.NewStore(db).Add(memory.Entry{ID: source, Content: content, ArticlePath: summaryPath})
+		if embedder := embed.NewFromConfig(cfg); embedder != nil {
+			if v, err := embedder.Embed(content); err == nil {
+				vectors.NewStore(db).Upsert(source, v)
+			}
+		}
+	}
+
+	// Update manifest
+	var concepts []string
+	if conceptsStr != "" {
+		for _, c := range strings.Split(conceptsStr, ",") {
+			if c = strings.TrimSpace(c); c != "" {
+				concepts = append(concepts, c)
+			}
+		}
+	}
+	mf, _ := manifest.Load(filepath.Join(dir, ".manifest.json"))
+	if _, exists := mf.Sources[source]; !exists {
+		mf.AddSource(source, "", "article", int64(len(content)))
+	}
+	mf.MarkCompiled(source, summaryPath, concepts)
+	mf.Save(filepath.Join(dir, ".manifest.json"))
+
+	msg := fmt.Sprintf("Summary written: %s (%d chars)", summaryPath, len(content))
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"path": summaryPath}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}
+
+func runWriteArticle(cmd *cobra.Command, args []string) error {
+	dir, _ := filepath.Abs(projectDir)
+	conceptID, _ := cmd.Flags().GetString("concept")
+	content, _ := cmd.Flags().GetString("content")
+
+	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	articlePath := filepath.Join(cfg.Output, "concepts", conceptID+".md")
+	absPath := filepath.Join(dir, articlePath)
+	os.MkdirAll(filepath.Dir(absPath), 0755)
+
+	if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
+		if outputFormat == "json" {
+			fmt.Println(cli.FormatJSON(false, nil, err.Error()))
+			return nil
+		}
+		return err
+	}
+
+	// Update ontology + FTS5 + embed
+	db, dbErr := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+	if dbErr == nil {
+		defer db.Close()
+		merged := ontology.MergedRelations(cfg.Ontology.Relations)
+		ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+		ont.AddEntity(ontology.Entity{ID: conceptID, Type: "concept", Name: conceptID, ArticlePath: articlePath})
+		memory.NewStore(db).Add(memory.Entry{ID: "concept:" + conceptID, Content: content, ArticlePath: articlePath})
+		if embedder := embed.NewFromConfig(cfg); embedder != nil {
+			if v, err := embedder.Embed(content); err == nil {
+				vectors.NewStore(db).Upsert("concept:"+conceptID, v)
+			}
+		}
+	}
+
+	// Update manifest
+	mf, _ := manifest.Load(filepath.Join(dir, ".manifest.json"))
+	mf.AddConcept(conceptID, articlePath, nil)
+	mf.Save(filepath.Join(dir, ".manifest.json"))
+
+	msg := fmt.Sprintf("Article written: %s", articlePath)
+	if outputFormat == "json" {
+		fmt.Println(cli.FormatJSON(true, map[string]string{"path": articlePath}, ""))
+	} else {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/xoai/sage-wiki/internal/hub"
 	"github.com/xoai/sage-wiki/internal/linter"
 	mcppkg "github.com/xoai/sage-wiki/internal/mcp"
 	"github.com/xoai/sage-wiki/internal/memory"
@@ -206,7 +207,28 @@ Self-attention computes contextual representations.
 		t.Logf("lint findings: %d", len(results))
 	})
 
-	// Step 12: Learn via StoreLearning (no API needed)
+	// Step 12: Hub add + list (no API needed)
+	t.Run("hub_add_list", func(t *testing.T) {
+		hubCfg := hub.New()
+		overwritten := hubCfg.AddProject("test-project", hub.Project{
+			Path: dir, Searchable: true,
+		})
+		if overwritten {
+			t.Error("first add should return false")
+		}
+		overwritten = hubCfg.AddProject("test-project", hub.Project{
+			Path: dir, Searchable: true, Description: "updated",
+		})
+		if !overwritten {
+			t.Error("second add should return true (overwrite)")
+		}
+		projects := hubCfg.SearchableProjects()
+		if len(projects) != 1 {
+			t.Errorf("expected 1 searchable project, got %d", len(projects))
+		}
+	})
+
+	// Step 13: Learn via StoreLearning (no API needed)
 	t.Run("learn", func(t *testing.T) {
 		db, err := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
 		if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/xoai/sage-wiki/internal/linter"
 	mcppkg "github.com/xoai/sage-wiki/internal/mcp"
 	"github.com/xoai/sage-wiki/internal/memory"
 	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/storage"
 	"github.com/xoai/sage-wiki/internal/wiki"
 )
 
@@ -185,6 +187,57 @@ Self-attention computes contextual representations.
 		dims, _ := srv.VecStore().Dimensions()
 		if dims != 4 {
 			t.Errorf("expected 4 dimensions, got %d", dims)
+		}
+	})
+
+	// Step 11: Lint (no API needed)
+	t.Run("lint", func(t *testing.T) {
+		runner := linter.NewRunner()
+		ctx := &linter.LintContext{
+			ProjectDir:     dir,
+			OutputDir:      "wiki",
+			DBPath:         filepath.Join(dir, ".sage", "wiki.db"),
+			ValidRelations: []string{"implements", "optimizes"},
+		}
+		results, err := runner.Run(ctx, "", false)
+		if err != nil {
+			t.Fatalf("lint: %v", err)
+		}
+		t.Logf("lint findings: %d", len(results))
+	})
+
+	// Step 12: Learn via StoreLearning (no API needed)
+	t.Run("learn", func(t *testing.T) {
+		db, err := storage.Open(filepath.Join(dir, ".sage", "wiki.db"))
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer db.Close()
+		err = linter.StoreLearning(db, "gotcha", "integration test learning", "test", "integration")
+		if err != nil {
+			t.Fatalf("StoreLearning: %v", err)
+		}
+	})
+
+	// Step 14: Ontology list (no API needed)
+	t.Run("ontology_list_entities", func(t *testing.T) {
+		entities, err := srv.OntStore().ListEntities("concept")
+		if err != nil {
+			t.Fatalf("ListEntities: %v", err)
+		}
+		if len(entities) != 2 {
+			t.Errorf("expected 2 concept entities, got %d", len(entities))
+		}
+	})
+
+	// Step 15: Ontology list relations (no API needed)
+	t.Run("ontology_list_relations", func(t *testing.T) {
+		rels, err := srv.OntStore().ListRelations("", 100)
+		if err != nil {
+			t.Fatalf("ListRelations: %v", err)
+		}
+		if len(rels) != 2 {
+			t.Errorf("expected 2 relations, got %d", len(rels))
 		}
 	})
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Response is the standard JSON envelope for all CLI commands.
+type Response struct {
+	OK    bool   `json:"ok"`
+	Data  any    `json:"data,omitempty"`
+	Error string `json:"error,omitempty"`
+	Code  int    `json:"code,omitempty"`
+}
+
+// FormatJSON returns a JSON string with the standard envelope.
+func FormatJSON(ok bool, data any, errMsg string) string {
+	resp := Response{OK: ok, Data: data, Error: errMsg}
+	if !ok && errMsg != "" {
+		resp.Code = 1
+	}
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"ok":false,"error":"marshal failed: %v"}`, err)
+	}
+	return string(out)
+}
+
+// Output dispatches to JSON or text formatting based on format flag.
+func Output(format string, text string, ok bool, data any, errMsg string) string {
+	if format == "json" {
+		return FormatJSON(ok, data, errMsg)
+	}
+	return text
+}
+
+// PrintResult prints to stdout (JSON) or stderr (text errors).
+func PrintResult(format string, text string, ok bool, data any, errMsg string) {
+	if !ok && format != "json" {
+		fmt.Fprintln(os.Stderr, errMsg)
+		return
+	}
+	fmt.Println(Output(format, text, ok, data, errMsg))
+}
+
+// ExitCode returns the appropriate exit code.
+func ExitCode(ok bool, partial bool) int {
+	if ok && !partial {
+		return 0
+	}
+	if partial {
+		return 2
+	}
+	return 1
+}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONSuccess(t *testing.T) {
+	data := map[string]int{"count": 5}
+	out := FormatJSON(true, data, "")
+	var resp Response
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+}
+
+func TestJSONError(t *testing.T) {
+	out := FormatJSON(false, nil, "something failed")
+	var resp Response
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.OK {
+		t.Error("expected ok=false")
+	}
+	if resp.Error != "something failed" {
+		t.Errorf("expected error message, got %q", resp.Error)
+	}
+}
+
+func TestOutputDispatch(t *testing.T) {
+	// format=json -> JSON output
+	got := Output("json", "text fallback", true, map[string]int{"n": 1}, "")
+	var resp Response
+	if err := json.Unmarshal([]byte(got), &resp); err != nil {
+		t.Fatalf("json dispatch failed: %v", err)
+	}
+
+	// format=text -> text output
+	got = Output("text", "text fallback", true, nil, "")
+	if got != "text fallback" {
+		t.Errorf("text dispatch: expected fallback, got %q", got)
+	}
+}

--- a/internal/compiler/diff.go
+++ b/internal/compiler/diff.go
@@ -48,6 +48,11 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 				return nil
 			}
 
+			// 跳过隐藏文件（.DS_Store 等）
+			if strings.HasPrefix(d.Name(), ".") {
+				return nil
+			}
+
 			// Get relative path from project root
 			relPath, _ := filepath.Rel(projectDir, path)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ var relationNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Config represents the sage-wiki project configuration.
 type Config struct {
+	Extends     string       `yaml:"extends,omitempty"`
 	Version     int          `yaml:"version"`
 	Project     string       `yaml:"project"`
 	Description string       `yaml:"description"`
@@ -30,6 +31,7 @@ type Config struct {
 	Linting     LintingConfig  `yaml:"linting"`
 	Serve       ServeConfig    `yaml:"serve"`
 	Ontology    OntologyConfig `yaml:"ontology,omitempty"`
+	TypeSignals []TypeSignal   `yaml:"type_signals,omitempty"`
 }
 
 type VaultConfig struct {
@@ -204,6 +206,16 @@ type ServeConfig struct {
 	Port      int    `yaml:"port"`
 }
 
+// TypeSignal defines a content-based type detection rule.
+// Files are matched by filename keywords and/or content keywords.
+type TypeSignal struct {
+	Type             string   `yaml:"type"`
+	Pattern          string   `yaml:"pattern,omitempty"`           // simple substring match (legacy)
+	FilenameKeywords []string `yaml:"filename_keywords,omitempty"` // keywords matched against filename
+	ContentKeywords  []string `yaml:"content_keywords,omitempty"`  // keywords matched against content head
+	MinContentHits   int      `yaml:"min_content_hits,omitempty"`  // minimum content keyword matches required
+}
+
 // OntologyConfig configures ontology relation types.
 type OntologyConfig struct {
 	Relations []RelationConfig `yaml:"relations,omitempty"`
@@ -274,6 +286,9 @@ func (c *CompilerConfig) UserNow() string {
 }
 
 // Load reads and parses a config file, expanding environment variables.
+// If the config contains an "extends" field, the base config is loaded first
+// and deep-merged with the child config (maps merge recursively, scalars/slices
+// from child replace base). At most one level of inheritance (base's extends is ignored).
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -283,10 +298,50 @@ func Load(path string) (*Config, error) {
 	// Expand environment variables in ${VAR} format
 	expanded := expandEnvVars(string(data))
 
+	// Quick parse to check for extends field
+	var peek struct {
+		Extends string `yaml:"extends"`
+	}
+	yaml.Unmarshal([]byte(expanded), &peek)
+
+	finalYAML := expanded
+	if peek.Extends != "" {
+		basePath := peek.Extends
+		if !filepath.IsAbs(basePath) {
+			basePath = filepath.Join(filepath.Dir(path), basePath)
+		}
+
+		baseData, err := os.ReadFile(basePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: extends base %q not found, using child config only\n", peek.Extends)
+		} else {
+			baseExpanded := expandEnvVars(string(baseData))
+
+			// Deep merge via map[string]any to avoid yaml.v3 zero-value clobbering
+			var baseMap, childMap map[string]any
+			if err := yaml.Unmarshal([]byte(baseExpanded), &baseMap); err != nil {
+				return nil, fmt.Errorf("config.Load: parse base %q: %w", peek.Extends, err)
+			}
+			if err := yaml.Unmarshal([]byte(expanded), &childMap); err != nil {
+				return nil, fmt.Errorf("config.Load: parse child: %w", err)
+			}
+			// Remove extends from child before merge
+			delete(childMap, "extends")
+
+			merged := deepMerge(baseMap, childMap)
+			mergedBytes, err := yaml.Marshal(merged)
+			if err != nil {
+				return nil, fmt.Errorf("config.Load: marshal merged: %w", err)
+			}
+			finalYAML = string(mergedBytes)
+		}
+	}
+
 	cfg := Defaults()
-	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(finalYAML), &cfg); err != nil {
 		return nil, fmt.Errorf("config.Load: parse error: %w", err)
 	}
+	cfg.Extends = "" // clear after merge
 
 	if err := cfg.Validate(); err != nil {
 		return nil, err

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,0 +1,20 @@
+package config
+
+// deepMerge recursively merges src into dst (map level).
+// Maps: recursive merge. Slices/scalars: src replaces dst.
+func deepMerge(dst, src map[string]any) map[string]any {
+	out := make(map[string]any, len(dst))
+	for k, v := range dst {
+		out[k] = v
+	}
+	for k, v := range src {
+		if srcMap, ok := v.(map[string]any); ok {
+			if dstMap, ok := out[k].(map[string]any); ok {
+				out[k] = deepMerge(dstMap, srcMap)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+func TestDeepMergePartialNested(t *testing.T) {
+	base := map[string]any{
+		"compiler": map[string]any{
+			"max_parallel":       8,
+			"summary_max_tokens": 8000,
+			"auto_commit":        true,
+		},
+	}
+	child := map[string]any{
+		"compiler": map[string]any{
+			"auto_commit": false,
+		},
+	}
+	merged := deepMerge(base, child)
+	compiler := merged["compiler"].(map[string]any)
+	if compiler["max_parallel"] != 8 {
+		t.Errorf("max_parallel: got %v, want 8", compiler["max_parallel"])
+	}
+	if compiler["summary_max_tokens"] != 8000 {
+		t.Errorf("summary_max_tokens: got %v, want 8000", compiler["summary_max_tokens"])
+	}
+	if compiler["auto_commit"] != false {
+		t.Errorf("auto_commit: got %v, want false", compiler["auto_commit"])
+	}
+}
+
+func TestDeepMergeScalarReplace(t *testing.T) {
+	base := map[string]any{"project": "base", "version": 1}
+	child := map[string]any{"project": "child"}
+	merged := deepMerge(base, child)
+	if merged["project"] != "child" {
+		t.Errorf("project: got %v, want child", merged["project"])
+	}
+	if merged["version"] != 1 {
+		t.Errorf("version: got %v, want 1", merged["version"])
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -1,0 +1,74 @@
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Project represents a registered sage-wiki project.
+type Project struct {
+	Path        string `yaml:"path" json:"path"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Searchable  bool   `yaml:"searchable" json:"searchable"`
+}
+
+// HubConfig holds the multi-project registry.
+type HubConfig struct {
+	Projects map[string]Project `yaml:"projects" json:"projects"`
+}
+
+func New() *HubConfig {
+	return &HubConfig{Projects: make(map[string]Project)}
+}
+
+func Load(path string) (*HubConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("hub.Load: %w", err)
+	}
+	var cfg HubConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("hub.Load: %w", err)
+	}
+	if cfg.Projects == nil {
+		cfg.Projects = make(map[string]Project)
+	}
+	return &cfg, nil
+}
+
+func (c *HubConfig) Save(path string) error {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("hub.Save: %w", err)
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// AddProject adds or updates a project. Returns true if it overwrote an existing entry.
+func (c *HubConfig) AddProject(name string, p Project) bool {
+	_, existed := c.Projects[name]
+	c.Projects[name] = p
+	return existed
+}
+
+func (c *HubConfig) RemoveProject(name string) {
+	delete(c.Projects, name)
+}
+
+func (c *HubConfig) SearchableProjects() map[string]Project {
+	result := make(map[string]Project)
+	for name, p := range c.Projects {
+		if p.Searchable {
+			result[name] = p
+		}
+	}
+	return result
+}
+
+func DefaultPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".sage-hub.yaml")
+}

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -1,0 +1,47 @@
+package hub
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewAndSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hub.yaml")
+
+	cfg := New()
+	cfg.AddProject("main", Project{Path: "/tmp/wiki", Description: "Main", Searchable: true})
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Projects["main"].Path != "/tmp/wiki" {
+		t.Errorf("path not persisted: %q", loaded.Projects["main"].Path)
+	}
+}
+
+func TestSearchableProjects(t *testing.T) {
+	cfg := New()
+	cfg.AddProject("a", Project{Path: "/a", Searchable: true})
+	cfg.AddProject("b", Project{Path: "/b", Searchable: false})
+	cfg.AddProject("c", Project{Path: "/c", Searchable: true})
+
+	s := cfg.SearchableProjects()
+	if len(s) != 2 {
+		t.Errorf("expected 2 searchable, got %d", len(s))
+	}
+}
+
+func TestRemoveProject(t *testing.T) {
+	cfg := New()
+	cfg.AddProject("x", Project{Path: "/x"})
+	cfg.RemoveProject("x")
+	if len(cfg.Projects) != 0 {
+		t.Error("not removed")
+	}
+}

--- a/internal/hub/search.go
+++ b/internal/hub/search.go
@@ -1,0 +1,113 @@
+package hub
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/embed"
+	"github.com/xoai/sage-wiki/internal/hybrid"
+	"github.com/xoai/sage-wiki/internal/memory"
+	"github.com/xoai/sage-wiki/internal/storage"
+	"github.com/xoai/sage-wiki/internal/vectors"
+)
+
+// FederatedResult is a search result tagged with source project.
+type FederatedResult struct {
+	Project     string   `json:"project"`
+	ArticlePath string   `json:"article_path"`
+	Content     string   `json:"content"`
+	RRFScore    float64  `json:"rrf_score"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+// FederatedSearch searches multiple projects in parallel with RRF merge.
+func FederatedSearch(projects map[string]Project, query string, limit int) ([]FederatedResult, error) {
+	type projectResult struct {
+		name    string
+		results []hybrid.SearchResult
+		err     error
+	}
+
+	var wg sync.WaitGroup
+	ch := make(chan projectResult, len(projects))
+
+	for name, proj := range projects {
+		wg.Add(1)
+		go func(name string, proj Project) {
+			defer wg.Done()
+			results, err := searchProject(proj.Path, query, limit)
+			ch <- projectResult{name: name, results: results, err: err}
+		}(name, proj)
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var all []FederatedResult
+	var errCount int
+	for pr := range ch {
+		if pr.err != nil {
+			fmt.Printf("warning: search %s failed: %v\n", pr.name, pr.err)
+			errCount++
+			continue
+		}
+		for _, r := range pr.results {
+			all = append(all, FederatedResult{
+				Project:     pr.name,
+				ArticlePath: r.ArticlePath,
+				Content:     r.Content,
+				RRFScore:    r.RRFScore,
+				Tags:        r.Tags,
+			})
+		}
+	}
+
+	// W2 fix: if ALL projects failed, return error
+	if errCount == len(projects) {
+		return nil, fmt.Errorf("all %d projects failed to search", errCount)
+	}
+
+	// Sort by score descending, then apply RRF re-ranking
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].RRFScore > all[j].RRFScore
+	})
+
+	k := 60.0
+	for i := range all {
+		all[i].RRFScore = 1.0 / (k + float64(i) + 1)
+	}
+
+	if len(all) > limit {
+		all = all[:limit]
+	}
+
+	return all, nil
+}
+
+func searchProject(projectDir string, query string, limit int) ([]hybrid.SearchResult, error) {
+	db, err := storage.Open(filepath.Join(projectDir, ".sage", "wiki.db"))
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	mem := memory.NewStore(db)
+	vec := vectors.NewStore(db)
+	searcher := hybrid.NewSearcher(mem, vec)
+
+	var queryVec []float32
+
+	cfg, cfgErr := config.Load(filepath.Join(projectDir, "config.yaml"))
+	if cfgErr == nil {
+		if embedder := embed.NewFromConfig(cfg); embedder != nil {
+			queryVec, _ = embedder.Embed(query)
+		}
+	}
+
+	return searcher.Search(hybrid.SearchOpts{
+		Query: query, Limit: limit,
+	}, queryVec)
+}

--- a/internal/hub/search_test.go
+++ b/internal/hub/search_test.go
@@ -1,0 +1,50 @@
+package hub
+
+import (
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/memory"
+	"github.com/xoai/sage-wiki/internal/storage"
+	"github.com/xoai/sage-wiki/internal/wiki"
+)
+
+func setupTestDB(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := wiki.InitGreenfield(dir, name, "test-model"); err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.Open(dir + "/.sage/wiki.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	memory.NewStore(db).Add(memory.Entry{
+		ID: name + "-e1", Content: "test content about " + name,
+		ArticlePath: "wiki/concepts/" + name + ".md",
+	})
+	return dir
+}
+
+func TestFederatedSearch(t *testing.T) {
+	dir1 := setupTestDB(t, "alpha")
+	dir2 := setupTestDB(t, "beta")
+
+	projects := map[string]Project{
+		"alpha": {Path: dir1, Searchable: true},
+		"beta":  {Path: dir2, Searchable: true},
+	}
+
+	results, err := FederatedSearch(projects, "test content", 10)
+	if err != nil {
+		t.Fatalf("FederatedSearch: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected results")
+	}
+	for _, r := range results {
+		if r.Project == "" {
+			t.Error("missing project field")
+		}
+	}
+}

--- a/internal/ontology/ontology.go
+++ b/internal/ontology/ontology.go
@@ -405,3 +405,36 @@ func (s *Store) CitedBy(entityID string) ([]Entity, error) {
 	}
 	return entities, rows.Err()
 }
+
+// ListRelations returns relations, optionally filtered by type, with a limit.
+func (s *Store) ListRelations(relationType string, limit int) ([]Relation, error) {
+	var rows *sql.Rows
+	var err error
+	if relationType != "" {
+		rows, err = s.db.ReadDB().Query(
+			`SELECT id, source_id, target_id, relation, created_at
+			 FROM relations WHERE relation=? ORDER BY created_at DESC LIMIT ?`,
+			relationType, limit,
+		)
+	} else {
+		rows, err = s.db.ReadDB().Query(
+			`SELECT id, source_id, target_id, relation, created_at
+			 FROM relations ORDER BY created_at DESC LIMIT ?`,
+			limit,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var rels []Relation
+	for rows.Next() {
+		var r Relation
+		if err := rows.Scan(&r.ID, &r.SourceID, &r.TargetID, &r.Relation, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		rels = append(rels, r)
+	}
+	return rels, rows.Err()
+}


### PR DESCRIPTION
## Summary

- Add multi-project hub system (`sage-wiki hub`) for managing multiple wiki projects
- Add config extends (`extends: base.yaml`) for YAML config inheritance with deep merge
- Add federated search across all searchable projects with RRF score merging
- Hub commands: `init`, `add`, `remove`, `list`, `status`, `compile`, `search`

> **Depends on:** #30 (CLI-first architecture) for `--format json` infrastructure

## Motivation

Users with multiple knowledge bases (e.g., separate wikis for different domains) currently have no way to search across them or manage them as a group. The hub provides:
- Federated search: `sage-wiki hub search "query"` searches all registered projects
- Batch operations: `sage-wiki hub compile --all` compiles everything
- Config inheritance: shared base config with per-project overrides

## Design

- Hub config stored at `~/.sage-hub.yaml` (project registry)
- Config extends uses single-level deep merge (maps merge recursively, scalars/slices from child replace base)
- Federated search opens each project's DB independently, runs parallel hybrid searches, merges via RRF

## Test plan

- [x] `go build` passes
- [x] `go test ./...` — all 33 packages pass (including hub + config merge tests)
- [x] Integration test: hub add + list + overwrite detection
- [ ] Manual: `sage-wiki hub init && sage-wiki hub add . && sage-wiki hub search "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)