### PR TITLE
feat: inject raw source content into article write prompts

### DIFF
--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -400,6 +400,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 					RelationPatterns: relPatterns,
 					ChunkSize:        cfg.Search.ChunkSizeOrDefault(),
 					Language:         cfg.Language,
+					SourceDirs:       cfg.ResolveSources(projectDir),
 				}, concepts)
 
 				for _, ar := range articles {
@@ -822,6 +823,7 @@ func resumeBatch(
 					RelationPatterns: relPatterns,
 					ChunkSize:        cfg.Search.ChunkSizeOrDefault(),
 					Language:         cfg.Language,
+					SourceDirs:       cfg.ResolveSources(projectDir),
 				}, concepts)
 
 				for _, ar := range articles {

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -49,6 +49,7 @@ type ArticleWriteOpts struct {
 	RelationPatterns []ontology.RelationPattern
 	ChunkSize        int // tokens per chunk (default 800)
 	Language         string
+	SourceDirs       []string // resolved source directories for fallback file lookup
 }
 
 // WriteArticles runs Pass 3: write concept articles with ontology edges.
@@ -99,6 +100,42 @@ func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept) ArticleRes
 		existingContent = string(data)
 	}
 
+	// Load raw source files for grounding
+	var sourceContent strings.Builder
+	for _, src := range concept.Sources {
+		rawPath := filepath.Join(opts.ProjectDir, src)
+		data, err := os.ReadFile(rawPath)
+		if err != nil {
+			// Fallback: search by basename in configured source directories
+			base := filepath.Base(src)
+			for _, srcDir := range opts.SourceDirs {
+				_ = filepath.WalkDir(srcDir, func(path string, d os.DirEntry, walkErr error) error {
+					if walkErr != nil || d.IsDir() {
+						return nil
+					}
+					if filepath.Base(path) == base {
+						if found, readErr := os.ReadFile(path); readErr == nil {
+							data = found
+							if rel, relErr := filepath.Rel(opts.ProjectDir, path); relErr == nil {
+								src = rel
+							}
+						}
+						return filepath.SkipAll
+					}
+					return nil
+				})
+				if data != nil {
+					break
+				}
+			}
+		}
+		if data != nil {
+			sourceContent.WriteString("### Source: " + src + "\n")
+			sourceContent.Write(data)
+			sourceContent.WriteString("\n\n")
+		}
+	}
+
 	// Build prompt
 	relatedNames := findRelatedConcepts(concept)
 	prompt, err := prompts.Render("write_article", prompts.WriteArticleData{
@@ -112,6 +149,7 @@ func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept) ArticleRes
 		RelatedList:     strings.Join(relatedNames, ", "),
 		Confidence:      "medium",
 		MaxTokens:       opts.MaxTokens,
+		SourceContent:   sourceContent.String(),
 	}, opts.Language)
 	if err != nil {
 		result.Error = fmt.Errorf("render write_article prompt: %w", err)

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -199,6 +199,7 @@ type WriteArticleData struct {
 	RelatedList     string
 	Confidence      string
 	MaxTokens       int
+	SourceContent   string // raw source content injected for grounding
 }
 
 // CaptionData holds data for image captioning template.

--- a/internal/prompts/templates/write_article.txt
+++ b/internal/prompts/templates/write_article.txt
@@ -19,13 +19,16 @@ Related concepts: {{.RelatedList}}
 {{.Learnings}}
 {{end}}
 
-Write a structured wiki article. When source material is provided above, ground your article in it — prefer specific details from the source over general knowledge.
+Write a structured wiki article with:
 
 ## Definition
 Clear, precise definition of the concept.
 
-## What we know
-Key facts, findings, or implementation details from the sources.
+## How it works
+Technical explanation with appropriate depth.
+
+## Variants
+Known variants, implementations, or alternatives.
 
 ## Trade-offs
 Key trade-offs, limitations, or considerations.

--- a/internal/prompts/templates/write_article.txt
+++ b/internal/prompts/templates/write_article.txt
@@ -4,6 +4,11 @@ Concept: {{.ConceptName}}
 Sources: {{.Sources}}
 Related concepts: {{.RelatedList}}
 
+{{if .SourceContent}}
+## Source material:
+{{.SourceContent}}
+{{end}}
+
 {{if .ExistingArticle}}
 ## Existing article (update/expand):
 {{.ExistingArticle}}
@@ -14,16 +19,13 @@ Related concepts: {{.RelatedList}}
 {{.Learnings}}
 {{end}}
 
-Write a structured wiki article with:
+Write a structured wiki article. When source material is provided above, ground your article in it — prefer specific details from the source over general knowledge.
 
 ## Definition
 Clear, precise definition of the concept.
 
-## How it works
-Technical explanation with appropriate depth.
-
-## Variants
-Known variants, implementations, or alternatives.
+## What we know
+Key facts, findings, or implementation details from the sources.
 
 ## Trade-offs
 Key trade-offs, limitations, or considerations.


### PR DESCRIPTION
## Summary

- Articles were written from concept name + metadata only — the LLM never saw the actual source text in Pass 3
- This caused hallucination when concepts had suggestive names but sparse source material (e.g., a one-line AC entry would generate a full technical explanation)
- Inject raw source files into the write prompt via new `{{.SourceContent}}` template variable
- Add basename fallback for stale source paths (files moved after extraction still get found)
- Use raw source files, not summaries — summaries are already an interpretation and invite gap-filling

Related to PR #24 (which injects summaries). This takes a different approach: raw source files give the LLM the unfiltered original to ground against. Projects can customize grounding strictness via `prompts/write-article.md` overrides.

## Changes

| File | Change |
|------|--------|
| `prompts.go` | Add `SourceContent` field to `WriteArticleData` |
| `write.go` | Load raw source files with basename fallback, pass to template |
| `pipeline.go` | Wire `SourceDirs` from `cfg.ResolveSources()` |
| `write_article.txt` | Add `{{.SourceContent}}` section to default template |

## Test plan

- [x] `go build ./...`
- [x] Compile with Sonnet via OmniRoute — articles with source content are grounded, previously-hallucinated articles now match source
- [x] Basename fallback verified: moved files found by scanning source directories
- [x] Backwards compatible: `{{.SourceContent}}` is empty string when no sources found, existing custom prompts without it still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)