### PR TITLE
feat: pre-extracted content support and facts storage

### DIFF
--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -10,12 +10,15 @@ import (
 
 // SourceContent holds extracted text from a source file.
 type SourceContent struct {
-	Path       string
-	Type       string // article, paper, code
-	Text       string
-	Frontmatter string
-	Chunks     []Chunk
-	ChunkCount int
+	Path          string
+	Type          string // article, paper, code
+	Text          string
+	Frontmatter   string
+	Chunks        []Chunk
+	ChunkCount    int
+	PreExtracted  bool   // true if content came from pre-extracted files
+	Confidence    string // high/medium/low
+	ExtractEngine string // extraction engine used (e.g. markitdown)
 }
 
 // Chunk represents a section of a large source.

--- a/internal/extract/preextract.go
+++ b/internal/extract/preextract.go
@@ -1,0 +1,93 @@
+package extract
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PreExtractFrontmatter holds parsed frontmatter from pre-extracted files.
+type PreExtractFrontmatter struct {
+	PreExtracted bool   `yaml:"pre_extracted"`
+	Confidence   string `yaml:"confidence"`
+	Engine       string `yaml:"engine"`
+	OriginalPath string `yaml:"original_path"`
+	OriginalHash string `yaml:"original_hash"`
+}
+
+// TryPreExtracted checks for a pre-extracted .md file and returns its content.
+// Returns nil, nil if no pre-extracted file exists or confidence is low.
+func TryPreExtracted(projectDir string, rawRelPath string) (*SourceContent, error) {
+	// raw/inbox/test.pdf → inbox/test.pdf
+	relPath := rawRelPath
+	if strings.HasPrefix(relPath, "raw/") {
+		relPath = relPath[4:]
+	}
+
+	preDir := filepath.Join(projectDir, ".pre-extracted", "files")
+	mdPath := filepath.Join(preDir, relPath+".md")
+
+	data, err := os.ReadFile(mdPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Parse frontmatter
+	content := string(data)
+	fm, body, err := parsePreExtractFrontmatter(content)
+	if err != nil {
+		return nil, nil // corrupted frontmatter, fall back to Go engine
+	}
+
+	if !fm.PreExtracted || fm.Confidence == "low" {
+		return nil, nil
+	}
+
+	sc := &SourceContent{
+		Path:          rawRelPath,
+		Text:          body,
+		PreExtracted:  true,
+		Confidence:    fm.Confidence,
+		ExtractEngine: fm.Engine,
+	}
+	return sc, nil
+}
+
+// ExtractFromProject tries pre-extracted content first, then falls back to the Go engine.
+func ExtractFromProject(projectDir string, relPath string, sourceType string) (*SourceContent, error) {
+	sc, err := TryPreExtracted(projectDir, relPath)
+	if err != nil {
+		return nil, fmt.Errorf("pre-extract check: %w", err)
+	}
+	if sc != nil {
+		return sc, nil
+	}
+
+	// Fall back to built-in Go extraction engine
+	absPath := filepath.Join(projectDir, relPath)
+	return Extract(absPath, sourceType)
+}
+
+func parsePreExtractFrontmatter(content string) (*PreExtractFrontmatter, string, error) {
+	if !strings.HasPrefix(content, "---\n") {
+		return nil, content, fmt.Errorf("no frontmatter")
+	}
+	end := strings.Index(content[4:], "\n---")
+	if end < 0 {
+		return nil, content, fmt.Errorf("no frontmatter end")
+	}
+	fmStr := content[4 : 4+end]
+	body := strings.TrimSpace(content[4+end+4:])
+
+	var fm PreExtractFrontmatter
+	if err := yaml.Unmarshal([]byte(fmStr), &fm); err != nil {
+		return nil, content, err
+	}
+	return &fm, body, nil
+}

--- a/internal/extract/preextract_test.go
+++ b/internal/extract/preextract_test.go
@@ -1,0 +1,89 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTryPreExtracted_Found(t *testing.T) {
+	// Create temp directory to simulate .pre-extracted/
+	dir := t.TempDir()
+	preDir := filepath.Join(dir, ".pre-extracted", "files", "inbox")
+	os.MkdirAll(preDir, 0755)
+
+	content := "---\npre_extracted: true\nconfidence: high\nengine: markitdown\n---\n# Test content"
+	os.WriteFile(filepath.Join(preDir, "test.pdf.md"), []byte(content), 0644)
+
+	sc, err := TryPreExtracted(dir, "raw/inbox/test.pdf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("expected SourceContent, got nil")
+	}
+	if sc.PreExtracted != true {
+		t.Error("expected PreExtracted=true")
+	}
+	if sc.Confidence != "high" {
+		t.Errorf("expected confidence=high, got %s", sc.Confidence)
+	}
+}
+
+func TestTryPreExtracted_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	sc, err := TryPreExtracted(dir, "raw/inbox/missing.pdf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc != nil {
+		t.Error("expected nil for missing pre-extracted file")
+	}
+}
+
+func TestTryPreExtracted_LowConfidence(t *testing.T) {
+	dir := t.TempDir()
+	preDir := filepath.Join(dir, ".pre-extracted", "files", "inbox")
+	os.MkdirAll(preDir, 0755)
+
+	content := "---\npre_extracted: true\nconfidence: low\nengine: markitdown\n---\n# Low quality"
+	os.WriteFile(filepath.Join(preDir, "test.pdf.md"), []byte(content), 0644)
+
+	sc, err := TryPreExtracted(dir, "raw/inbox/test.pdf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// low confidence should return nil, let Go engine handle it
+	if sc != nil {
+		t.Error("expected nil for low confidence")
+	}
+}
+
+func TestTryPreExtracted_CorruptedFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	preDir := filepath.Join(dir, ".pre-extracted", "files", "inbox")
+	os.MkdirAll(preDir, 0755)
+
+	content := "not yaml frontmatter\n# Just content"
+	os.WriteFile(filepath.Join(preDir, "test.pdf.md"), []byte(content), 0644)
+
+	sc, err := TryPreExtracted(dir, "raw/inbox/test.pdf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc != nil {
+		t.Error("expected nil for corrupted frontmatter")
+	}
+}
+
+func TestTryPreExtracted_NoPreExtractedDir(t *testing.T) {
+	dir := t.TempDir()
+	// Do not create .pre-extracted/ directory
+	sc, err := TryPreExtracted(dir, "raw/inbox/test.pdf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc != nil {
+		t.Error("expected nil when .pre-extracted/ doesn't exist")
+	}
+}

--- a/internal/facts/facts.go
+++ b/internal/facts/facts.go
@@ -1,0 +1,229 @@
+package facts
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+// Fact represents a structured numeric fact.
+type Fact struct {
+	ID               int64   `json:"id,omitempty"`
+	SourceFile       string  `json:"source_file"`
+	SourceProject    string  `json:"source_project,omitempty"`
+	Value            string  `json:"value"`
+	Numeric          float64 `json:"numeric"`
+	Sign             string  `json:"sign,omitempty"`
+	NumberType       string  `json:"number_type,omitempty"`
+	Certainty        string  `json:"certainty,omitempty"`
+	Entity           string  `json:"entity"`
+	EntityType       string  `json:"entity_type,omitempty"`
+	Period           string  `json:"period,omitempty"`
+	PeriodType       string  `json:"period_type,omitempty"`
+	SemanticLabel    string  `json:"semantic_label,omitempty"`
+	SourceLocation   string  `json:"source_location,omitempty"`
+	ContextType      string  `json:"context_type,omitempty"`
+	ExactQuote       string  `json:"exact_quote,omitempty"`
+	Verified         bool    `json:"verified,omitempty"`
+	ExtractionMethod string  `json:"extraction_method,omitempty"`
+	SchemaVersion    string  `json:"schema_version,omitempty"`
+	ImportedAt       string  `json:"imported_at,omitempty"`
+	QuoteHash        string  `json:"quote_hash,omitempty"`
+}
+
+// QueryOpts holds query filter criteria.
+type QueryOpts struct {
+	Entity     string
+	EntityType string
+	Period     string
+	Label      string
+	NumberType string
+	Source     string
+	Limit      int
+	Fuzzy      bool // fuzzy match entity and label (LIKE %keyword%)
+}
+
+// FactStats holds aggregate statistics for the facts table.
+type FactStats struct {
+	TotalFacts     int `json:"total_facts"`
+	UniqueEntities int `json:"unique_entities"`
+	UniquePeriods  int `json:"unique_periods"`
+	UniqueLabels   int `json:"unique_labels"`
+	UniqueSources  int `json:"unique_sources"`
+}
+
+// Store manages reads and writes to the facts table.
+type Store struct {
+	db *storage.DB
+}
+
+// NewStore creates a new facts Store.
+func NewStore(db *storage.DB) *Store {
+	return &Store{db: db}
+}
+
+// quoteHash computes a short SHA-256 hash of exact_quote for deduplication.
+func quoteHash(quote string) string {
+	if quote == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(quote))
+	return fmt.Sprintf("%x", h[:8]) // first 16 hex chars
+}
+
+// Insert adds a fact to the store. Duplicates (same dedup key) are silently ignored.
+func (s *Store) Insert(f Fact) error {
+	f.QuoteHash = quoteHash(f.ExactQuote)
+	if f.Sign == "" {
+		f.Sign = "positive"
+	}
+	if f.Certainty == "" {
+		f.Certainty = "exact"
+	}
+	if f.Entity == "" {
+		f.Entity = "unknown"
+	}
+	if f.Period == "" {
+		f.Period = "unknown"
+	}
+	if f.PeriodType == "" {
+		f.PeriodType = "unknown"
+	}
+	if f.SourceProject == "" {
+		f.SourceProject = "local"
+	}
+
+	return s.db.WriteTx(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT OR IGNORE INTO facts (
+				source_file, source_project, value, numeric, sign,
+				number_type, certainty, entity, entity_type,
+				period, period_type, semantic_label,
+				source_location, context_type, exact_quote,
+				verified, extraction_method, schema_version, quote_hash
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			f.SourceFile, f.SourceProject, f.Value, f.Numeric, f.Sign,
+			f.NumberType, f.Certainty, f.Entity, f.EntityType,
+			f.Period, f.PeriodType, f.SemanticLabel,
+			f.SourceLocation, f.ContextType, f.ExactQuote,
+			f.Verified, f.ExtractionMethod, f.SchemaVersion, f.QuoteHash,
+		)
+		return err
+	})
+}
+
+// Query returns facts matching the given filter criteria.
+func (s *Store) Query(opts QueryOpts) ([]Fact, error) {
+	var where []string
+	var args []interface{}
+
+	if opts.Entity != "" {
+		if opts.Fuzzy {
+			where = append(where, "entity LIKE ?")
+			args = append(args, "%"+opts.Entity+"%")
+		} else {
+			where = append(where, "entity = ?")
+			args = append(args, opts.Entity)
+		}
+	}
+	if opts.EntityType != "" {
+		where = append(where, "entity_type = ?")
+		args = append(args, opts.EntityType)
+	}
+	if opts.Period != "" {
+		where = append(where, "period = ?")
+		args = append(args, opts.Period)
+	}
+	if opts.Label != "" {
+		if opts.Fuzzy {
+			where = append(where, "semantic_label LIKE ?")
+			args = append(args, "%"+opts.Label+"%")
+		} else {
+			where = append(where, "semantic_label = ?")
+			args = append(args, opts.Label)
+		}
+	}
+	if opts.NumberType != "" {
+		where = append(where, "number_type = ?")
+		args = append(args, opts.NumberType)
+	}
+	if opts.Source != "" {
+		where = append(where, "source_file = ?")
+		args = append(args, opts.Source)
+	}
+
+	q := "SELECT id, source_file, source_project, value, numeric, sign, number_type, certainty, entity, entity_type, period, period_type, semantic_label, source_location, context_type, exact_quote, verified, extraction_method, schema_version, imported_at, quote_hash FROM facts"
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	q += " ORDER BY entity, period, semantic_label"
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 1000
+	}
+	q += fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := s.db.ReadDB().Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("facts.Query: %w", err)
+	}
+	defer rows.Close()
+
+	var results []Fact
+	for rows.Next() {
+		var f Fact
+		var importedAt, quoteHash sql.NullString
+		err := rows.Scan(
+			&f.ID, &f.SourceFile, &f.SourceProject, &f.Value, &f.Numeric,
+			&f.Sign, &f.NumberType, &f.Certainty, &f.Entity, &f.EntityType,
+			&f.Period, &f.PeriodType, &f.SemanticLabel,
+			&f.SourceLocation, &f.ContextType, &f.ExactQuote,
+			&f.Verified, &f.ExtractionMethod, &f.SchemaVersion,
+			&importedAt, &quoteHash,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("facts.Query scan: %w", err)
+		}
+		f.ImportedAt = importedAt.String
+		f.QuoteHash = quoteHash.String
+		results = append(results, f)
+	}
+	return results, rows.Err()
+}
+
+// DeleteBySource removes all facts from a given source file.
+func (s *Store) DeleteBySource(sourceFile string) (int64, error) {
+	var affected int64
+	err := s.db.WriteTx(func(tx *sql.Tx) error {
+		result, err := tx.Exec("DELETE FROM facts WHERE source_file = ?", sourceFile)
+		if err != nil {
+			return err
+		}
+		affected, err = result.RowsAffected()
+		return err
+	})
+	return affected, err
+}
+
+// Stats returns aggregate statistics for the facts table.
+func (s *Store) Stats() (FactStats, error) {
+	var stats FactStats
+	row := s.db.ReadDB().QueryRow(`
+		SELECT
+			COUNT(*),
+			COUNT(DISTINCT entity),
+			COUNT(DISTINCT period),
+			COUNT(DISTINCT semantic_label),
+			COUNT(DISTINCT source_file)
+		FROM facts
+	`)
+	err := row.Scan(&stats.TotalFacts, &stats.UniqueEntities, &stats.UniquePeriods, &stats.UniqueLabels, &stats.UniqueSources)
+	if err != nil {
+		return stats, fmt.Errorf("facts.Stats: %w", err)
+	}
+	return stats, nil
+}

--- a/internal/facts/facts_test.go
+++ b/internal/facts/facts_test.go
@@ -1,0 +1,230 @@
+package facts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+func setupTestDB(t *testing.T) (*storage.DB, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return db, func() {
+		db.Close()
+		os.Remove(dbPath)
+	}
+}
+
+func TestInsertAndQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	f := Fact{
+		SourceFile:    "raw/inbox/test.pdf",
+		Value:         "5.2亿元",
+		Numeric:       5.2,
+		NumberType:    "monetary",
+		Entity:        "希烽光电",
+		EntityType:    "company",
+		Period:        "2024",
+		PeriodType:    "actual",
+		SemanticLabel: "营业收入",
+		ExactQuote:    "营业收入 5.2 亿元",
+		SchemaVersion: "1.0",
+	}
+
+	// Insert
+	err := store.Insert(f)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Query
+	results, err := store.Query(QueryOpts{Entity: "希烽光电"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Numeric != 5.2 {
+		t.Errorf("expected numeric=5.2, got %f", results[0].Numeric)
+	}
+	if results[0].SemanticLabel != "营业收入" {
+		t.Errorf("expected label=营业收入, got %s", results[0].SemanticLabel)
+	}
+}
+
+func TestUpsertDedup(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	f := Fact{
+		SourceFile:    "raw/inbox/test.pdf",
+		Value:         "5.2亿元",
+		Numeric:       5.2,
+		Entity:        "希烽光电",
+		Period:        "2024",
+		SemanticLabel: "营业收入",
+		ExactQuote:    "营业收入 5.2 亿元",
+		SchemaVersion: "1.0",
+	}
+
+	// Insert twice, should only have one record
+	if err := store.Insert(f); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	if err := store.Insert(f); err != nil {
+		t.Fatalf("second insert: %v", err)
+	}
+
+	results, err := store.Query(QueryOpts{Entity: "希烽光电"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 (dedup), got %d", len(results))
+	}
+}
+
+func TestDeleteBySource(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	for _, src := range []string{"file1.pdf", "file2.pdf"} {
+		err := store.Insert(Fact{
+			SourceFile:    src,
+			Value:         "100",
+			Numeric:       100,
+			Entity:        "A公司",
+			SemanticLabel: "营收",
+			ExactQuote:    "营收100",
+			SchemaVersion: "1.0",
+		})
+		if err != nil {
+			t.Fatalf("insert %s: %v", src, err)
+		}
+	}
+
+	deleted, err := store.DeleteBySource("file1.pdf")
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+
+	results, err := store.Query(QueryOpts{})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 remaining, got %d", len(results))
+	}
+}
+
+func TestQueryByPeriod(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	for _, p := range []string{"2023", "2024", "2025E"} {
+		err := store.Insert(Fact{
+			SourceFile:    "test.pdf",
+			Value:         "100",
+			Numeric:       100,
+			Entity:        "B公司",
+			Period:        p,
+			SemanticLabel: "营收" + p,
+			ExactQuote:    "营收100 " + p,
+			SchemaVersion: "1.0",
+		})
+		if err != nil {
+			t.Fatalf("insert %s: %v", p, err)
+		}
+	}
+
+	results, err := store.Query(QueryOpts{Period: "2024"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 for period 2024, got %d", len(results))
+	}
+}
+
+func TestQueryByLabel(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	for _, label := range []string{"营业收入", "净利润", "毛利率"} {
+		err := store.Insert(Fact{
+			SourceFile:    "test.pdf",
+			Value:         "100",
+			Numeric:       100,
+			Entity:        "C公司",
+			SemanticLabel: label,
+			ExactQuote:    label + " 100",
+			SchemaVersion: "1.0",
+		})
+		if err != nil {
+			t.Fatalf("insert %s: %v", label, err)
+		}
+	}
+
+	results, err := store.Query(QueryOpts{Label: "净利润"})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 for label 净利润, got %d", len(results))
+	}
+}
+
+func TestStats(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+
+	facts := []Fact{
+		{SourceFile: "a.pdf", Value: "1", Numeric: 1, Entity: "X", SemanticLabel: "rev", ExactQuote: "q1", SchemaVersion: "1.0"},
+		{SourceFile: "a.pdf", Value: "2", Numeric: 2, Entity: "Y", SemanticLabel: "cost", ExactQuote: "q2", SchemaVersion: "1.0"},
+		{SourceFile: "b.pdf", Value: "3", Numeric: 3, Entity: "X", SemanticLabel: "rev2", ExactQuote: "q3", SchemaVersion: "1.0"},
+	}
+	for _, f := range facts {
+		if err := store.Insert(f); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	s, err := store.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if s.TotalFacts != 3 {
+		t.Errorf("expected 3 total, got %d", s.TotalFacts)
+	}
+	if s.UniqueEntities != 2 {
+		t.Errorf("expected 2 entities, got %d", s.UniqueEntities)
+	}
+	if s.UniqueSources != 2 {
+		t.Errorf("expected 2 sources, got %d", s.UniqueSources)
+	}
+}

--- a/internal/facts/import.go
+++ b/internal/facts/import.go
@@ -1,0 +1,199 @@
+package facts
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Aliases holds alias normalization configuration.
+type Aliases struct {
+	EntityAliases map[string][]string `yaml:"entity_aliases"` // canonical → []alias
+	LabelAliases  map[string][]string `yaml:"label_aliases"`  // canonical → []alias
+}
+
+// ImportReport holds import statistics.
+type ImportReport struct {
+	Added   int `json:"added"`
+	Skipped int `json:"skipped"` // skipped via upsert dedup
+	Errors  int `json:"errors"`
+	Files   int `json:"files"` // number of .numbers.yaml files processed
+}
+
+// numbersFile is the top-level structure of a .numbers.yaml file.
+type numbersFile struct {
+	Numbers []numberEntry `yaml:"numbers"`
+}
+
+// numberEntry represents a single numeric entry in a .numbers.yaml file.
+type numberEntry struct {
+	Value            string  `yaml:"value"`
+	Numeric          float64 `yaml:"numeric"`
+	Sign             string  `yaml:"sign"`
+	NumberType       string  `yaml:"number_type"`
+	Certainty        string  `yaml:"certainty"`
+	Entity           string  `yaml:"entity"`
+	EntityType       string  `yaml:"entity_type"`
+	Period           string  `yaml:"period"`
+	PeriodType       string  `yaml:"period_type"`
+	SemanticLabel    string  `yaml:"semantic_label"`
+	SourceFile       string  `yaml:"source_file"`
+	SourceLocation   string  `yaml:"source_location"`
+	ContextType      string  `yaml:"context_type"`
+	ExactQuote       string  `yaml:"exact_quote"`
+	Verified         bool    `yaml:"verified"`
+	ExtractionMethod string  `yaml:"extraction_method"`
+}
+
+// extractMeta corresponds to extract-meta.yaml.
+type extractMeta struct {
+	SchemaVersion string `yaml:"schema_version"`
+	Extractor     string `yaml:"extractor"`
+}
+
+// ImportDir imports all .numbers.yaml files from .pre-extracted/ into the facts table.
+func ImportDir(store *Store, projectDir string, aliases *Aliases) (ImportReport, error) {
+	var report ImportReport
+
+	preDir := filepath.Join(projectDir, ".pre-extracted")
+
+	// Check extract-meta.yaml version
+	metaPath := filepath.Join(preDir, "extract-meta.yaml")
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		return report, fmt.Errorf("read extract-meta.yaml: %w", err)
+	}
+
+	var meta extractMeta
+	if err := yaml.Unmarshal(metaData, &meta); err != nil {
+		return report, fmt.Errorf("parse extract-meta.yaml: %w", err)
+	}
+
+	if !strings.HasPrefix(meta.SchemaVersion, "1.") {
+		return report, fmt.Errorf("incompatible schema version: %s (expected 1.x)", meta.SchemaVersion)
+	}
+
+	// Build reverse alias lookups
+	entityLookup := buildReverseLookup(aliases, true)
+	labelLookup := buildReverseLookup(aliases, false)
+
+	// Walk .numbers.yaml files
+	filesDir := filepath.Join(preDir, "files")
+	err = filepath.WalkDir(filesDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable files
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".numbers.yaml") {
+			return nil
+		}
+
+		report.Files++
+		importErr := importOneFile(store, path, filesDir, meta.SchemaVersion, entityLookup, labelLookup, &report)
+		if importErr != nil {
+			report.Errors++
+		}
+		return nil
+	})
+
+	return report, err
+}
+
+func importOneFile(store *Store, path string, filesDir string, schemaVersion string, entityLookup, labelLookup map[string]string, report *ImportReport) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var nf numbersFile
+	if err := yaml.Unmarshal(data, &nf); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	// Infer source_file relative path from the file path
+	relPath, _ := filepath.Rel(filesDir, path)
+	// e.g. inbox/report.pdf.numbers.yaml → inbox/report.pdf
+	sourceRel := strings.TrimSuffix(relPath, ".numbers.yaml")
+
+	return store.db.WriteTx(func(tx *sql.Tx) error {
+		for _, n := range nf.Numbers {
+			entity := normalizeAlias(n.Entity, entityLookup)
+			label := normalizeAlias(n.SemanticLabel, labelLookup)
+
+			qh := ""
+			if n.ExactQuote != "" {
+				h := sha256.Sum256([]byte(n.ExactQuote))
+				qh = fmt.Sprintf("%x", h[:8])
+			}
+
+			sourceFile := "raw/" + sourceRel
+			if n.SourceFile != "" {
+				// If YAML has a source_file field, override with path-derived value
+				// Keep raw/ prefix for manifest consistency
+			}
+
+			result, err := tx.Exec(`
+				INSERT OR IGNORE INTO facts (
+					source_file, value, numeric, sign,
+					number_type, certainty, entity, entity_type,
+					period, period_type, semantic_label,
+					source_location, context_type, exact_quote,
+					verified, extraction_method, schema_version, quote_hash
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				sourceFile, n.Value, n.Numeric, n.Sign,
+				n.NumberType, n.Certainty, entity, n.EntityType,
+				n.Period, n.PeriodType, label,
+				n.SourceLocation, n.ContextType, n.ExactQuote,
+				n.Verified, n.ExtractionMethod, schemaVersion, qh,
+			)
+			if err != nil {
+				return err
+			}
+
+			affected, _ := result.RowsAffected()
+			if affected > 0 {
+				report.Added++
+			} else {
+				report.Skipped++
+			}
+		}
+		return nil
+	})
+}
+
+// buildReverseLookup builds an alias → canonical reverse lookup map.
+func buildReverseLookup(aliases *Aliases, isEntity bool) map[string]string {
+	if aliases == nil {
+		return nil
+	}
+
+	m := make(map[string]string)
+	var source map[string][]string
+	if isEntity {
+		source = aliases.EntityAliases
+	} else {
+		source = aliases.LabelAliases
+	}
+
+	for canonical, aliasList := range source {
+		for _, alias := range aliasList {
+			m[alias] = canonical
+		}
+	}
+	return m
+}
+
+// normalizeAlias looks up the alias map; returns canonical if found, original value otherwise.
+func normalizeAlias(value string, lookup map[string]string) string {
+	if lookup == nil || value == "" {
+		return value
+	}
+	if canonical, ok := lookup[value]; ok {
+		return canonical
+	}
+	return value
+}

--- a/internal/facts/import_test.go
+++ b/internal/facts/import_test.go
@@ -1,0 +1,200 @@
+package facts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+func setupImportTest(t *testing.T) (string, *storage.DB, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Create .pre-extracted directory structure
+	preDir := filepath.Join(dir, ".pre-extracted", "files", "inbox")
+	os.MkdirAll(preDir, 0755)
+
+	// Write extract-meta.yaml
+	metaYAML := `schema_version: "1.0"
+extractor: file-extract
+extractor_version: "0.1.0"
+extracted_at: "2026-04-12T14:30:00"
+`
+	os.WriteFile(filepath.Join(dir, ".pre-extracted", "extract-meta.yaml"), []byte(metaYAML), 0644)
+
+	return dir, db, func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+func writeNumbersYAML(t *testing.T, dir, relPath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(dir, ".pre-extracted", "files", relPath)
+	os.MkdirAll(filepath.Dir(fullPath), 0755)
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", relPath, err)
+	}
+}
+
+func TestImportBasic(t *testing.T) {
+	dir, db, cleanup := setupImportTest(t)
+	defer cleanup()
+
+	numbersYAML := `numbers:
+  - value: "5.2亿元"
+    numeric: 520000000
+    number_type: monetary
+    entity: "希烽光电"
+    entity_type: company
+    period: "2024"
+    period_type: actual
+    semantic_label: "营业收入"
+    source_file: "投资建议书.pdf"
+    source_location: "P5"
+    context_type: paragraph
+    exact_quote: "2024年营业收入5.2亿元"
+    extraction_method: ai_enrichment
+`
+	writeNumbersYAML(t, dir, "inbox/投资建议书.pdf.numbers.yaml", numbersYAML)
+
+	store := NewStore(db)
+	report, err := ImportDir(store, dir, nil)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if report.Added != 1 {
+		t.Errorf("expected 1 added, got %d", report.Added)
+	}
+	if report.Errors != 0 {
+		t.Errorf("expected 0 errors, got %d", report.Errors)
+	}
+
+	results, _ := store.Query(QueryOpts{Entity: "希烽光电"})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(results))
+	}
+	if results[0].Numeric != 520000000 {
+		t.Errorf("expected numeric=520000000, got %f", results[0].Numeric)
+	}
+}
+
+func TestImportUpsertNoDuplicate(t *testing.T) {
+	dir, db, cleanup := setupImportTest(t)
+	defer cleanup()
+
+	numbersYAML := `numbers:
+  - value: "100"
+    numeric: 100
+    entity: "A公司"
+    semantic_label: "营收"
+    exact_quote: "营收100"
+`
+	writeNumbersYAML(t, dir, "inbox/test.pdf.numbers.yaml", numbersYAML)
+
+	store := NewStore(db)
+
+	// Import twice
+	r1, _ := ImportDir(store, dir, nil)
+	r2, _ := ImportDir(store, dir, nil)
+
+	if r1.Added != 1 {
+		t.Errorf("first import: expected 1 added, got %d", r1.Added)
+	}
+	// Second import should skip all (upsert dedup)
+	if r2.Added != 0 {
+		t.Errorf("second import: expected 0 added (dedup), got %d", r2.Added)
+	}
+	if r2.Skipped != 1 {
+		t.Errorf("second import: expected 1 skipped, got %d", r2.Skipped)
+	}
+}
+
+func TestImportCorruptedYAML(t *testing.T) {
+	dir, db, cleanup := setupImportTest(t)
+	defer cleanup()
+
+	writeNumbersYAML(t, dir, "inbox/bad.pdf.numbers.yaml", "not: [valid yaml: {{{")
+
+	store := NewStore(db)
+	report, err := ImportDir(store, dir, nil)
+	if err != nil {
+		t.Fatalf("import should not fail entirely: %v", err)
+	}
+	if report.Errors != 1 {
+		t.Errorf("expected 1 error for corrupt yaml, got %d", report.Errors)
+	}
+}
+
+func TestImportBadSchemaVersion(t *testing.T) {
+	dir, db, cleanup := setupImportTest(t)
+	defer cleanup()
+
+	// Overwrite extract-meta.yaml with incompatible version
+	metaYAML := `schema_version: "99.0"
+extractor: future-tool
+`
+	os.WriteFile(filepath.Join(dir, ".pre-extracted", "extract-meta.yaml"), []byte(metaYAML), 0644)
+
+	numbersYAML := `numbers:
+  - value: "100"
+    numeric: 100
+    entity: "A"
+    semantic_label: "x"
+    exact_quote: "x100"
+`
+	writeNumbersYAML(t, dir, "inbox/test.pdf.numbers.yaml", numbersYAML)
+
+	store := NewStore(db)
+	_, err := ImportDir(store, dir, nil)
+	if err == nil {
+		t.Error("expected error for incompatible schema version")
+	}
+}
+
+func TestImportWithAliases(t *testing.T) {
+	dir, db, cleanup := setupImportTest(t)
+	defer cleanup()
+
+	numbersYAML := `numbers:
+  - value: "200"
+    numeric: 200
+    entity: "XiFeng Optics"
+    semantic_label: "Net Profit"
+    exact_quote: "net profit 200"
+`
+	writeNumbersYAML(t, dir, "inbox/en.pdf.numbers.yaml", numbersYAML)
+
+	aliases := &Aliases{
+		EntityAliases: map[string][]string{
+			"希烽光电": {"XiFeng Optics", "希烽", "XiFeng"},
+		},
+		LabelAliases: map[string][]string{
+			"净利润": {"Net Profit", "Net Income"},
+		},
+	}
+
+	store := NewStore(db)
+	report, err := ImportDir(store, dir, aliases)
+	if err != nil {
+		t.Fatalf("import with aliases: %v", err)
+	}
+	if report.Added != 1 {
+		t.Errorf("expected 1 added, got %d", report.Added)
+	}
+
+	results, _ := store.Query(QueryOpts{Entity: "希烽光电"})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 fact with canonical entity, got %d", len(results))
+	}
+	if results[0].SemanticLabel != "净利润" {
+		t.Errorf("expected label=净利润, got %s", results[0].SemanticLabel)
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -145,6 +145,7 @@ func (db *DB) migrate() error {
 		{sql: migrationV2},
 		{sql: migrationV3},
 		{sql: migrationV4, disableFK: true},
+		{sql: migrationV5},
 	}
 
 	for i := version; i < len(migrations); i++ {
@@ -327,4 +328,37 @@ ALTER TABLE relations_rebuild RENAME TO relations;
 CREATE INDEX IF NOT EXISTS idx_relations_source ON relations(source_id);
 CREATE INDEX IF NOT EXISTS idx_relations_target ON relations(target_id);
 CREATE INDEX IF NOT EXISTS idx_relations_type ON relations(relation);
+`
+
+// migrationV5 adds the facts table for structured numeric data from file-extract.
+const migrationV5 = `
+CREATE TABLE IF NOT EXISTS facts (
+	id              INTEGER PRIMARY KEY AUTOINCREMENT,
+	source_file     TEXT NOT NULL,
+	source_project  TEXT DEFAULT 'local',
+	value           TEXT NOT NULL,
+	numeric         REAL,
+	sign            TEXT DEFAULT 'positive',
+	number_type     TEXT,
+	certainty       TEXT DEFAULT 'exact',
+	entity          TEXT DEFAULT 'unknown',
+	entity_type     TEXT,
+	period          TEXT DEFAULT 'unknown',
+	period_type     TEXT DEFAULT 'unknown',
+	semantic_label  TEXT,
+	source_location TEXT,
+	context_type    TEXT,
+	exact_quote     TEXT,
+	verified        BOOLEAN DEFAULT 0,
+	extraction_method TEXT,
+	schema_version  TEXT,
+	imported_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
+	quote_hash      TEXT,
+	UNIQUE(source_file, entity, semantic_label, period, numeric, quote_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_entity ON facts(entity);
+CREATE INDEX IF NOT EXISTS idx_facts_period ON facts(period);
+CREATE INDEX IF NOT EXISTS idx_facts_source ON facts(source_file);
+CREATE INDEX IF NOT EXISTS idx_facts_label  ON facts(semantic_label);
 `

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -23,12 +23,12 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("query schema_version: %v", err)
 	}
-	if version != 4 {
-		t.Errorf("expected schema version 4, got %d", version)
+	if version != 5 {
+		t.Errorf("expected schema version 5, got %d", version)
 	}
 
 	// Verify tables exist
-	tables := []string{"entries", "vec_entries", "entities", "relations", "learnings", "chunks_meta", "chunks_fts", "vec_chunks"}
+	tables := []string{"entries", "vec_entries", "entities", "relations", "learnings", "chunks_meta", "chunks_fts", "vec_chunks", "facts"}
 	for _, table := range tables {
 		var name string
 		err := db.ReadDB().QueryRow(
@@ -62,8 +62,8 @@ func TestIdempotentMigration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if count != 4 {
-		t.Errorf("expected 4 schema_version rows, got %d", count)
+	if count != 5 {
+		t.Errorf("expected 5 schema_version rows, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `.pre-extracted/` file-based contract for external extraction tools
- Confidence-based fallback (low confidence → built-in Go extraction)
- Facts table (migrationV5): structured numeric data with 21-column schema
- Idempotent import via SHA-256 quote_hash dedup
- Entity alias normalization from config-driven alias map

## Design highlights
- **File-based contract**: Zero runtime coupling between file-extract and sage-wiki
- **21-column schema justified**: entity, period, period_type, semantic_label, certainty, sign etc. needed for financial/regulatory data
- **quote_hash dedup**: INSERT OR IGNORE with SHA-256 of exact quote makes re-import idempotent

Replaces pre-extract and facts storage portions of #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)