### PR TITLE
fix: don't flag dimension mismatch when provider reports 0

### DIFF
--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -105,8 +105,8 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 	if embedder != nil {
 		info.EmbedProvider = embedder.Name()
 		info.EmbedDims = embedder.Dimensions()
-		// Check dimension mismatch
-		if info.VectorDims > 0 && info.VectorDims != embedder.Dimensions() {
+		// Check dimension mismatch (0 means unknown — skip check)
+		if info.VectorDims > 0 && info.EmbedDims > 0 && info.VectorDims != info.EmbedDims {
 			info.DimMismatch = true
 		}
 	} else {


### PR DESCRIPTION
## Summary

- Status check falsely warns about dimension mismatch when the embedding provider reports 0 dimensions
- This happens when the configured model (e.g. `voyage-3`) isn't in the static `defaultDimensions` lookup table and no embed call has triggered auto-detection yet
- Fix: treat provider dims of 0 as "unknown" rather than "different" — only flag a mismatch when both sides are known and disagree

## Change

One-line guard in `internal/wiki/status.go`: add `info.EmbedDims > 0` to the mismatch condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)