### PR TITLE
fix: rename ontology.relations to ontology.relation_types with backwards compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Cascade Awareness
 
-- **Orphan detection on source removal** — When a source is removed during compile, affected concepts are identified *before* the manifest entry is deleted. Single-source concepts are flagged as orphaned with a log warning. Multi-source concepts get their sources list updated.
+- **Orphan detection on source removal** — When a source is removed during compile, affected concepts are identified _before_ the manifest entry is deleted. Single-source concepts are flagged as orphaned with a log warning. Multi-source concepts get their sources list updated.
 - **`--prune` flag** — Opt-in destructive cleanup: `sage-wiki compile --prune` deletes orphaned article files, removes FTS5/vector/ontology entries, and cleans up the manifest. Warn-only by default.
 
 ### Ontology Helpers
@@ -30,17 +30,25 @@
 
 ```yaml
 search:
-  graph_expansion: true        # enable graph-based context expansion (default: true)
-  graph_max_expand: 10         # max articles added via graph
-  graph_depth: 2               # ontology traversal depth
-  context_max_tokens: 8000     # token budget for query context
-  weight_direct_link: 3.0      # graph signal weights
+  graph_expansion: true # enable graph-based context expansion (default: true)
+  graph_max_expand: 10 # max articles added via graph
+  graph_depth: 2 # ontology traversal depth
+  context_max_tokens: 8000 # token budget for query context
+  weight_direct_link: 3.0 # graph signal weights
   weight_source_overlap: 4.0
   weight_common_neighbor: 1.5
   weight_type_affinity: 1.0
 ```
 
 All fields optional with sensible defaults. `graph_expansion` uses `*bool` pattern (like `query_expansion`, `rerank`) — nil defaults to true. Existing configs work unchanged.
+
+---
+
+## Unreleased
+
+### Config Key Rename
+
+- **`ontology.relation_types`** replaces `ontology.relations` as the preferred config key, for consistency with `ontology.entity_types`. The old `relations` key is still accepted with a deprecation warning. If both keys are present, `relation_types` takes precedence.
 
 ---
 
@@ -66,9 +74,9 @@ All fields optional with sensible defaults. `graph_expansion` uses `*bool` patte
 ontology:
   relations:
     - name: implements
-      synonyms: ["thực hiện", "triển khai"]   # extend built-in with multilingual synonyms
+      synonyms: ["thực hiện", "triển khai"] # extend built-in with multilingual synonyms
     - name: regulates
-      synonyms: ["regulates", "regulated by"]  # add a custom relation type
+      synonyms: ["regulates", "regulated by"] # add a custom relation type
 ```
 
 ### Fixes
@@ -89,14 +97,14 @@ ontology:
 
 ### Binaries
 
-| Platform | Binary |
-|----------|--------|
-| Linux amd64 | `sage-wiki-linux-amd64` |
-| Linux arm64 | `sage-wiki-linux-arm64` |
-| macOS amd64 (Intel) | `sage-wiki-darwin-amd64` |
-| macOS arm64 (Apple Silicon) | `sage-wiki-darwin-arm64` |
-| Windows amd64 | `sage-wiki-windows-amd64.exe` |
-| Windows arm64 | `sage-wiki-windows-arm64.exe` |
+| Platform                    | Binary                        |
+| --------------------------- | ----------------------------- |
+| Linux amd64                 | `sage-wiki-linux-amd64`       |
+| Linux arm64                 | `sage-wiki-linux-arm64`       |
+| macOS amd64 (Intel)         | `sage-wiki-darwin-amd64`      |
+| macOS arm64 (Apple Silicon) | `sage-wiki-darwin-arm64`      |
+| Windows amd64               | `sage-wiki-windows-amd64.exe` |
+| Windows arm64               | `sage-wiki-windows-arm64.exe` |
 
 ### Docker
 
@@ -133,11 +141,11 @@ docker pull xoai/sage-wiki:v0.1.2
 
 ```yaml
 compiler:
-  mode: standard          # standard, batch, or auto
-  estimate_before: false  # prompt before compiling
-  prompt_cache: true      # enable prompt caching (default: true)
-  batch_threshold: 10     # min sources for auto-batch
-  token_price_per_million: 0  # override pricing (0 = use built-in)
+  mode: standard # standard, batch, or auto
+  estimate_before: false # prompt before compiling
+  prompt_cache: true # enable prompt caching (default: true)
+  batch_threshold: 10 # min sources for auto-batch
+  token_price_per_million: 0 # override pricing (0 = use built-in)
 ```
 
 ### New CLI Flags
@@ -222,11 +230,11 @@ First public release of sage-wiki, an LLM-compiled personal knowledge base.
 
 ### Binaries
 
-| Platform | Binary |
-|----------|--------|
-| Linux amd64 | `sage-wiki-linux-amd64` |
-| Linux arm64 | `sage-wiki-linux-arm64` |
-| macOS amd64 (Intel) | `sage-wiki-darwin-amd64` |
-| macOS arm64 (Apple Silicon) | `sage-wiki-darwin-arm64` |
-| Windows amd64 | `sage-wiki-windows-amd64.exe` |
-| Windows arm64 | `sage-wiki-windows-arm64.exe` |
+| Platform                    | Binary                        |
+| --------------------------- | ----------------------------- |
+| Linux amd64                 | `sage-wiki-linux-amd64`       |
+| Linux arm64                 | `sage-wiki-linux-arm64`       |
+| macOS amd64 (Intel)         | `sage-wiki-darwin-amd64`      |
+| macOS arm64 (Apple Silicon) | `sage-wiki-darwin-arm64`      |
+| Windows amd64               | `sage-wiki-windows-amd64.exe` |
+| Windows arm64               | `sage-wiki-windows-arm64.exe` |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Drop in your papers, articles, and notes. sage-wiki compiles them into a structu
 
 https://github.com/user-attachments/assets/c35ee202-e9df-4ccd-b520-8f057163ff26
 
-*Dots on the outer boundary represent summaries of all documents in the knowledge base, while dots in the inner circle represent concepts extracted from the knowledge base, with links showing how those concepts connect to one another.*
+_Dots on the outer boundary represent summaries of all documents in the knowledge base, while dots in the inner circle represent concepts extracted from the knowledge base, with links showing how those concepts connect to one another._
 
 ## Install
 
@@ -31,20 +31,20 @@ go build -tags webui -o sage-wiki ./cmd/sage-wiki/
 
 ## Supported Source Formats
 
-| Format | Extensions | What gets extracted |
-|--------|-----------|-------------------|
-| Markdown | `.md` | Body text with frontmatter parsed separately |
-| PDF | `.pdf` | Full text via pure-Go extraction |
-| Word | `.docx` | Document text from XML |
-| Excel | `.xlsx` | Cell values and sheet data |
-| PowerPoint | `.pptx` | Slide text content |
-| CSV | `.csv` | Headers + rows (up to 1000 rows) |
-| EPUB | `.epub` | Chapter text from XHTML |
-| Email | `.eml` | Headers (from/to/subject/date) + body |
-| Plain text | `.txt`, `.log` | Raw content |
-| Transcripts | `.vtt`, `.srt` | Raw content |
-| Images | `.png`, `.jpg`, `.gif`, `.webp`, `.svg` | Description via vision LLM (caption, content, visible text) |
-| Code | `.go`, `.py`, `.js`, `.ts`, `.rs`, etc. | Source code |
+| Format      | Extensions                              | What gets extracted                                         |
+| ----------- | --------------------------------------- | ----------------------------------------------------------- |
+| Markdown    | `.md`                                   | Body text with frontmatter parsed separately                |
+| PDF         | `.pdf`                                  | Full text via pure-Go extraction                            |
+| Word        | `.docx`                                 | Document text from XML                                      |
+| Excel       | `.xlsx`                                 | Cell values and sheet data                                  |
+| PowerPoint  | `.pptx`                                 | Slide text content                                          |
+| CSV         | `.csv`                                  | Headers + rows (up to 1000 rows)                            |
+| EPUB        | `.epub`                                 | Chapter text from XHTML                                     |
+| Email       | `.eml`                                  | Headers (from/to/subject/date) + body                       |
+| Plain text  | `.txt`, `.log`                          | Raw content                                                 |
+| Transcripts | `.vtt`, `.srt`                          | Raw content                                                 |
+| Images      | `.png`, `.jpg`, `.gif`, `.webp`, `.svg` | Description via vision LLM (caption, content, visible text) |
+| Code        | `.go`, `.py`, `.js`, `.ts`, `.rs`, etc. | Source code                                                 |
 
 Just drop files into your source folder — sage-wiki detects the format automatically. Images require a vision-capable LLM (Gemini, Claude, GPT-4o).
 
@@ -110,20 +110,20 @@ See the [self-hosting guide](docs/guides/self-hosted-server.md) for Docker Compo
 
 ## Commands
 
-| Command | Description |
-|---------|------------|
-| `sage-wiki init [--vault]` | Initialize project (greenfield or vault overlay) |
-| `sage-wiki compile [--watch] [--dry-run] [--batch] [--estimate] [--no-cache] [--prune]` | Compile sources into wiki articles |
-| `sage-wiki serve [--transport stdio\|sse]` | Start MCP server for LLM agents |
-| `sage-wiki serve --ui [--port 3333]` | Start web UI (requires `-tags webui` build) |
-| `sage-wiki lint [--fix] [--pass name]` | Run linting passes |
-| `sage-wiki search "query" [--tags ...]` | Hybrid search (BM25 + vector) |
-| `sage-wiki query "question"` | Q&A against the wiki |
-| `sage-wiki tui` | Launch interactive terminal dashboard |
-| `sage-wiki ingest <url\|path>` | Add a source |
-| `sage-wiki status` | Wiki stats and health |
-| `sage-wiki provenance <source-or-concept>` | Show source↔article provenance mappings |
-| `sage-wiki doctor` | Validate config and connectivity |
+| Command                                                                                 | Description                                      |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `sage-wiki init [--vault]`                                                              | Initialize project (greenfield or vault overlay) |
+| `sage-wiki compile [--watch] [--dry-run] [--batch] [--estimate] [--no-cache] [--prune]` | Compile sources into wiki articles               |
+| `sage-wiki serve [--transport stdio\|sse]`                                              | Start MCP server for LLM agents                  |
+| `sage-wiki serve --ui [--port 3333]`                                                    | Start web UI (requires `-tags webui` build)      |
+| `sage-wiki lint [--fix] [--pass name]`                                                  | Run linting passes                               |
+| `sage-wiki search "query" [--tags ...]`                                                 | Hybrid search (BM25 + vector)                    |
+| `sage-wiki query "question"`                                                            | Q&A against the wiki                             |
+| `sage-wiki tui`                                                                         | Launch interactive terminal dashboard            |
+| `sage-wiki ingest <url\|path>`                                                          | Add a source                                     |
+| `sage-wiki status`                                                                      | Wiki stats and health                            |
+| `sage-wiki provenance <source-or-concept>`                                              | Show source↔article provenance mappings          |
+| `sage-wiki doctor`                                                                      | Validate config and connectivity                 |
 
 ## TUI
 
@@ -152,6 +152,7 @@ sage-wiki serve --ui
 ```
 
 Features:
+
 - **Article browser** with rendered markdown, syntax highlighting, and clickable `[[wikilinks]]`
 - **Hybrid search** with ranked results and snippets
 - **Knowledge graph** — interactive force-directed visualization of concepts and their connections
@@ -163,6 +164,7 @@ Features:
 The web UI is built with Preact + Tailwind CSS and embedded into the Go binary via `go:embed`. It adds ~1.2 MB (gzipped) to the binary size. To build without the web UI, omit the `-tags webui` flag — the binary will still work for all CLI and MCP operations.
 
 Options:
+
 - `--port 3333` — change the port (default 3333)
 - `--bind 0.0.0.0` — expose on the network (default localhost only, no auth)
 
@@ -177,11 +179,11 @@ description: "Personal research wiki"
 
 # Source folders to watch and compile
 sources:
-  - path: raw               # or vault folders like Clippings/, Papers/
-    type: auto               # auto-detect from file extension
+  - path: raw # or vault folders like Clippings/, Papers/
+    type: auto # auto-detect from file extension
     watch: true
 
-output: wiki                 # compiled output directory (_wiki for vault overlay)
+output: wiki # compiled output directory (_wiki for vault overlay)
 
 # Folders to never read or send to APIs (vault overlay mode)
 # ignore:
@@ -195,7 +197,7 @@ output: wiki                 # compiled output directory (_wiki for vault overla
 #   base_url: https://openrouter.ai/api/v1
 api:
   provider: gemini
-  api_key: ${GEMINI_API_KEY}    # env var expansion supported
+  api_key: ${GEMINI_API_KEY} # env var expansion supported
   # base_url:                   # custom endpoint (OpenRouter, Azure, etc.)
   # rate_limit: 60              # requests per minute
 
@@ -210,18 +212,18 @@ models:
 # Embedding provider (optional — auto-detected from api provider)
 # Override to use a different provider for embeddings
 embed:
-  provider: auto              # auto, openai, gemini, ollama, voyage, mistral
+  provider: auto # auto, openai, gemini, ollama, voyage, mistral
   # model: text-embedding-3-small
   # api_key: ${OPENAI_API_KEY}  # separate key for embeddings
   # base_url:                   # separate endpoint
 
 compiler:
-  max_parallel: 4             # concurrent LLM calls
-  debounce_seconds: 2         # watch mode debounce
+  max_parallel: 4 # concurrent LLM calls
+  debounce_seconds: 2 # watch mode debounce
   summary_max_tokens: 2000
   article_max_tokens: 4000
-  auto_commit: true           # git commit after compile
-  auto_lint: true             # run lint after compile
+  auto_commit: true # git commit after compile
+  auto_lint: true # run lint after compile
   # mode: standard            # standard, batch, or auto
   # estimate_before: false    # prompt with cost estimate before compiling
   # prompt_cache: true        # enable prompt caching (default: true)
@@ -233,7 +235,7 @@ compiler:
   #   - domain
 
 search:
-  hybrid_weight_bm25: 0.7    # BM25 vs vector weight
+  hybrid_weight_bm25: 0.7 # BM25 vs vector weight
   hybrid_weight_vector: 0.3
   default_limit: 10
   # query_expansion: true     # LLM query expansion for Q&A (default: true)
@@ -249,17 +251,21 @@ search:
   # weight_type_affinity: 1.0  # graph signal: entity type pair bonus
 
 serve:
-  transport: stdio            # stdio or sse
-  port: 3333                  # SSE mode only
+  transport: stdio # stdio or sse
+  port: 3333 # SSE mode only
 
-# Ontology relation types (optional)
-# Extend built-in types with additional synonyms or add custom relation types.
+
+# Ontology types (optional)
+# Extend built-in types with additional synonyms or add custom types.
 # ontology:
-#   relations:
+#   relation_types:
 #     - name: implements           # extend built-in with more synonyms
 #       synonyms: ["thực hiện", "triển khai"]
 #     - name: regulates            # add a custom relation type
 #       synonyms: ["regulates", "regulated by", "调控"]
+#   entity_types:
+#     - name: decision
+#       description: "A recorded decision with rationale"
 ```
 
 ### Configurable Relations
@@ -307,13 +313,13 @@ sage-wiki uses an enhanced search pipeline for Q&A queries, inspired by analyzin
 - **Graph-enhanced context expansion** — After retrieval, a 4-signal graph scorer finds related articles via the ontology: direct relations (×3.0), shared source documents (×4.0), common neighbors via Adamic-Adar (×1.5), and entity type affinity (×1.0). This surfaces articles that are structurally related but missed by keyword/vector search.
 - **Token budget control** — Query context is capped at a configurable token limit (default 8000), with articles truncated at 4000 tokens each. Greedy filling prioritizes the highest-scored articles.
 
-| | sage-wiki | qmd |
-|---|---|---|
-| Chunk search | FTS5 + vector (dual-channel) | Vector-only |
-| Query expansion | LLM-based (lex/vec/hyde) | LLM-based |
-| Re-ranking | LLM + position-aware blending | Cross-encoder |
-| Graph context | 4-signal graph expansion + 1-hop traversal | No graph |
-| Cost per query | Free (Ollama) / ~$0.0006 (cloud) | Free (local GGUF) |
+|                 | sage-wiki                                  | qmd               |
+| --------------- | ------------------------------------------ | ----------------- |
+| Chunk search    | FTS5 + vector (dual-channel)               | Vector-only       |
+| Query expansion | LLM-based (lex/vec/hyde)                   | LLM-based         |
+| Re-ranking      | LLM + position-aware blending              | Cross-encoder     |
+| Graph context   | 4-signal graph expansion + 1-hop traversal | No graph          |
+| Cost per query  | Free (Ollama) / ~$0.0006 (cloud)           | Free (local GGUF) |
 
 Zero config = all features enabled. With Ollama or other local models, enhanced search is completely free — re-ranking is auto-disabled (local models struggle with structured JSON scoring) but chunk-level search and query expansion still work. With cloud LLMs, the additional cost is negligible (~$0.0006/query). Both expansion and re-ranking can be toggled via config. See the [full search quality guide](docs/guides/search-quality.md) for configuration, cost breakdown, and detailed comparison.
 
@@ -425,29 +431,29 @@ Run `python3 eval.py .` on your own project to reproduce. See [eval.py](eval.py)
 
 ### Performance
 
-| Operation | p50 | Throughput |
-|---|--:|--:|
-| FTS5 keyword search (top-10) | 411µs | 1,775 qps |
-| Vector cosine search (2,858 × 3072d) | 81ms | 15 qps |
-| Hybrid RRF (BM25 + vector) | 80ms | 16 qps |
-| Graph traversal (BFS depth ≤ 5) | 1µs | 738K qps |
-| Cycle detection (full graph) | 1.4ms | — |
-| FTS insert (batch 100) | — | 89,802 /s |
-| Sustained mixed reads | 77µs | 8,500+ ops/s |
+| Operation                            |   p50 |   Throughput |
+| ------------------------------------ | ----: | -----------: |
+| FTS5 keyword search (top-10)         | 411µs |    1,775 qps |
+| Vector cosine search (2,858 × 3072d) |  81ms |       15 qps |
+| Hybrid RRF (BM25 + vector)           |  80ms |       16 qps |
+| Graph traversal (BFS depth ≤ 5)      |   1µs |     738K qps |
+| Cycle detection (full graph)         | 1.4ms |            — |
+| FTS insert (batch 100)               |     — |    89,802 /s |
+| Sustained mixed reads                |  77µs | 8,500+ ops/s |
 
 Non-LLM compile overhead (hashing + dependency analysis) is under 1 second. The compiler's wall time is dominated entirely by LLM API calls.
 
 ### Quality
 
-| Metric | Score |
-|---|--:|
-| Search recall@10 | **100%** |
-| Search recall@1 | 91.6% |
-| Source citation rate | 94.6% |
-| Alias coverage | 90.0% |
-| Fact extraction rate | 68.5% |
-| Wiki connectivity | 60.5% |
-| Cross-reference integrity | 50.0% |
+| Metric                    |     Score |
+| ------------------------- | --------: |
+| Search recall@10          |  **100%** |
+| Search recall@1           |     91.6% |
+| Source citation rate      |     94.6% |
+| Alias coverage            |     90.0% |
+| Fact extraction rate      |     68.5% |
+| Wiki connectivity         |     60.5% |
+| Cross-reference integrity |     50.0% |
 | **Overall quality score** | **73.0%** |
 
 ### Running the eval

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@
 
 https://github.com/user-attachments/assets/c35ee202-e9df-4ccd-b520-8f057163ff26
 
-*外圈的点代表知识库中所有文档的摘要,内圈的点代表从知识库中提取的概念,连线展示了这些概念之间的关联。*
+_外圈的点代表知识库中所有文档的摘要,内圈的点代表从知识库中提取的概念,连线展示了这些概念之间的关联。_
 
 ## 安装
 
@@ -31,20 +31,20 @@ go build -tags webui -o sage-wiki ./cmd/sage-wiki/
 
 ## 支持的源文件格式
 
-| 格式 | 扩展名 | 提取内容 |
-|------|--------|---------|
-| Markdown | `.md` | 正文,frontmatter 单独解析 |
-| PDF | `.pdf` | 纯 Go 提取全文 |
-| Word | `.docx` | XML 中的文档文本 |
-| Excel | `.xlsx` | 单元格值和工作表数据 |
-| PowerPoint | `.pptx` | 幻灯片文本内容 |
-| CSV | `.csv` | 表头 + 行数据 (最多 1000 行) |
-| EPUB | `.epub` | XHTML 中的章节文本 |
-| 邮件 | `.eml` | 邮件头 (发件人/收件人/主题/日期) + 正文 |
-| 纯文本 | `.txt`, `.log` | 原始内容 |
-| 字幕 | `.vtt`, `.srt` | 原始内容 |
-| 图片 | `.png`, `.jpg`, `.gif`, `.webp`, `.svg` | 通过 vision LLM 生成描述 (标题、内容、可见文字) |
-| 代码 | `.go`, `.py`, `.js`, `.ts`, `.rs` 等 | 源代码 |
+| 格式       | 扩展名                                  | 提取内容                                        |
+| ---------- | --------------------------------------- | ----------------------------------------------- |
+| Markdown   | `.md`                                   | 正文,frontmatter 单独解析                       |
+| PDF        | `.pdf`                                  | 纯 Go 提取全文                                  |
+| Word       | `.docx`                                 | XML 中的文档文本                                |
+| Excel      | `.xlsx`                                 | 单元格值和工作表数据                            |
+| PowerPoint | `.pptx`                                 | 幻灯片文本内容                                  |
+| CSV        | `.csv`                                  | 表头 + 行数据 (最多 1000 行)                    |
+| EPUB       | `.epub`                                 | XHTML 中的章节文本                              |
+| 邮件       | `.eml`                                  | 邮件头 (发件人/收件人/主题/日期) + 正文         |
+| 纯文本     | `.txt`, `.log`                          | 原始内容                                        |
+| 字幕       | `.vtt`, `.srt`                          | 原始内容                                        |
+| 图片       | `.png`, `.jpg`, `.gif`, `.webp`, `.svg` | 通过 vision LLM 生成描述 (标题、内容、可见文字) |
+| 代码       | `.go`, `.py`, `.js`, `.ts`, `.rs` 等    | 源代码                                          |
 
 只需将文件放入源文件夹 -- sage-wiki 会自动检测格式。图片需要支持 vision 的 LLM (Gemini、Claude、GPT-4o)。
 
@@ -110,20 +110,20 @@ docker run -d -p 3333:3333 -v ./my-wiki:/wiki -e GEMINI_API_KEY=... sage-wiki
 
 ## 命令
 
-| 命令 | 说明 |
-|------|------|
-| `sage-wiki init [--vault]` | 初始化项目 (全新或 vault 覆盖模式) |
-| `sage-wiki compile [--watch] [--dry-run] [--batch] [--estimate] [--no-cache] [--prune]` | 将源文件编译为 wiki 文章 |
-| `sage-wiki serve [--transport stdio\|sse]` | 启动 MCP 服务器供 LLM Agent 使用 |
-| `sage-wiki serve --ui [--port 3333]` | 启动 Web UI (需要 `-tags webui` 构建) |
-| `sage-wiki lint [--fix] [--pass name]` | 运行 lint 检查 |
-| `sage-wiki search "query" [--tags ...]` | 混合搜索 (BM25 + 向量) |
-| `sage-wiki query "question"` | 对 wiki 进行问答 |
-| `sage-wiki tui` | 启动交互式终端面板 |
-| `sage-wiki ingest <url\|path>` | 添加源文件 |
-| `sage-wiki status` | 查看 wiki 统计和健康状态 |
-| `sage-wiki provenance <source-or-concept>` | 查看源文件与文章的溯源映射 |
-| `sage-wiki doctor` | 验证配置和连接性 |
+| 命令                                                                                    | 说明                                  |
+| --------------------------------------------------------------------------------------- | ------------------------------------- |
+| `sage-wiki init [--vault]`                                                              | 初始化项目 (全新或 vault 覆盖模式)    |
+| `sage-wiki compile [--watch] [--dry-run] [--batch] [--estimate] [--no-cache] [--prune]` | 将源文件编译为 wiki 文章              |
+| `sage-wiki serve [--transport stdio\|sse]`                                              | 启动 MCP 服务器供 LLM Agent 使用      |
+| `sage-wiki serve --ui [--port 3333]`                                                    | 启动 Web UI (需要 `-tags webui` 构建) |
+| `sage-wiki lint [--fix] [--pass name]`                                                  | 运行 lint 检查                        |
+| `sage-wiki search "query" [--tags ...]`                                                 | 混合搜索 (BM25 + 向量)                |
+| `sage-wiki query "question"`                                                            | 对 wiki 进行问答                      |
+| `sage-wiki tui`                                                                         | 启动交互式终端面板                    |
+| `sage-wiki ingest <url\|path>`                                                          | 添加源文件                            |
+| `sage-wiki status`                                                                      | 查看 wiki 统计和健康状态              |
+| `sage-wiki provenance <source-or-concept>`                                              | 查看源文件与文章的溯源映射            |
+| `sage-wiki doctor`                                                                      | 验证配置和连接性                      |
 
 ## TUI
 
@@ -152,6 +152,7 @@ sage-wiki serve --ui
 ```
 
 功能:
+
 - **文章浏览器**: 渲染 markdown,语法高亮,可点击的 `[[wikilinks]]`
 - **混合搜索**: 排序结果和摘要片段
 - **知识图谱**: 交互式力导向图,可视化概念及其关联
@@ -163,6 +164,7 @@ sage-wiki serve --ui
 Web UI 使用 Preact + Tailwind CSS 构建,通过 `go:embed` 嵌入 Go 二进制文件。压缩后增加约 1.2 MB 体积。构建时省略 `-tags webui` 标志即可不包含 Web UI -- 二进制文件仍支持所有 CLI 和 MCP 操作。
 
 选项:
+
 - `--port 3333` -- 修改端口 (默认 3333)
 - `--bind 0.0.0.0` -- 暴露到网络 (默认仅 localhost,无认证)
 
@@ -177,11 +179,11 @@ description: "Personal research wiki"
 
 # 要监听和编译的源文件夹
 sources:
-  - path: raw               # 或 vault 文件夹如 Clippings/, Papers/
-    type: auto               # 根据文件扩展名自动检测
+  - path: raw # 或 vault 文件夹如 Clippings/, Papers/
+    type: auto # 根据文件扩展名自动检测
     watch: true
 
-output: wiki                 # 编译输出目录 (vault 覆盖模式下为 _wiki)
+output: wiki # 编译输出目录 (vault 覆盖模式下为 _wiki)
 
 # 不读取也不发送给 API 的文件夹 (vault 覆盖模式)
 # ignore:
@@ -195,7 +197,7 @@ output: wiki                 # 编译输出目录 (vault 覆盖模式下为 _wik
 #   base_url: https://openrouter.ai/api/v1
 api:
   provider: gemini
-  api_key: ${GEMINI_API_KEY}    # 支持环境变量展开
+  api_key: ${GEMINI_API_KEY} # 支持环境变量展开
   # base_url:                   # 自定义端点 (OpenRouter, Azure 等)
   # rate_limit: 60              # 每分钟请求数
 
@@ -210,18 +212,18 @@ models:
 # Embedding 提供商 (可选 -- 自动从 api 提供商检测)
 # 可覆盖为不同的 embedding 提供商
 embed:
-  provider: auto              # auto, openai, gemini, ollama, voyage, mistral
+  provider: auto # auto, openai, gemini, ollama, voyage, mistral
   # model: text-embedding-3-small
   # api_key: ${OPENAI_API_KEY}  # 单独的 embedding API Key
   # base_url:                   # 单独的端点
 
 compiler:
-  max_parallel: 4             # 并发 LLM 调用数
-  debounce_seconds: 2         # watch 模式防抖
+  max_parallel: 4 # 并发 LLM 调用数
+  debounce_seconds: 2 # watch 模式防抖
   summary_max_tokens: 2000
   article_max_tokens: 4000
-  auto_commit: true           # 编译后自动 git commit
-  auto_lint: true             # 编译后自动 lint
+  auto_commit: true # 编译后自动 git commit
+  auto_lint: true # 编译后自动 lint
   # mode: standard            # standard, batch 或 auto
   # estimate_before: false    # 编译前显示费用估算
   # prompt_cache: true        # 启用 prompt 缓存 (默认: true)
@@ -233,7 +235,7 @@ compiler:
   #   - domain
 
 search:
-  hybrid_weight_bm25: 0.7    # BM25 与向量搜索的权重
+  hybrid_weight_bm25: 0.7 # BM25 与向量搜索的权重
   hybrid_weight_vector: 0.3
   default_limit: 10
   # query_expansion: true     # LLM 查询扩展 (默认: true)
@@ -249,17 +251,21 @@ search:
   # weight_type_affinity: 1.0  # 图信号: 实体类型对加成
 
 serve:
-  transport: stdio            # stdio 或 sse
-  port: 3333                  # 仅 SSE 模式
+  transport: stdio # stdio 或 sse
+  port: 3333 # 仅 SSE 模式
 
-# 本体关系类型 (可选)
-# 扩展内置类型的同义词或添加自定义关系类型。
+
+# 本体类型 (可选)
+# 扩展内置类型的同义词或添加自定义类型。
 # ontology:
-#   relations:
+#   relation_types:
 #     - name: implements           # 为内置类型添加更多同义词
 #       synonyms: ["thuc hien", "trien khai"]
 #     - name: regulates            # 添加自定义关系类型
 #       synonyms: ["regulates", "regulated by", "调控"]
+#   entity_types:
+#     - name: decision
+#       description: "决策记录及其理由"
 ```
 
 ### 可配置的关系类型
@@ -307,12 +313,12 @@ sage-wiki 使用增强搜索管线处理问答查询,灵感来自对 [qmd](https
 - **图增强上下文扩展** -- 检索后,4 信号图评分器通过本体发现相关文章: 直接关系 (x3.0)、共享源文档 (x4.0)、Adamic-Adar 共同邻居 (x1.5) 和实体类型亲和度 (x1.0)。这能找到结构上相关但被关键词/向量搜索遗漏的文章。
 - **Token 预算控制** -- 查询上下文限制在可配置的 token 上限内 (默认 8000),每篇文章截断至 4000 token。贪心填充优先选择评分最高的文章。
 
-| | sage-wiki | qmd |
-|---|---|---|
-| Chunk 搜索 | FTS5 + 向量 (双通道) | 仅向量 |
-| 查询扩展 | 基于 LLM (词法/向量/HyDE) | 基于 LLM |
-| 重排序 | LLM + 位置感知融合 | Cross-encoder |
-| 图上下文 | 4 信号图扩展 + 1 跳遍历 | 无图 |
+|              | sage-wiki                         | qmd              |
+| ------------ | --------------------------------- | ---------------- |
+| Chunk 搜索   | FTS5 + 向量 (双通道)              | 仅向量           |
+| 查询扩展     | 基于 LLM (词法/向量/HyDE)         | 基于 LLM         |
+| 重排序       | LLM + 位置感知融合                | Cross-encoder    |
+| 图上下文     | 4 信号图扩展 + 1 跳遍历           | 无图             |
 | 单次查询费用 | 免费 (Ollama) / 约 $0.0006 (云端) | 免费 (本地 GGUF) |
 
 零配置 = 所有功能默认启用。使用 Ollama 或其他本地模型时,增强搜索完全免费 -- 重排序会自动禁用 (本地模型难以处理结构化 JSON 评分),但 chunk 级别搜索和查询扩展仍然有效。使用云端 LLM 时,额外费用可忽略 (约 $0.0006/次查询)。扩展和重排序均可通过配置开关。参阅[完整搜索质量指南](docs/guides/search-quality.md)了解配置、费用明细和详细对比。
@@ -425,29 +431,29 @@ sage-wiki 作为 MCP 服务器运行,因此你可以直接从 AI 对话中捕获
 
 ### 性能
 
-| 操作 | p50 | 吞吐量 |
-|------|----:|-------:|
-| FTS5 关键词搜索 (top-10) | 411us | 1,775 qps |
-| 向量余弦搜索 (2,858 x 3072d) | 81ms | 15 qps |
-| 混合 RRF (BM25 + 向量) | 80ms | 16 qps |
-| 图遍历 (BFS 深度 <= 5) | 1us | 738K qps |
-| 环检测 (全图) | 1.4ms | -- |
-| FTS 插入 (批量 100) | -- | 89,802 /s |
-| 持续混合读取 | 77us | 8,500+ ops/s |
+| 操作                         |   p50 |       吞吐量 |
+| ---------------------------- | ----: | -----------: |
+| FTS5 关键词搜索 (top-10)     | 411us |    1,775 qps |
+| 向量余弦搜索 (2,858 x 3072d) |  81ms |       15 qps |
+| 混合 RRF (BM25 + 向量)       |  80ms |       16 qps |
+| 图遍历 (BFS 深度 <= 5)       |   1us |     738K qps |
+| 环检测 (全图)                | 1.4ms |           -- |
+| FTS 插入 (批量 100)          |    -- |    89,802 /s |
+| 持续混合读取                 |  77us | 8,500+ ops/s |
 
 非 LLM 编译开销 (哈希 + 依赖分析) 低于 1 秒。编译器的实际耗时完全由 LLM API 调用决定。
 
 ### 质量
 
-| 指标 | 分数 |
-|------|-----:|
-| 搜索召回率@10 | **100%** |
-| 搜索召回率@1 | 91.6% |
-| 源引用率 | 94.6% |
-| 别名覆盖率 | 90.0% |
-| 事实提取率 | 68.5% |
-| Wiki 连通性 | 60.5% |
-| 交叉引用完整性 | 50.0% |
+| 指标             |      分数 |
+| ---------------- | --------: |
+| 搜索召回率@10    |  **100%** |
+| 搜索召回率@1     |     91.6% |
+| 源引用率         |     94.6% |
+| 别名覆盖率       |     90.0% |
+| 事实提取率       |     68.5% |
+| Wiki 连通性      |     60.5% |
+| 交叉引用完整性   |     50.0% |
 | **综合质量分数** | **73.0%** |
 
 ### 运行评估

--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -348,12 +348,14 @@ func runLint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
 	ctx := &linter.LintContext{
-		ProjectDir:     dir,
-		OutputDir:      cfg.Output,
-		DBPath:         filepath.Join(dir, ".sage", "wiki.db"),
-		ValidRelations: ontology.ValidRelationNames(merged),
+		ProjectDir:       dir,
+		OutputDir:        cfg.Output,
+		DBPath:           filepath.Join(dir, ".sage", "wiki.db"),
+		ValidRelations:   ontology.ValidRelationNames(mergedRels),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
 	}
 
 	runner := linter.NewRunner()

--- a/docs/guides/configurable-relations.md
+++ b/docs/guides/configurable-relations.md
@@ -20,16 +20,16 @@ These edges power the knowledge graph visualization, Q&A context retrieval, and 
 
 ## Built-in relation types
 
-| Type | Keywords | Notes |
-|------|----------|-------|
-| `implements` | implements, implementation of, is an implementation, 实现了, 实现方式 | |
-| `extends` | extends, extension of, builds on, builds upon, 扩展了, 基于 | |
-| `optimizes` | optimizes, optimization of, improves upon, faster than, 优化了, 改进了, 提升了 | |
-| `contradicts` | contradicts, conflicts with, disagrees with, challenges, 矛盾, 冲突, 挑战了 | |
-| `cites` | *(none)* | Created programmatically when articles reference sources |
-| `prerequisite_of` | prerequisite, requires knowledge of, depends on, built on top of, 前提, 依赖于, 前置条件 | |
-| `trades_off` | trade-off, tradeoff, trades off, at the cost of, 取舍, 权衡, 代价是 | |
-| `derived_from` | *(none)* | Created programmatically by the Q&A system when filing answers |
+| Type              | Keywords                                                                                 | Notes                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `implements`      | implements, implementation of, is an implementation, 实现了, 实现方式                    |                                                                |
+| `extends`         | extends, extension of, builds on, builds upon, 扩展了, 基于                              |                                                                |
+| `optimizes`       | optimizes, optimization of, improves upon, faster than, 优化了, 改进了, 提升了           |                                                                |
+| `contradicts`     | contradicts, conflicts with, disagrees with, challenges, 矛盾, 冲突, 挑战了              |                                                                |
+| `cites`           | _(none)_                                                                                 | Created programmatically when articles reference sources       |
+| `prerequisite_of` | prerequisite, requires knowledge of, depends on, built on top of, 前提, 依赖于, 前置条件 |                                                                |
+| `trades_off`      | trade-off, tradeoff, trades off, at the cost of, 取舍, 权衡, 代价是                      |                                                                |
+| `derived_from`    | _(none)_                                                                                 | Created programmatically by the Q&A system when filing answers |
 
 Built-in types are always present. They cannot be removed, but you can add synonyms to them.
 
@@ -39,7 +39,7 @@ Add an `ontology` section to your `config.yaml`:
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     # Extend a built-in type with additional synonyms
     - name: implements
       synonyms: ["thực hiện", "triển khai"]
@@ -55,7 +55,7 @@ When the `name` matches a built-in type, your synonyms are **appended** to the d
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     - name: implements
       synonyms: ["thực hiện", "triển khai"]
 ```
@@ -63,6 +63,7 @@ ontology:
 After merging, `implements` will match all of its original English and Chinese keywords **plus** the Vietnamese ones you added.
 
 This is useful for:
+
 - **Multilingual wikis** — add keywords in your language so the compiler detects relations in non-English content
 - **Domain jargon** — add field-specific phrases that mean the same thing (e.g., "is a subclass of" for `extends`)
 
@@ -72,7 +73,7 @@ When the `name` doesn't match any built-in, a new relation type is created:
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     - name: regulates
       synonyms: ["regulates", "regulated by", "调控", "调节"]
     - name: inspired_by
@@ -84,6 +85,7 @@ Custom types work exactly like built-in types: the compiler scans for their keyw
 ### Naming rules
 
 Relation names must:
+
 - Start with a lowercase letter
 - Contain only lowercase letters, digits, and underscores
 - Match the pattern `^[a-z][a-z0-9_]*$`
@@ -99,7 +101,7 @@ Invalid names are rejected at config load time with a clear error message.
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     - name: regulates
       synonyms: ["regulates", "regulated by", "activates", "inhibits", "调控"]
     - name: encodes
@@ -112,7 +114,7 @@ ontology:
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     - name: depends_on
       synonyms: ["depends on", "dependency of", "requires"]
     - name: wraps
@@ -125,9 +127,10 @@ ontology:
 
 ```yaml
 ontology:
-  relations:
+  relation_types:
     - name: inspired_by
-      synonyms: ["inspired by", "influenced by", "draws from", "in the tradition of"]
+      synonyms:
+        ["inspired by", "influenced by", "draws from", "in the tradition of"]
     - name: critiques
       synonyms: ["critiques", "critique of", "responds to", "counters"]
     - name: synthesizes

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -194,7 +194,8 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 	chunkStore := memory.NewChunkStore(db)
 
 	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	pipelineOntStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	pipelineOntStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 
 	// Backfill chunk index if needed (after migration, before first compile)
 	if chunkStore.NeedsBackfill(memStore) {
@@ -369,7 +370,8 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 				}
 
 				merged := ontology.MergedRelations(cfg.Ontology.Relations)
-				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+				mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 
 				client.SetPass("write")
 				var writeCacheID string
@@ -785,7 +787,8 @@ func resumeBatch(
 				}
 
 				merged := ontology.MergedRelations(cfg.Ontology.Relations)
-				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+				mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+				ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes))
 				client.SetPass("write")
 				writeCacheID, _ := client.SetupCache("You are a knowledge base article writer. Write comprehensive, well-structured wiki articles.", writeModel)
 				relPatterns := ontology.RelationPatterns(merged)

--- a/internal/compiler/pipeline_test.go
+++ b/internal/compiler/pipeline_test.go
@@ -229,7 +229,7 @@ func TestHandleRemovedSources_SingleSourcePrune(t *testing.T) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, nil)
+	ontStore := ontology.NewStore(db, nil, nil)
 
 	// Index the article in FTS5 and ontology
 	memStore.Add(memory.Entry{ID: "concept:attention", Content: "Attention content", Tags: []string{"concept"}, ArticlePath: articlePath})
@@ -286,7 +286,7 @@ func TestHandleRemovedSources_SingleSourceNoPrune(t *testing.T) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, nil)
+	ontStore := ontology.NewStore(db, nil, nil)
 
 	memStore.Add(memory.Entry{ID: "concept:attention", Content: "Attention", Tags: []string{"concept"}, ArticlePath: articlePath})
 	ontStore.AddEntity(ontology.Entity{ID: "attention", Type: "concept", Name: "Attention", ArticlePath: articlePath})
@@ -331,7 +331,7 @@ func TestHandleRemovedSources_MultiSource(t *testing.T) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, nil)
+	ontStore := ontology.NewStore(db, nil, nil)
 
 	mf := manifest.New()
 	mf.AddSource("raw/paper.pdf", "sha256:abc", "paper", 5000)
@@ -364,7 +364,7 @@ func TestHandleRemovedSources_NoOrphans(t *testing.T) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, nil)
+	ontStore := ontology.NewStore(db, nil, nil)
 
 	mf := manifest.New()
 	mf.AddSource("raw/paper.pdf", "sha256:abc", "paper", 5000)

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -81,8 +81,9 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	embedder := embed.NewFromConfig(cfg)
 	chunkStore := memory.NewChunkStore(db)
 
@@ -115,7 +116,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 			articleMaxTokens = 4000
 		}
 
-		relPatterns := ontology.RelationPatterns(merged)
+		relPatterns := ontology.RelationPatterns(mergedRels)
 		log.Info("Pass 3: writing articles", "concepts", len(concepts))
 		articles := WriteArticles(ArticleWriteOpts{
 			ProjectDir:       projectDir,

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -152,12 +152,11 @@ func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept) ArticleRes
 	}
 	result.ArticlePath = articlePath
 
-	// Create ontology entity
-	entityType := ontology.TypeConcept
-	if concept.Type == "technique" {
-		entityType = ontology.TypeTechnique
-	} else if concept.Type == "claim" {
-		entityType = ontology.TypeClaim
+	// Create ontology entity — pass through LLM-assigned type if valid,
+	// fall back to concept for unknown or empty types.
+	entityType := concept.Type
+	if entityType == "" || !opts.OntStore.IsValidType(entityType) {
+		entityType = ontology.TypeConcept
 	}
 
 	if err := opts.OntStore.AddEntity(ontology.Entity{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var relationNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+var typeNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Config represents the sage-wiki project configuration.
 type Config struct {
@@ -205,15 +205,22 @@ type ServeConfig struct {
 	Port      int    `yaml:"port"`
 }
 
-// OntologyConfig configures ontology relation types.
+// OntologyConfig configures ontology relation and entity types.
 type OntologyConfig struct {
-	Relations []RelationConfig `yaml:"relations,omitempty"`
+	Relations   []RelationConfig   `yaml:"relations,omitempty"`
+	EntityTypes []EntityTypeConfig `yaml:"entity_types,omitempty"`
 }
 
 // RelationConfig defines a custom or extended relation type.
 type RelationConfig struct {
 	Name     string   `yaml:"name"`
 	Synonyms []string `yaml:"synonyms"`
+}
+
+// EntityTypeConfig defines a custom or extended entity type.
+type EntityTypeConfig struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
 }
 
 // Defaults returns a Config with sensible defaults for greenfield mode.
@@ -339,8 +346,16 @@ func (c *Config) Validate() error {
 		if r.Name == "" {
 			return fmt.Errorf("config: ontology.relations: name is required")
 		}
-		if !relationNameRe.MatchString(r.Name) {
+		if !typeNameRe.MatchString(r.Name) {
 			return fmt.Errorf("config: ontology.relations: invalid name %q (must match [a-z][a-z0-9_]*)", r.Name)
+		}
+	}
+	for _, et := range c.Ontology.EntityTypes {
+		if et.Name == "" {
+			return fmt.Errorf("config: ontology.entity_types: name is required")
+		}
+		if !typeNameRe.MatchString(et.Name) {
+			return fmt.Errorf("config: ontology.entity_types: invalid name %q (must match [a-z][a-z0-9_]*)", et.Name)
 		}
 	}
 	if c.Search.ChunkSize != 0 && (c.Search.ChunkSize < 100 || c.Search.ChunkSize > 5000) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -207,8 +208,9 @@ type ServeConfig struct {
 
 // OntologyConfig configures ontology relation and entity types.
 type OntologyConfig struct {
-	Relations   []RelationConfig   `yaml:"relations,omitempty"`
-	EntityTypes []EntityTypeConfig `yaml:"entity_types,omitempty"`
+	Relations     []RelationConfig   `yaml:"relations,omitempty"`
+	RelationTypes []RelationConfig   `yaml:"relation_types,omitempty"` // preferred key; "relations" accepted for backwards compat
+	EntityTypes   []EntityTypeConfig `yaml:"entity_types,omitempty"`
 }
 
 // RelationConfig defines a custom or extended relation type.
@@ -342,12 +344,20 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: invalid compiler.mode %q (valid: standard, batch, auto)", c.Compiler.Mode)
 		}
 	}
+	// Merge relation_types (preferred) and relations (deprecated) keys.
+	// If both are set, relation_types takes precedence.
+	if len(c.Ontology.RelationTypes) > 0 {
+		c.Ontology.Relations = c.Ontology.RelationTypes
+		c.Ontology.RelationTypes = nil // normalize to single field
+	} else if len(c.Ontology.Relations) > 0 {
+		log.Println("config: ontology.relations is deprecated, use ontology.relation_types instead")
+	}
 	for _, r := range c.Ontology.Relations {
 		if r.Name == "" {
-			return fmt.Errorf("config: ontology.relations: name is required")
+			return fmt.Errorf("config: ontology.relation_types: name is required")
 		}
 		if !typeNameRe.MatchString(r.Name) {
-			return fmt.Errorf("config: ontology.relations: invalid name %q (must match [a-z][a-z0-9_]*)", r.Name)
+			return fmt.Errorf("config: ontology.relation_types: invalid name %q (must match [a-z][a-z0-9_]*)", r.Name)
 		}
 	}
 	for _, et := range c.Ontology.EntityTypes {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,6 +202,20 @@ func TestValidation(t *testing.T) {
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{Relations: []RelationConfig{{Name: "regulates", Synonyms: []string{"regulates"}}, {Name: "implements"}}}},
 		},
 		{
+			name:    "invalid entity type name uppercase",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: "Concept"}}}},
+			wantErr: "invalid name",
+		},
+		{
+			name:    "invalid entity type name empty",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: ""}}}},
+			wantErr: "name is required",
+		},
+		{
+			name: "valid entity type names",
+			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{EntityTypes: []EntityTypeConfig{{Name: "conversation"}, {Name: "decision"}}}},
+		},
+		{
 			name: "valid empty ontology",
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{}},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -198,8 +198,12 @@ func TestValidation(t *testing.T) {
 			wantErr: "invalid name",
 		},
 		{
-			name: "valid relation names",
+			name: "valid relation names via relations key",
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{Relations: []RelationConfig{{Name: "regulates", Synonyms: []string{"regulates"}}, {Name: "implements"}}}},
+		},
+		{
+			name: "valid relation names via relation_types key",
+			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{RelationTypes: []RelationConfig{{Name: "regulates"}, {Name: "implements"}}}},
 		},
 		{
 			name:    "invalid entity type name uppercase",
@@ -242,6 +246,28 @@ func TestValidation(t *testing.T) {
 				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
 			}
 		})
+	}
+}
+
+func TestRelationTypesMergePrecedence(t *testing.T) {
+	cfg := Config{
+		Project: "test",
+		Output:  "wiki",
+		Sources: []Source{{Path: "raw"}},
+		Ontology: OntologyConfig{
+			Relations:     []RelationConfig{{Name: "old_key"}},
+			RelationTypes: []RelationConfig{{Name: "new_key"}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	// relation_types should take precedence
+	if len(cfg.Ontology.Relations) != 1 || cfg.Ontology.Relations[0].Name != "new_key" {
+		t.Errorf("expected relation_types to override relations, got %v", cfg.Ontology.Relations)
+	}
+	if len(cfg.Ontology.RelationTypes) != 0 {
+		t.Error("expected RelationTypes to be normalized to nil after merge")
 	}
 }
 

--- a/internal/graph/relevance_test.go
+++ b/internal/graph/relevance_test.go
@@ -16,7 +16,7 @@ func setupTestStore(t *testing.T) *ontology.Store {
 		t.Fatalf("open db: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	return ontology.NewStore(db, ontology.ValidRelationNames(ontology.BuiltinRelations))
+	return ontology.NewStore(db, ontology.ValidRelationNames(ontology.BuiltinRelations), ontology.ValidEntityTypeNames(ontology.BuiltinEntityTypes))
 }
 
 // buildTestGraph creates:

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -16,10 +16,11 @@ func setupLintProject(t *testing.T) (string, *LintContext) {
 	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
 
 	ctx := &LintContext{
-		ProjectDir:     dir,
-		OutputDir:      "wiki",
-		DBPath:         filepath.Join(dir, ".sage", "wiki.db"),
-		ValidRelations: ontology.ValidRelationNames(ontology.BuiltinRelations),
+		ProjectDir:       dir,
+		OutputDir:        "wiki",
+		DBPath:           filepath.Join(dir, ".sage", "wiki.db"),
+		ValidRelations:   ontology.ValidRelationNames(ontology.BuiltinRelations),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(ontology.BuiltinEntityTypes),
 	}
 	return dir, ctx
 }

--- a/internal/linter/passes.go
+++ b/internal/linter/passes.go
@@ -145,7 +145,7 @@ func (p *OrphansPass) Run(ctx *LintContext) ([]Finding, error) {
 		return nil, nil
 	}
 
-	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations)
+	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations, ctx.ValidEntityTypes)
 
 	entities, err := ontStore.ListEntities("")
 	if err != nil {
@@ -228,7 +228,7 @@ func (p *ConnectionsPass) Run(ctx *LintContext) ([]Finding, error) {
 	}
 
 	vecStore := vectors.NewStore(ctx.DB)
-	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations)
+	ontStore := ontology.NewStore(ctx.DB, ctx.ValidRelations, ctx.ValidEntityTypes)
 
 	// Get all concept entities with vectors
 	concepts, err := ontStore.ListEntities("concept")

--- a/internal/linter/runner.go
+++ b/internal/linter/runner.go
@@ -37,11 +37,12 @@ type LintPass interface {
 
 // LintContext provides access to project data for lint passes.
 type LintContext struct {
-	ProjectDir     string
-	OutputDir      string
-	DBPath         string
-	DB             *storage.DB // shared DB connection (optional — opened from DBPath if nil)
-	ValidRelations []string    // valid ontology relation type names
+	ProjectDir       string
+	OutputDir        string
+	DBPath           string
+	DB               *storage.DB // shared DB connection (optional — opened from DBPath if nil)
+	ValidRelations   []string    // valid ontology relation type names
+	ValidEntityTypes []string    // valid ontology entity type names
 }
 
 // LintResult holds the aggregated output of a lint run.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -51,8 +51,9 @@ func NewServer(projectDir string) (*Server, error) {
 
 	mem := memory.NewStore(db)
 	vec := vectors.NewStore(db)
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ont := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	searcher := hybrid.NewSearcher(mem, vec)
 
 	s := &Server{

--- a/internal/mcp/tools_compound.go
+++ b/internal/mcp/tools_compound.go
@@ -56,13 +56,15 @@ func (s *Server) handleLint(ctx context.Context, req mcplib.CallToolRequest) (*m
 	passName, _ := args["pass"].(string)
 	fix, _ := args["fix"].(bool)
 
-	merged := ontology.MergedRelations(s.cfg.Ontology.Relations)
+	mergedRels := ontology.MergedRelations(s.cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(s.cfg.Ontology.EntityTypes)
 	lintCtx := &linter.LintContext{
-		ProjectDir:     s.projectDir,
-		OutputDir:      s.cfg.Output,
-		DBPath:         filepath.Join(s.projectDir, ".sage", "wiki.db"),
-		DB:             s.db,
-		ValidRelations: ontology.ValidRelationNames(merged),
+		ProjectDir:       s.projectDir,
+		OutputDir:        s.cfg.Output,
+		DBPath:           filepath.Join(s.projectDir, ".sage", "wiki.db"),
+		DB:               s.db,
+		ValidRelations:   ontology.ValidRelationNames(mergedRels),
+		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
 	}
 
 	runner := linter.NewRunner()

--- a/internal/ontology/entities.go
+++ b/internal/ontology/entities.go
@@ -1,0 +1,58 @@
+package ontology
+
+import "github.com/xoai/sage-wiki/internal/config"
+
+// EntityTypeDef defines an entity type with optional description.
+type EntityTypeDef struct {
+	Name        string
+	Description string
+}
+
+// BuiltinEntityTypes defines the 5 immutable entity types.
+var BuiltinEntityTypes = []EntityTypeDef{
+	{Name: TypeConcept, Description: "An abstract idea or principle"},
+	{Name: TypeTechnique, Description: "A method or algorithm"},
+	{Name: TypeSource, Description: "A reference document or data source"},
+	{Name: TypeClaim, Description: "An assertion that may be true or false"},
+	{Name: TypeArtifact, Description: "A concrete output or deliverable"},
+}
+
+// MergedEntityTypes merges user config with built-in defaults.
+// Built-in types are always present even if not in config.
+// Config can extend built-in descriptions or add custom types.
+func MergedEntityTypes(cfgTypes []config.EntityTypeConfig) []EntityTypeDef {
+	// Start with copies of builtins
+	result := make([]EntityTypeDef, len(BuiltinEntityTypes))
+	copy(result, BuiltinEntityTypes)
+
+	builtinIdx := make(map[string]int, len(result))
+	for i, e := range result {
+		builtinIdx[e.Name] = i
+	}
+
+	for _, ct := range cfgTypes {
+		if idx, ok := builtinIdx[ct.Name]; ok {
+			// Override description for built-in type
+			if ct.Description != "" {
+				result[idx].Description = ct.Description
+			}
+		} else {
+			// New custom type
+			result = append(result, EntityTypeDef{
+				Name:        ct.Name,
+				Description: ct.Description,
+			})
+		}
+	}
+
+	return result
+}
+
+// ValidEntityTypeNames returns the names from a merged entity type list.
+func ValidEntityTypeNames(defs []EntityTypeDef) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}

--- a/internal/ontology/entities_test.go
+++ b/internal/ontology/entities_test.go
@@ -1,0 +1,200 @@
+package ontology
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+func TestMergedEntityTypesEmptyConfig(t *testing.T) {
+	merged := MergedEntityTypes(nil)
+	if len(merged) != len(BuiltinEntityTypes) {
+		t.Fatalf("expected %d builtins, got %d", len(BuiltinEntityTypes), len(merged))
+	}
+	for i, b := range BuiltinEntityTypes {
+		if merged[i].Name != b.Name {
+			t.Errorf("index %d: expected %q, got %q", i, b.Name, merged[i].Name)
+		}
+	}
+}
+
+func TestMergedEntityTypesExtendBuiltin(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "concept", Description: "Custom description for concept"},
+	}
+	merged := MergedEntityTypes(cfg)
+
+	// Should still be 5 total (no new types)
+	if len(merged) != len(BuiltinEntityTypes) {
+		t.Fatalf("expected %d, got %d", len(BuiltinEntityTypes), len(merged))
+	}
+
+	// Description should be overridden
+	if merged[0].Description != "Custom description for concept" {
+		t.Errorf("expected custom description, got %q", merged[0].Description)
+	}
+}
+
+func TestMergedEntityTypesAddCustom(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "conversation", Description: "A dialogue or discussion"},
+	}
+	merged := MergedEntityTypes(cfg)
+
+	if len(merged) != len(BuiltinEntityTypes)+1 {
+		t.Fatalf("expected %d, got %d", len(BuiltinEntityTypes)+1, len(merged))
+	}
+
+	last := merged[len(merged)-1]
+	if last.Name != "conversation" {
+		t.Errorf("expected conversation, got %q", last.Name)
+	}
+	if last.Description != "A dialogue or discussion" {
+		t.Errorf("expected description, got %q", last.Description)
+	}
+}
+
+func TestMergedEntityTypesDoesNotMutateBuiltins(t *testing.T) {
+	originalDesc := BuiltinEntityTypes[0].Description
+	cfg := []config.EntityTypeConfig{
+		{Name: "concept", Description: "Overridden"},
+	}
+	MergedEntityTypes(cfg)
+	if BuiltinEntityTypes[0].Description != originalDesc {
+		t.Error("MergedEntityTypes mutated BuiltinEntityTypes")
+	}
+}
+
+func TestValidEntityTypeNames(t *testing.T) {
+	defs := []EntityTypeDef{
+		{Name: "concept"},
+		{Name: "conversation"},
+	}
+	names := ValidEntityTypeNames(defs)
+	if len(names) != 2 || names[0] != "concept" || names[1] != "conversation" {
+		t.Errorf("unexpected names: %v", names)
+	}
+}
+
+// Integration: zero config produces identical behavior to hardcoded builtins
+func TestZeroEntityConfigSameBehavior(t *testing.T) {
+	merged := MergedEntityTypes(nil)
+	names := ValidEntityTypeNames(merged)
+
+	// 5 built-in names
+	if len(names) != 5 {
+		t.Fatalf("expected 5 names, got %d", len(names))
+	}
+
+	// Store accepts all built-in types
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+	for _, name := range names {
+		err := store.AddEntity(Entity{
+			ID:   "e-" + name,
+			Type: name,
+			Name: "Entity " + name,
+		})
+		if err != nil {
+			t.Errorf("built-in entity type %q rejected: %v", name, err)
+		}
+	}
+}
+
+// Integration: custom entity type works end-to-end
+func TestCustomEntityTypeEndToEnd(t *testing.T) {
+	cfg := []config.EntityTypeConfig{
+		{Name: "conversation", Description: "A dialogue"},
+	}
+	merged := MergedEntityTypes(cfg)
+	names := ValidEntityTypeNames(merged)
+
+	// 6 names (5 builtins + 1 custom)
+	if len(names) != 6 {
+		t.Fatalf("expected 6 names, got %d", len(names))
+	}
+
+	// Store accepts the custom type
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+	err = store.AddEntity(Entity{
+		ID:   "conv-1",
+		Type: "conversation",
+		Name: "Design Discussion",
+	})
+	if err != nil {
+		t.Fatalf("custom entity type should be accepted: %v", err)
+	}
+
+	// Verify it was stored
+	entity, err := store.GetEntity("conv-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entity == nil {
+		t.Fatal("expected entity, got nil")
+	}
+	if entity.Type != "conversation" {
+		t.Errorf("expected type conversation, got %q", entity.Type)
+	}
+}
+
+// Integration: AddEntity with invalid type returns error
+func TestAddEntityInvalidTypeError(t *testing.T) {
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	names := ValidEntityTypeNames(MergedEntityTypes(nil))
+	store := NewStore(db, ValidRelationNames(BuiltinRelations), names)
+
+	err = store.AddEntity(Entity{
+		ID:   "e1",
+		Type: "nonexistent_type",
+		Name: "Test",
+	})
+	if err == nil {
+		t.Error("expected error for invalid entity type")
+	}
+	if err != nil && !strings.Contains(err.Error(), "unknown entity type") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Integration: nil validEntityTypes accepts all types (permissive mode)
+func TestNilValidEntityTypesAcceptsAll(t *testing.T) {
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db, nil, nil)
+	err = store.AddEntity(Entity{
+		ID:   "e1",
+		Type: "anything_goes",
+		Name: "Test",
+	})
+	if err != nil {
+		t.Errorf("nil validEntityTypes should accept all types: %v", err)
+	}
+}

--- a/internal/ontology/entities_test.go
+++ b/internal/ontology/entities_test.go
@@ -179,6 +179,40 @@ func TestAddEntityInvalidTypeError(t *testing.T) {
 	}
 }
 
+// IsValidType: table-driven tests
+func TestIsValidType(t *testing.T) {
+	tests := []struct {
+		name       string
+		types      []string // nil = permissive
+		checkType  string
+		wantValid  bool
+	}{
+		{"builtin concept", ValidEntityTypeNames(BuiltinEntityTypes), "concept", true},
+		{"builtin technique", ValidEntityTypeNames(BuiltinEntityTypes), "technique", true},
+		{"unknown type rejected", ValidEntityTypeNames(BuiltinEntityTypes), "conversation", false},
+		{"empty type rejected", ValidEntityTypeNames(BuiltinEntityTypes), "", false},
+		{"custom type accepted", append(ValidEntityTypeNames(BuiltinEntityTypes), "conversation"), "conversation", true},
+		{"nil types accepts all", nil, "anything", true},
+		{"nil types accepts empty", nil, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			db, err := storage.Open(filepath.Join(dir, "test.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			store := NewStore(db, nil, tt.types)
+			got := store.IsValidType(tt.checkType)
+			if got != tt.wantValid {
+				t.Errorf("IsValidType(%q) = %v, want %v", tt.checkType, got, tt.wantValid)
+			}
+		})
+	}
+}
+
 // Integration: nil validEntityTypes accepts all types (permissive mode)
 func TestNilValidEntityTypesAcceptsAll(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/ontology/ontology.go
+++ b/internal/ontology/ontology.go
@@ -67,13 +67,15 @@ type TraverseOpts struct {
 
 // Store manages ontology entities and relations.
 type Store struct {
-	db             *storage.DB
-	validRelations map[string]bool
+	db               *storage.DB
+	validRelations   map[string]bool
+	validEntityTypes map[string]bool
 }
 
-// NewStore creates an ontology store with application-layer relation validation.
+// NewStore creates an ontology store with application-layer type validation.
 // validRelations lists the allowed relation type names. If nil, all types are accepted.
-func NewStore(db *storage.DB, validRelations []string) *Store {
+// validEntityTypes lists the allowed entity type names. If nil, all types are accepted.
+func NewStore(db *storage.DB, validRelations []string, validEntityTypes []string) *Store {
 	s := &Store{db: db}
 	if validRelations != nil {
 		s.validRelations = make(map[string]bool, len(validRelations))
@@ -81,11 +83,20 @@ func NewStore(db *storage.DB, validRelations []string) *Store {
 			s.validRelations[r] = true
 		}
 	}
+	if validEntityTypes != nil {
+		s.validEntityTypes = make(map[string]bool, len(validEntityTypes))
+		for _, t := range validEntityTypes {
+			s.validEntityTypes[t] = true
+		}
+	}
 	return s
 }
 
 // AddEntity creates a new entity.
 func (s *Store) AddEntity(e Entity) error {
+	if s.validEntityTypes != nil && !s.validEntityTypes[e.Type] {
+		return fmt.Errorf("ontology: unknown entity type %q", e.Type)
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	if e.CreatedAt == "" {
 		e.CreatedAt = now

--- a/internal/ontology/ontology.go
+++ b/internal/ontology/ontology.go
@@ -92,6 +92,15 @@ func NewStore(db *storage.DB, validRelations []string, validEntityTypes []string
 	return s
 }
 
+// IsValidType returns true if the given type is in the valid entity types list.
+// When no validation list is configured, all types are accepted.
+func (s *Store) IsValidType(t string) bool {
+	if s.validEntityTypes == nil {
+		return true
+	}
+	return s.validEntityTypes[t]
+}
+
 // AddEntity creates a new entity.
 func (s *Store) AddEntity(e Entity) error {
 	if s.validEntityTypes != nil && !s.validEntityTypes[e.Type] {

--- a/internal/ontology/ontology_test.go
+++ b/internal/ontology/ontology_test.go
@@ -15,7 +15,7 @@ func setupTestDB(t *testing.T) *Store {
 		t.Fatalf("open db: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	return NewStore(db, ValidRelationNames(BuiltinRelations))
+	return NewStore(db, ValidRelationNames(BuiltinRelations), ValidEntityTypeNames(BuiltinEntityTypes))
 }
 
 func TestAddAndGetEntity(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCustomRelationAccepted(t *testing.T) {
 
 	// Include a custom relation type
 	validNames := append(ValidRelationNames(BuiltinRelations), "regulates")
-	store := NewStore(db, validNames)
+	store := NewStore(db, validNames, ValidEntityTypeNames(BuiltinEntityTypes))
 
 	store.AddEntity(Entity{ID: "e1", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "e2", Type: TypeConcept, Name: "B"})
@@ -158,7 +158,7 @@ func TestNilValidRelationsAcceptsAll(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, nil)
+	store := NewStore(db, nil, nil)
 	store.AddEntity(Entity{ID: "e1", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "e2", Type: TypeConcept, Name: "B"})
 

--- a/internal/ontology/relations_test.go
+++ b/internal/ontology/relations_test.go
@@ -155,7 +155,7 @@ func TestZeroConfigSameBehavior(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "a", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "b", Type: TypeConcept, Name: "B"})
 
@@ -199,7 +199,7 @@ func TestCustomRelationEndToEnd(t *testing.T) {
 	}
 	defer db.Close()
 
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "gene-a", Type: TypeConcept, Name: "Gene A"})
 	store.AddEntity(Entity{ID: "gene-b", Type: TypeConcept, Name: "Gene B"})
 
@@ -257,7 +257,7 @@ func TestAddRelationInvalidTypeError(t *testing.T) {
 	defer db.Close()
 
 	names := ValidRelationNames(MergedRelations(nil))
-	store := NewStore(db, names)
+	store := NewStore(db, names, ValidEntityTypeNames(BuiltinEntityTypes))
 	store.AddEntity(Entity{ID: "a", Type: TypeConcept, Name: "A"})
 	store.AddEntity(Entity{ID: "b", Type: TypeConcept, Name: "B"})
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -121,7 +121,9 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 	// Auto-file to outputs/
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	embedder := embed.NewFromConfig(cfg)
 	chunkStore := memory.NewChunkStore(db)
 	outputPath, err := autoFile(projectDir, cfg.Output, result, memStore, vecStore, ontStore, embedder, cfg.Compiler.UserNow(), autoFileOpts{ChunkStore: chunkStore, DB: db, ChunkSize: cfg.Search.ChunkSizeOrDefault()})
@@ -139,7 +141,9 @@ func Query(projectDir string, question string, format string, topK int, opts ...
 func buildQueryContext(projectDir string, question string, topK int, cfg *config.Config, db *storage.DB) (string, []string, error) {
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	chunkStore := memory.NewChunkStore(db)
 	embedder := embed.NewFromConfig(cfg)
 
@@ -440,7 +444,9 @@ func SaveAnswer(projectDir string, question string, answer string, sources []str
 	}
 	memStore := memory.NewStore(db)
 	vecStore := vectors.NewStore(db)
-	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ontStore := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	embedder := embed.NewFromConfig(cfg)
 	chunkStore := memory.NewChunkStore(db)
 	result := &QueryResult{
@@ -638,7 +644,9 @@ func StreamQuery(ctx context.Context, projectDir string, question string, topK i
 		}
 		memStore := memory.NewStore(db)
 		vecStore := vectors.NewStore(db)
-		ontStore := ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+		mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+		mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+		ontStore := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 		embedder := embed.NewFromConfig(cfg)
 		chunkStore := memory.NewChunkStore(db)
 		if outputPath, err := autoFile(projectDir, cfg.Output, result, memStore, vecStore, ontStore, embedder, cfg.Compiler.UserNow(), autoFileOpts{ChunkStore: chunkStore, DB: db, ChunkSize: cfg.Search.ChunkSizeOrDefault()}); err != nil {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -75,7 +75,7 @@ func TestComputeGraphExpansion_EmptySeeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	ont := ontology.NewStore(db, nil)
+	ont := ontology.NewStore(db, nil, nil)
 
 	expanded := computeGraphExpansion(cfg, ont, nil)
 	if expanded != nil {
@@ -90,7 +90,7 @@ func TestComputeGraphExpansion_WithGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	ont := ontology.NewStore(db, nil)
+	ont := ontology.NewStore(db, nil, nil)
 
 	// Build graph: attention --extends--> transformer, both cite same source
 	ont.AddEntity(ontology.Entity{ID: "attention", Type: "concept", Name: "Attention", ArticlePath: "wiki/concepts/attention.md"})
@@ -134,7 +134,7 @@ func TestComputeGraphExpansion_DisabledByConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	ont := ontology.NewStore(db, nil)
+	ont := ontology.NewStore(db, nil, nil)
 
 	ont.AddEntity(ontology.Entity{ID: "attention", Type: "concept", Name: "Attention", ArticlePath: "wiki/concepts/attention.md"})
 	ont.AddEntity(ontology.Entity{ID: "transformer", Type: "concept", Name: "Transformer", ArticlePath: "wiki/concepts/transformer.md"})

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -135,19 +135,33 @@ func (db *DB) migrate() error {
 		return err
 	}
 
-	migrations := []string{
-		migrationV1,
-		migrationV2,
-		migrationV3,
+	type migration struct {
+		sql            string
+		disableFK      bool // run PRAGMA foreign_keys=OFF before tx, restore after
+	}
+
+	migrations := []migration{
+		{sql: migrationV1},
+		{sql: migrationV2},
+		{sql: migrationV3},
+		{sql: migrationV4, disableFK: true},
 	}
 
 	for i := version; i < len(migrations); i++ {
+		m := migrations[i]
 		log.Info("running migration", "version", i+1)
+
+		if m.disableFK {
+			if _, err := db.write.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+				return fmt.Errorf("migration v%d: disable FK: %w", i+1, err)
+			}
+		}
+
 		tx, err := db.write.Begin()
 		if err != nil {
 			return fmt.Errorf("migration v%d: begin: %w", i+1, err)
 		}
-		if _, err := tx.Exec(migrations[i]); err != nil {
+		if _, err := tx.Exec(m.sql); err != nil {
 			tx.Rollback()
 			return fmt.Errorf("migration v%d: %w", i+1, err)
 		}
@@ -157,6 +171,12 @@ func (db *DB) migrate() error {
 		}
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("migration v%d: commit: %w", i+1, err)
+		}
+
+		if m.disableFK {
+			if _, err := db.write.Exec("PRAGMA foreign_keys = ON"); err != nil {
+				return fmt.Errorf("migration v%d: restore FK: %w", i+1, err)
+			}
 		}
 	}
 
@@ -267,4 +287,44 @@ CREATE TABLE IF NOT EXISTS vec_chunks (
 	dimensions INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_vec_chunks_doc ON vec_chunks(doc_id);
+`
+
+// migrationV4 removes the CHECK constraint on entities.type to support custom entity types.
+// Requires disableFK=true in the migration runner because we drop and recreate the entities
+// table, which temporarily invalidates the relations FK reference.
+const migrationV4 = `
+-- Remove CHECK constraint on entities.type for custom entity types
+CREATE TABLE IF NOT EXISTS entities_new (
+	id TEXT PRIMARY KEY,
+	type TEXT NOT NULL,
+	name TEXT NOT NULL,
+	definition TEXT,
+	article_path TEXT,
+	metadata JSON,
+	created_at TEXT,
+	updated_at TEXT
+);
+
+INSERT OR IGNORE INTO entities_new SELECT * FROM entities;
+DROP TABLE IF EXISTS entities;
+ALTER TABLE entities_new RENAME TO entities;
+
+-- Recreate relations table to restore CASCADE DELETE on the new entities table
+CREATE TABLE IF NOT EXISTS relations_rebuild (
+	id TEXT PRIMARY KEY,
+	source_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+	target_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+	relation TEXT NOT NULL,
+	metadata JSON,
+	created_at TEXT,
+	UNIQUE(source_id, target_id, relation)
+);
+
+INSERT OR IGNORE INTO relations_rebuild SELECT * FROM relations;
+DROP TABLE IF EXISTS relations;
+ALTER TABLE relations_rebuild RENAME TO relations;
+
+CREATE INDEX IF NOT EXISTS idx_relations_source ON relations(source_id);
+CREATE INDEX IF NOT EXISTS idx_relations_target ON relations(target_id);
+CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(relation);
 `

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -23,8 +23,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query schema_version: %v", err)
 	}
-	if version != 3 {
-		t.Errorf("expected schema version 3, got %d", version)
+	if version != 4 {
+		t.Errorf("expected schema version 4, got %d", version)
 	}
 
 	// Verify tables exist
@@ -62,8 +62,8 @@ func TestIdempotentMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 3 {
-		t.Errorf("expected 3 schema_version rows, got %d", count)
+	if count != 4 {
+		t.Errorf("expected 4 schema_version rows, got %d", count)
 	}
 }
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -56,8 +56,9 @@ func NewWebServer(projectDir string) (*WebServer, error) {
 
 	mem := memory.NewStore(db)
 	vec := vectors.NewStore(db)
-	merged := ontology.MergedRelations(cfg.Ontology.Relations)
-	ont := ontology.NewStore(db, ontology.ValidRelationNames(merged))
+	mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+	mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+	ont := ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	searcher := hybrid.NewSearcher(mem, vec)
 
 	return &WebServer{

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -236,16 +236,24 @@ serve:
   transport: stdio      # stdio or sse
   port: 3333            # SSE mode only
 
-# Ontology relation types (optional)
+# Ontology types (optional)
 # Extend built-in types with additional synonyms or add custom types.
-# Built-in types: implements, extends, optimizes, contradicts, cites,
-#                 prerequisite_of, trades_off, derived_from
+#
+# Built-in relation types: implements, extends, optimizes, contradicts, cites,
+#                          prerequisite_of, trades_off, derived_from
+# Built-in entity types: concept, technique, source, claim, artifact
+#
 # ontology:
 #   relations:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]   # add Vietnamese synonyms
 #     - name: regulates
 #       synonyms: ["regulates", "regulated by", "调控", "调节"]
+#   entity_types:
+#     - name: conversation
+#       description: "A dialogue or discussion"
+#     - name: decision
+#       description: "A recorded decision with rationale"
 `, project, description, model, model, model, model, model)
 }
 
@@ -303,12 +311,15 @@ search:
 serve:
   transport: stdio
 
-# Ontology relation types (optional)
+# Ontology types (optional)
 # ontology:
 #   relations:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]
 #     - name: regulates
 #       synonyms: ["regulates", "regulated by"]
+#   entity_types:
+#     - name: conversation
+#     - name: decision
 `, project, project, sourcesYAML, output, ignoreYAML, model, model, model, model, model)
 }

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -244,7 +244,7 @@ serve:
 # Built-in entity types: concept, technique, source, claim, artifact
 #
 # ontology:
-#   relations:
+#   relation_types:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]   # add Vietnamese synonyms
 #     - name: regulates
@@ -313,7 +313,7 @@ serve:
 
 # Ontology types (optional)
 # ontology:
-#   relations:
+#   relation_types:
 #     - name: implements
 #       synonyms: ["thực hiện", "triển khai"]
 #     - name: regulates

--- a/internal/wiki/status.go
+++ b/internal/wiki/status.go
@@ -91,7 +91,9 @@ func GetStatus(projectDir string, stores *Stores) (*StatusInfo, error) {
 
 		memStore = memory.NewStore(db)
 		vecStore = vectors.NewStore(db)
-		ontStore = ontology.NewStore(db, ontology.ValidRelationNames(ontology.MergedRelations(cfg.Ontology.Relations)))
+		mergedRels := ontology.MergedRelations(cfg.Ontology.Relations)
+		mergedTypes := ontology.MergedEntityTypes(cfg.Ontology.EntityTypes)
+		ontStore = ontology.NewStore(db, ontology.ValidRelationNames(mergedRels), ontology.ValidEntityTypeNames(mergedTypes))
 	}
 
 	info.EntryCount, _ = memStore.Count()


### PR DESCRIPTION
## Summary

- The YAML tag `relations` was inconsistent with `entity_types` — users writing `relation_types:` (the natural match) had custom relations silently ignored
- Now accepts **both** keys: `relation_types` is preferred, `relations` is accepted with a deprecation log
- If both keys are present, `relation_types` takes precedence
- All docs, templates, error messages, and the configurable-relations guide updated

Supersedes #35. The NULL scan fix was split to standalone #37 per review feedback.

## Depends on

- #38 (custom entity types) — must merge first
- #39 (passthrough entity types) — must merge first

## Changes

- **Config**: `RelationTypes` field with `yaml:"relation_types"`, merge logic in `Validate()`
- **Docs**: README.md, README_zh.md, CHANGELOG.md, `docs/guides/configurable-relations.md` (6 occurrences)
- **Templates**: Both init templates use `relation_types:`
- **Tests**: precedence test (relation_types wins over relations), validation via both keys

## Backwards compatibility

Existing `config.yaml` files with `ontology.relations:` continue to work. They get a `log.Println` deprecation notice. No silent breakage.

## Test plan

- [x] All tests pass (`go test ./...` — 23 packages)
- [x] `relation_types` key accepted and validated
- [x] `relations` key still accepted (backwards compat)
- [x] Precedence test: when both keys present, `relation_types` wins
- [x] Error messages say `relation_types` (not `relations`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)