### PR TITLE
feat: content-aware type detection with configurable signals

### DIFF
--- a/internal/compiler/diff.go
+++ b/internal/compiler/diff.go
@@ -72,14 +72,22 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 				return nil
 			}
 
-			var contentHead string
+			var detectedType string
 			if len(cfg.TypeSignals) > 0 {
-				contentHead = extract.ReadHead(path, extract.DefaultHeadRunes)
+				// Reuse cached type from manifest if file is unchanged
+				if existing, ok := mf.Sources[relPath]; ok && existing.Hash == hash && existing.Type != "" {
+					detectedType = existing.Type
+				} else {
+					contentHead := extract.ReadHead(path, extract.DefaultHeadRunes)
+					detectedType = extract.DetectSourceTypeWithSignals(path, contentHead, convertSignals(cfg.TypeSignals))
+				}
+			} else {
+				detectedType = extract.DetectSourceType(path)
 			}
 			current[relPath] = SourceInfo{
 				Path: relPath,
 				Hash: hash,
-				Type: extract.DetectSourceTypeWithSignals(path, contentHead, convertSignals(cfg.TypeSignals)),
+				Type: detectedType,
 				Size: info.Size(),
 			}
 			return nil

--- a/internal/compiler/diff.go
+++ b/internal/compiler/diff.go
@@ -48,6 +48,11 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 				return nil
 			}
 
+			// Skip hidden files (.DS_Store etc.)
+			if strings.HasPrefix(d.Name(), ".") {
+				return nil
+			}
+
 			// Get relative path from project root
 			relPath, _ := filepath.Rel(projectDir, path)
 
@@ -67,10 +72,14 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 				return nil
 			}
 
+			var contentHead string
+			if len(cfg.TypeSignals) > 0 {
+				contentHead = extract.ReadHead(path, extract.DefaultHeadRunes)
+			}
 			current[relPath] = SourceInfo{
 				Path: relPath,
 				Hash: hash,
-				Type: extract.DetectSourceType(path),
+				Type: extract.DetectSourceTypeWithSignals(path, contentHead, convertSignals(cfg.TypeSignals)),
 				Size: info.Size(),
 			}
 			return nil

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -302,7 +302,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 		memStore.Add(memory.Entry{
 			ID:          sr.SourcePath,
 			Content:     sr.Summary,
-			Tags:        []string{extractType(sr.SourcePath)},
+			Tags:        []string{extractType(sr.SourcePath, cfg.TypeSignals)},
 			ArticlePath: sr.SummaryPath,
 		})
 
@@ -708,7 +708,7 @@ func resumeBatch(
 
 		// Update manifest — ensure source entry exists, then mark compiled
 		if _, exists := mf.Sources[br.CustomID]; !exists {
-			mf.AddSource(br.CustomID, "", extractType(br.CustomID), 0)
+			mf.AddSource(br.CustomID, "", extractType(br.CustomID, cfg.TypeSignals), 0)
 		}
 		mf.MarkCompiled(br.CustomID, summaryPath, nil)
 
@@ -716,7 +716,7 @@ func resumeBatch(
 		memStore.Add(memory.Entry{
 			ID:          br.CustomID,
 			Content:     summaryText,
-			Tags:        []string{extractType(br.CustomID)},
+			Tags:        []string{extractType(br.CustomID, cfg.TypeSignals)},
 			ArticlePath: summaryPath,
 		})
 
@@ -900,8 +900,26 @@ func removeFromPending(state *CompileState, path string) {
 	}
 }
 
-func extractType(path string) string {
-	return extract.DetectSourceType(path)
+func extractType(path string, typeSignals []config.TypeSignal) string {
+	var contentHead string
+	if len(typeSignals) > 0 {
+		contentHead = extract.ReadHead(path, extract.DefaultHeadRunes)
+	}
+	return extract.DetectSourceTypeWithSignals(path, contentHead, convertSignals(typeSignals))
+}
+
+func convertSignals(typeSignals []config.TypeSignal) []extract.TypeSignal {
+	signals := make([]extract.TypeSignal, len(typeSignals))
+	for i, s := range typeSignals {
+		signals[i] = extract.TypeSignal{
+			Type:             s.Type,
+			Pattern:          s.Pattern,
+			FilenameKeywords: s.FilenameKeywords,
+			ContentKeywords:  s.ContentKeywords,
+			MinContentHits:   s.MinContentHits,
+		}
+	}
+	return signals
 }
 
 // timeNow returns the current time in RFC3339 using the given timezone.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Linting     LintingConfig  `yaml:"linting"`
 	Serve       ServeConfig    `yaml:"serve"`
 	Ontology    OntologyConfig `yaml:"ontology,omitempty"`
+	TypeSignals []TypeSignal   `yaml:"type_signals,omitempty"`
 }
 
 type VaultConfig struct {
@@ -206,6 +207,16 @@ type ServeConfig struct {
 	Port      int    `yaml:"port"`
 }
 
+// TypeSignal defines a content-based type detection rule.
+// Files are matched by filename keywords and/or content keywords.
+type TypeSignal struct {
+	Type             string   `yaml:"type"`
+	Pattern          string   `yaml:"pattern,omitempty"`           // simple substring match (legacy)
+	FilenameKeywords []string `yaml:"filename_keywords,omitempty"` // keywords matched against filename
+	ContentKeywords  []string `yaml:"content_keywords,omitempty"`  // keywords matched against content head
+	MinContentHits   int      `yaml:"min_content_hits,omitempty"`  // minimum content keyword matches required
+}
+
 // OntologyConfig configures ontology relation and entity types.
 type OntologyConfig struct {
 	Relations     []RelationConfig   `yaml:"relations,omitempty"`
@@ -370,6 +381,17 @@ func (c *Config) Validate() error {
 	}
 	if c.Search.ChunkSize != 0 && (c.Search.ChunkSize < 100 || c.Search.ChunkSize > 5000) {
 		return fmt.Errorf("config: search.chunk_size must be 100-5000, got %d", c.Search.ChunkSize)
+	}
+	for i, ts := range c.TypeSignals {
+		if ts.Type == "" {
+			return fmt.Errorf("config: type_signals[%d]: type is required", i)
+		}
+		if len(ts.FilenameKeywords) == 0 && len(ts.ContentKeywords) == 0 && ts.Pattern == "" {
+			return fmt.Errorf("config: type_signals[%d] (%s): at least one keyword (filename, content, or pattern) is required", i, ts.Type)
+		}
+		if len(ts.ContentKeywords) > 0 && ts.MinContentHits <= 0 {
+			return fmt.Errorf("config: type_signals[%d] (%s): min_content_hits must be > 0 when content_keywords is set", i, ts.Type)
+		}
 	}
 	if c.Compiler.Timezone != "" {
 		loc, err := time.LoadLocation(c.Compiler.Timezone)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -408,6 +408,110 @@ func TestUserTimeLocation(t *testing.T) {
 	}
 }
 
+func TestTypeSignalParsing(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+
+	content := `
+version: 1
+project: test-wiki
+sources:
+  - path: raw
+    type: auto
+    watch: true
+output: wiki
+type_signals:
+  - type: regulation
+    filename_keywords: ["法规", "办法"]
+    content_keywords: ["第一条", "第二条"]
+    min_content_hits: 2
+  - type: research
+    filename_keywords: ["研报"]
+    content_keywords: ["投资评级"]
+    min_content_hits: 1
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(cfg.TypeSignals) != 2 {
+		t.Fatalf("expected 2 type signals, got %d", len(cfg.TypeSignals))
+	}
+	if cfg.TypeSignals[0].Type != "regulation" {
+		t.Errorf("expected type 'regulation', got %q", cfg.TypeSignals[0].Type)
+	}
+	if len(cfg.TypeSignals[0].FilenameKeywords) != 2 {
+		t.Errorf("expected 2 filename keywords, got %d", len(cfg.TypeSignals[0].FilenameKeywords))
+	}
+	if cfg.TypeSignals[0].MinContentHits != 2 {
+		t.Errorf("expected min_content_hits 2, got %d", cfg.TypeSignals[0].MinContentHits)
+	}
+}
+
+func TestTypeSignalValidation(t *testing.T) {
+	base := Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}}
+
+	tests := []struct {
+		name    string
+		signals []TypeSignal
+		wantErr string
+	}{
+		{
+			name:    "missing type",
+			signals: []TypeSignal{{FilenameKeywords: []string{"foo"}}},
+			wantErr: "type is required",
+		},
+		{
+			name:    "no keywords at all",
+			signals: []TypeSignal{{Type: "regulation"}},
+			wantErr: "at least one keyword",
+		},
+		{
+			name:    "content keywords without min_content_hits",
+			signals: []TypeSignal{{Type: "regulation", ContentKeywords: []string{"foo"}}},
+			wantErr: "min_content_hits must be > 0",
+		},
+		{
+			name:    "valid filename only",
+			signals: []TypeSignal{{Type: "regulation", FilenameKeywords: []string{"foo"}}},
+		},
+		{
+			name:    "valid content keywords with min hits",
+			signals: []TypeSignal{{Type: "regulation", ContentKeywords: []string{"foo"}, MinContentHits: 1}},
+		},
+		{
+			name:    "valid pattern only",
+			signals: []TypeSignal{{Type: "regulation", Pattern: "foo"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			cfg.TypeSignals = tt.signals
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -10,12 +10,15 @@ import (
 
 // SourceContent holds extracted text from a source file.
 type SourceContent struct {
-	Path       string
-	Type       string // article, paper, code
-	Text       string
-	Frontmatter string
-	Chunks     []Chunk
-	ChunkCount int
+	Path          string
+	Type          string // article, paper, code
+	Text          string
+	Frontmatter   string
+	Chunks        []Chunk
+	ChunkCount    int
+	PreExtracted  bool   // whether content was pre-extracted
+	Confidence    string // high/medium/low
+	ExtractEngine string // extraction engine used
 }
 
 // Chunk represents a section of a large source.
@@ -294,6 +297,7 @@ func splitByParagraphs(text string, maxTokens int) []Chunk {
 }
 
 // DetectSourceType guesses source type from file extension.
+// This is the basic 1-parameter version used as a fallback.
 func DetectSourceType(path string) string {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
@@ -322,3 +326,54 @@ func DetectSourceType(path string) string {
 		return "article"
 	}
 }
+
+// DetectSourceTypeWithSignals guesses source type using file extension,
+// content head (first N bytes), and user-configured type signals.
+// Signal-based matches (filename keywords, content keywords) take priority
+// over extension-based detection.
+func DetectSourceTypeWithSignals(path string, contentHead string, typeSignals []TypeSignal) string {
+	baseName := filepath.Base(path)
+	for _, sig := range typeSignals {
+		// Legacy simple pattern match
+		if sig.Pattern != "" && strings.Contains(contentHead, sig.Pattern) {
+			return sig.Type
+		}
+
+		// Filename keyword match
+		for _, kw := range sig.FilenameKeywords {
+			if strings.Contains(baseName, kw) {
+				return sig.Type
+			}
+		}
+
+		// Content keyword match with threshold
+		if len(sig.ContentKeywords) > 0 && contentHead != "" {
+			hits := 0
+			for _, kw := range sig.ContentKeywords {
+				if strings.Contains(contentHead, kw) {
+					hits++
+				}
+			}
+			minHits := sig.MinContentHits
+			if minHits <= 0 {
+				minHits = 1
+			}
+			if hits >= minHits {
+				return sig.Type
+			}
+		}
+	}
+	// Fall back to extension-based detection
+	return DetectSourceType(path)
+}
+
+// TypeSignal mirrors config.TypeSignal so callers in other packages
+// can pass signals without importing config in every call site.
+type TypeSignal struct {
+	Type             string
+	Pattern          string   // simple substring match (legacy)
+	FilenameKeywords []string // keywords matched against filename
+	ContentKeywords  []string // keywords matched against content head
+	MinContentHits   int      // minimum content keyword matches required
+}
+

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -228,6 +228,7 @@ func TestChunkCJKText(t *testing.T) {
 }
 
 func TestDetectSourceType(t *testing.T) {
+	// Backward compat: nil signals = extension-only
 	tests := []struct {
 		path     string
 		expected string
@@ -247,9 +248,83 @@ func TestDetectSourceType(t *testing.T) {
 		{"transcript.vtt", "article"},
 	}
 	for _, tt := range tests {
-		got := DetectSourceType(tt.path)
+		got := DetectSourceTypeWithSignals(tt.path, "", nil)
 		if got != tt.expected {
-			t.Errorf("DetectSourceType(%s) = %s, want %s", tt.path, got, tt.expected)
+			t.Errorf("DetectSourceTypeWithSignals(%s, \"\", nil) = %s, want %s", tt.path, got, tt.expected)
 		}
+	}
+}
+
+func TestDetectSourceTypeWithSignals(t *testing.T) {
+	signals := []TypeSignal{
+		{
+			Type:             "regulation",
+			FilenameKeywords: []string{"法规", "办法"},
+			ContentKeywords:  []string{"第一条", "第二条", "为了规范"},
+			MinContentHits:   2,
+		},
+		{
+			Type:             "research",
+			FilenameKeywords: []string{"研报"},
+			ContentKeywords:  []string{"投资评级", "目标价"},
+			MinContentHits:   1,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		contentHead string
+		expected    string
+	}{
+		{"filename match", "/path/证券法规汇编.pdf", "", "regulation"},
+		{"content match", "/path/document.pdf", "第一条 为了规范证券市场 第二条 适用范围", "regulation"},
+		{"content below threshold", "/path/doc.pdf", "第一条 只有一个关键词", "paper"},
+		{"research filename", "/path/AI研报.pdf", "", "research"},
+		{"research content", "/path/report.pdf", "本报告投资评级为买入", "research"},
+		{"no match fallback pdf", "/path/random.pdf", "no keywords here", "paper"},
+		{"no match fallback md", "/path/notes.md", "no keywords here", "article"},
+		{"signal priority", "/path/法规研报.pdf", "", "regulation"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectSourceTypeWithSignals(tt.path, tt.contentHead, signals)
+			if got != tt.expected {
+				t.Errorf("DetectSourceTypeWithSignals(%s) = %s, want %s", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReadHead(t *testing.T) {
+	dir := t.TempDir()
+
+	// ASCII file
+	path := filepath.Join(dir, "test.txt")
+	os.WriteFile(path, []byte("Hello, World! This is a test file with some content."), 0644)
+	got := ReadHead(path, 5)
+	if got != "Hello" {
+		t.Errorf("ReadHead(5) = %q, want %q", got, "Hello")
+	}
+
+	// Chinese content
+	cnPath := filepath.Join(dir, "chinese.txt")
+	os.WriteFile(cnPath, []byte("第一条 为了规范证券发行"), 0644)
+	got = ReadHead(cnPath, 10)
+	if len([]rune(got)) > 10 {
+		t.Errorf("ReadHead(10) returned %d runes, want <= 10", len([]rune(got)))
+	}
+
+	// Non-existent file
+	got = ReadHead("/nonexistent/file.txt", 100)
+	if got != "" {
+		t.Errorf("ReadHead(nonexistent) = %q, want empty", got)
+	}
+
+	// File shorter than limit
+	got = ReadHead(path, 10000)
+	if got != "Hello, World! This is a test file with some content." {
+		t.Errorf("ReadHead(10000) = %q, want full content", got)
 	}
 }

--- a/internal/extract/pdf.go
+++ b/internal/extract/pdf.go
@@ -2,13 +2,46 @@ package extract
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/ledongthuc/pdf"
 )
 
-// extractPDF extracts text from a PDF file using ledongthuc/pdf (pure Go).
+// extractPDF extracts text from a PDF file.
+// Tries pdftotext (poppler) first for better font/encoding support,
+// falls back to the pure Go library if pdftotext is not available.
 func extractPDF(path string) (*SourceContent, error) {
+	// Try pdftotext first
+	if text := extractPDFPoppler(path); text != "" {
+		return &SourceContent{
+			Path: path,
+			Type: "paper",
+			Text: text,
+		}, nil
+	}
+
+	// Fallback to Go library
+	return extractPDFGo(path)
+}
+
+// extractPDFPoppler uses pdftotext (poppler) for extraction.
+func extractPDFPoppler(path string) string {
+	pdftotext, err := exec.LookPath("pdftotext")
+	if err != nil {
+		return ""
+	}
+
+	out, err := exec.Command(pdftotext, path, "-").Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+// extractPDFGo uses the pure Go PDF library.
+func extractPDFGo(path string) (*SourceContent, error) {
 	f, r, err := pdf.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract pdf: open: %w", err)
@@ -26,7 +59,6 @@ func extractPDF(path string) (*SourceContent, error) {
 
 		content, err := page.GetPlainText(nil)
 		if err != nil {
-			// Skip pages that fail to extract
 			continue
 		}
 		text.WriteString(content)

--- a/internal/extract/pdf.go
+++ b/internal/extract/pdf.go
@@ -1,9 +1,11 @@
 package extract
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/ledongthuc/pdf"
 )
@@ -32,7 +34,9 @@ func extractPDFPoppler(path string) string {
 		return ""
 	}
 
-	out, err := exec.Command(pdftotext, path, "-").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, pdftotext, path, "-").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/extract/readhead.go
+++ b/internal/extract/readhead.go
@@ -1,10 +1,12 @@
 package extract
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/ledongthuc/pdf"
@@ -44,7 +46,9 @@ func readHeadPDFToText(path string, maxRunes int) string {
 	}
 
 	// -l 1: first page only, "--": end of flags (C1 security fix), "-": stdout
-	out, err := exec.Command(pdftotext, "-l", "1", "--", path, "-").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, pdftotext, "-l", "1", "--", path, "-").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/extract/readhead.go
+++ b/internal/extract/readhead.go
@@ -1,0 +1,115 @@
+package extract
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/ledongthuc/pdf"
+)
+
+// DefaultHeadRunes is the default number of runes to read for content-based type detection.
+const DefaultHeadRunes = 500
+
+// ReadHead reads the first maxRunes runes from a file.
+// For PDF files, extracts text from the first page using pdftotext (poppler)
+// with fallback to the Go PDF library.
+// Returns empty string on error or if file doesn't exist.
+func ReadHead(path string, maxRunes int) string {
+	if strings.ToLower(filepath.Ext(path)) == ".pdf" {
+		return readHeadPDF(path, maxRunes)
+	}
+	return readHeadText(path, maxRunes)
+}
+
+// readHeadPDF extracts text from the first page of a PDF.
+// Tries pdftotext (poppler) first for better font/encoding support,
+// falls back to the Go PDF library if pdftotext is not available.
+func readHeadPDF(path string, maxRunes int) string {
+	// Try pdftotext first — handles complex font encodings (e.g. Skia/Chrome PDFs)
+	if text := readHeadPDFToText(path, maxRunes); text != "" {
+		return text
+	}
+	// Fallback to Go library
+	return readHeadPDFGo(path, maxRunes)
+}
+
+// readHeadPDFToText uses pdftotext (poppler) to extract first-page text.
+func readHeadPDFToText(path string, maxRunes int) string {
+	pdftotext, err := exec.LookPath("pdftotext")
+	if err != nil {
+		return "" // pdftotext not installed
+	}
+
+	// -l 1: first page only, "--": end of flags (C1 security fix), "-": stdout
+	out, err := exec.Command(pdftotext, "-l", "1", "--", path, "-").Output()
+	if err != nil {
+		return ""
+	}
+
+	text := strings.TrimSpace(string(out))
+	runes := []rune(text)
+	if len(runes) > maxRunes {
+		runes = runes[:maxRunes]
+	}
+	return string(runes)
+}
+
+// readHeadPDFGo extracts text using the pure Go PDF library.
+func readHeadPDFGo(path string, maxRunes int) string {
+	f, r, err := pdf.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	if r.NumPage() < 1 {
+		return ""
+	}
+
+	page := r.Page(1)
+	if page.V.IsNull() {
+		return ""
+	}
+
+	content, err := page.GetPlainText(nil)
+	if err != nil {
+		return ""
+	}
+
+	runes := []rune(content)
+	if len(runes) > maxRunes {
+		runes = runes[:maxRunes]
+	}
+	return string(runes)
+}
+
+// readHeadText reads the first maxRunes runes from a text file.
+func readHeadText(path string, maxRunes int) string {
+	maxBytes := maxRunes * 4
+	if maxBytes > 8192 {
+		maxBytes = 8192
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	buf := make([]byte, maxBytes)
+	n, _ := f.Read(buf)
+	buf = buf[:n]
+
+	count := 0
+	i := 0
+	for i < len(buf) && count < maxRunes {
+		_, size := utf8.DecodeRune(buf[i:])
+		i += size
+		count++
+	}
+
+	return string(buf[:i])
+}

--- a/internal/wiki/ingest.go
+++ b/internal/wiki/ingest.go
@@ -111,7 +111,21 @@ func IngestPath(projectDir string, srcPath string) (*IngestResult, error) {
 		return nil, fmt.Errorf("ingest: file not found: %w", err)
 	}
 
-	srcType := extract.DetectSourceType(absPath)
+	var contentHead string
+	if len(cfg.TypeSignals) > 0 {
+		contentHead = extract.ReadHead(absPath, extract.DefaultHeadRunes)
+	}
+	signals := make([]extract.TypeSignal, len(cfg.TypeSignals))
+	for i, s := range cfg.TypeSignals {
+		signals[i] = extract.TypeSignal{
+			Type:             s.Type,
+			Pattern:          s.Pattern,
+			FilenameKeywords: s.FilenameKeywords,
+			ContentKeywords:  s.ContentKeywords,
+			MinContentHits:   s.MinContentHits,
+		}
+	}
+	srcType := extract.DetectSourceTypeWithSignals(absPath, contentHead, signals)
 	destDir := findSourceFolder(projectDir, cfg, srcType)
 	if destDir == "" {
 		// Fallback to first source folder


### PR DESCRIPTION
## Summary
- Add `TypeSignal` config for content-based source type detection
- `ReadHead` extracts file headers (text + PDF) for keyword matching
- Short-circuit: zero cost when no TypeSignals configured

## Review feedback addressed (from #18)
- ✅ C1: `--` before path in pdftotext (security)
- ✅ M1: Short-circuit ReadHead when TypeSignals empty (performance)  
- ✅ M3: TypeSignal field validation in Validate()
- ✅ Minor: DefaultHeadRunes named constant

Replaces #18 with clean branch from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)