### PR TITLE
fix: explicitly set stream:false in OpenAI non-streaming requests

### DIFF
--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -46,9 +46,7 @@ func (p *openaiProvider) formatBody(messages []Message, opts CallOpts, stream bo
 		"model":    opts.Model,
 		"messages": apiMessages,
 	}
-	if stream {
-		body["stream"] = true
-	}
+	body["stream"] = stream
 	if opts.MaxTokens > 0 {
 		body["max_tokens"] = opts.MaxTokens
 	}


### PR DESCRIPTION
## Summary

- Non-streaming requests omitted the `stream` field entirely, relying on the API server to default to non-streaming
- Some OpenAI-compatible proxies (e.g., OmniRoute, LiteLLM) default to streaming for certain providers when `stream` is absent
- This causes `"invalid character 'd' looking for beginning of value"` parse errors — the client receives SSE `data: {...}` chunks instead of a JSON object
- Fix: always set `stream: false` explicitly on non-streaming requests

One-line change in `internal/llm/openai.go`.

## Test plan

- [x] `go build ./...`
- [x] Verified against OmniRoute proxy routing to Anthropic Claude — non-streaming responses now return valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)