### PR TITLE
fix: pipeline resilience with 5xx retry and circuit breaker

### DIFF
--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -41,6 +41,7 @@ type CompileResult struct {
 	ConceptsExtracted  int
 	ArticlesWritten    int
 	Errors             int
+	EmbedErrors        int
 	CostReport         *llm.CostReport // nil if no LLM calls were made
 }
 
@@ -311,6 +312,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 			vec, err := embedder.Embed(sr.Summary)
 			if err != nil {
 				log.Warn("embedding failed", "source", sr.SourcePath, "error", err)
+				result.EmbedErrors++
 			} else {
 				vecStore.Upsert(sr.SourcePath, vec)
 			}
@@ -429,6 +431,15 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 	// Write CHANGELOG entry
 	if err := writeChangelog(projectDir, cfg.Output, result, cfg.Compiler.UserTimeLocation()); err != nil {
 		log.Warn("failed to write CHANGELOG", "error", err)
+	}
+
+	// FTS/vector consistency check
+	if result.EmbedErrors > 0 {
+		ftsCount, _ := memStore.Count()
+		vecCount, _ := vecStore.Count()
+		if ftsCount != vecCount {
+			log.Warn("FTS/vector mismatch after compile", "fts", ftsCount, "vec", vecCount, "embed_errors", result.EmbedErrors)
+		}
 	}
 
 	// Clean up checkpoint on success

--- a/internal/compiler/pipeline_test.go
+++ b/internal/compiler/pipeline_test.go
@@ -75,8 +75,8 @@ func TestCompileWithMockLLM(t *testing.T) {
 			// Pass 3: article writing
 			content = "---\nconcept: test-concept\n---\n\n# Test Concept\n\nA test concept."
 		} else {
-			// Pass 1: summarization
-			content = "## Key claims\nTest claim.\n\n## Concepts\ntest-concept"
+			// Pass 1: summarization (must be ≥100 chars to pass quality validation)
+			content = "## Key claims\n\nThis document discusses the main concepts and findings related to the test subject matter.\n\n## Concepts\n\ntest-concept: A fundamental concept extracted from the source material."
 		}
 
 		json.NewEncoder(w).Encode(map[string]any{

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -46,9 +46,16 @@ func Summarize(
 	sem := make(chan struct{}, maxParallel)
 	var wg sync.WaitGroup
 	var done atomic.Int32
+	var consecutiveErrors atomic.Int32
 	total := len(sources)
+	stopped := false
 
 	for i, src := range sources {
+		if stopped {
+			results[i] = SummaryResult{SourcePath: src.Path, Error: fmt.Errorf("skipped: circuit breaker triggered")}
+			continue
+		}
+
 		wg.Add(1)
 		sem <- struct{}{}
 
@@ -61,8 +68,14 @@ func Summarize(
 
 			n := int(done.Add(1))
 			if result.Error != nil {
+				errCount := consecutiveErrors.Add(1)
 				log.Error("summarize failed", "progress", fmt.Sprintf("%d/%d", n, total), "source", info.Path, "error", result.Error)
+				if errCount >= 5 {
+					log.Error("circuit breaker: 5 consecutive failures, skipping remaining sources")
+					stopped = true
+				}
 			} else {
+				consecutiveErrors.Store(0)
 				log.Info("summarized", "progress", fmt.Sprintf("%d/%d", n, total), "source", info.Path)
 			}
 		}(i, src)
@@ -153,7 +166,23 @@ func summarizeOne(
 		}
 	}
 
+	if err := validateSummary(summaryText); err != nil {
+		result.Error = fmt.Errorf("summary quality check failed for %s: %w", info.Path, err)
+		return result
+	}
+
 	return writeSummaryFile(projectDir, outputDir, info, content, summaryText, result, userTZ)
+}
+
+// validateSummary checks minimum quality thresholds for a generated summary.
+// Returns an error if the summary is too short or lacks basic structure,
+// causing the source to be marked as failed and retried on next compile.
+func validateSummary(text string) error {
+	runes := []rune(strings.TrimSpace(text))
+	if len(runes) < 100 {
+		return fmt.Errorf("summary too short (%d chars, minimum 100)", len(runes))
+	}
+	return nil
 }
 
 func writeSummaryFile(projectDir, outputDir string, info SourceInfo, content *extract.SourceContent, summaryText string, result SummaryResult, loc *time.Location) SummaryResult {

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -48,10 +48,10 @@ func Summarize(
 	var done atomic.Int32
 	var consecutiveErrors atomic.Int32
 	total := len(sources)
-	stopped := false
+	var stopped atomic.Bool
 
 	for i, src := range sources {
-		if stopped {
+		if stopped.Load() {
 			results[i] = SummaryResult{SourcePath: src.Path, Error: fmt.Errorf("skipped: circuit breaker triggered")}
 			continue
 		}
@@ -72,7 +72,7 @@ func Summarize(
 				log.Error("summarize failed", "progress", fmt.Sprintf("%d/%d", n, total), "source", info.Path, "error", result.Error)
 				if errCount >= 5 {
 					log.Error("circuit breaker: 5 consecutive failures, skipping remaining sources")
-					stopped = true
+					stopped.Store(true)
 				}
 			} else {
 				consecutiveErrors.Store(0)

--- a/internal/compiler/summarize_test.go
+++ b/internal/compiler/summarize_test.go
@@ -136,3 +136,28 @@ func TestSynthesizeHierarchicalSingleSummary(t *testing.T) {
 		t.Errorf("expected pass-through, got %q", result)
 	}
 }
+
+func TestValidateSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"too short", "This is short.", true},
+		{"exactly 100 chars", string(make([]rune, 100)), false},
+		{"valid summary", "这是一个足够长的摘要文本，包含了足够多的内容来通过最低质量检查。" +
+			"我们需要确保摘要有足够的信息量，不能太短。这段文字需要超过一百个字符的最低要求才能通过验证。" +
+			"所以我们在这里添加更多的内容来确保它足够长。", false},
+		{"whitespace padded but short content", "   short   ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSummary(tt.text)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSummary(%q): got err=%v, wantErr=%v", tt.name, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -122,11 +122,11 @@ func (c *Client) chatCompletionDirect(messages []Message, opts CallOpts) (*Respo
 			return result, nil
 		}
 
-		if resp.StatusCode == 429 {
+		if isRetryable(resp.StatusCode) {
 			delay := backoffDelay(attempt)
-			log.Warn("rate limited, retrying", "attempt", attempt+1, "delay", delay)
+			log.Warn("retryable error, retrying", "status", resp.StatusCode, "attempt", attempt+1, "delay", delay)
 			time.Sleep(delay)
-			lastErr = fmt.Errorf("rate limited (429): %s", string(body))
+			lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
 			continue
 		}
 
@@ -213,6 +213,12 @@ func defaultRateLimit(provider string) int {
 	default:
 		return 30
 	}
+}
+
+// isRetryable returns true for HTTP status codes that warrant automatic retry.
+// Covers rate limits (429) and transient server errors (500, 502, 503).
+func isRetryable(statusCode int) bool {
+	return statusCode == 429 || statusCode == 500 || statusCode == 502 || statusCode == 503
 }
 
 // backoffDelay returns exponential backoff with jitter, capped at 60s.

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -223,6 +223,22 @@ func TestBackoffDelay(t *testing.T) {
 	}
 }
 
+func TestIsRetryable(t *testing.T) {
+	retryable := []int{429, 500, 502, 503}
+	for _, code := range retryable {
+		if !isRetryable(code) {
+			t.Errorf("expected %d to be retryable", code)
+		}
+	}
+
+	notRetryable := []int{200, 400, 401, 403, 404, 422}
+	for _, code := range notRetryable {
+		if isRetryable(code) {
+			t.Errorf("expected %d to NOT be retryable", code)
+		}
+	}
+}
+
 func TestOllamaUsesOpenAIFormat(t *testing.T) {
 	client, err := NewClient("ollama", "", "", 0)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Retry with exponential backoff for 5xx LLM API errors (500, 502, 503) in addition to existing 429 rate-limit handling
- Circuit breaker in Summarize: after 5 consecutive failures, skip remaining sources to prevent cascading API waste
- Summary quality validation: reject summaries shorter than 100 chars (retried on next compile)
- Track embed errors explicitly (`CompileResult.EmbedErrors`) with FTS/vector count mismatch logging
- Tests for `isRetryable` and `validateSummary`

Replaces #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)