### PR TITLE
feat: Add support for the qwen model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ sage/
 # Build
 /sage-wiki
 bin/__pycache__/
+.idea

--- a/README.md
+++ b/README.md
@@ -202,10 +202,13 @@ output: wiki # compiled output directory (_wiki for vault overlay)
 #   - Personal
 
 # LLM provider
-# Supported: anthropic, openai, gemini, ollama, openai-compatible
+# Supported: anthropic, openai, gemini, ollama, openai-compatible, qwen
 # For OpenRouter or other OpenAI-compatible providers:
 #   provider: openai-compatible
 #   base_url: https://openrouter.ai/api/v1
+# For Alibaba Cloud DashScope Qwen:
+#   provider: qwen
+#   api_key: ${DASHSCOPE_API_KEY}
 api:
   provider: gemini
   api_key: ${GEMINI_API_KEY} # env var expansion supported

--- a/README_zh.md
+++ b/README_zh.md
@@ -202,10 +202,13 @@ output: wiki # 编译输出目录 (vault 覆盖模式下为 _wiki)
 #   - Personal
 
 # LLM 提供商
-# 支持: anthropic, openai, gemini, ollama, openai-compatible
+# 支持: anthropic, openai, gemini, ollama, openai-compatible, qwen
 # OpenRouter 或其他 OpenAI 兼容提供商:
 #   provider: openai-compatible
 #   base_url: https://openrouter.ai/api/v1
+# 阿里云 DashScope Qwen:
+#   provider: qwen
+#   api_key: ${DASHSCOPE_API_KEY}
 api:
   provider: gemini
   api_key: ${GEMINI_API_KEY} # 支持环境变量展开

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -443,10 +443,10 @@ func (c *Config) Validate() error {
 	}
 	if c.API.Provider != "" {
 		validProviders := map[string]bool{
-			"anthropic": true, "openai": true, "gemini": true, "ollama": true, "openai-compatible": true,
+			"anthropic": true, "openai": true, "gemini": true, "ollama": true, "openai-compatible": true, "qwen": true,
 		}
 		if !validProviders[c.API.Provider] {
-			return fmt.Errorf("config: invalid provider %q (valid: anthropic, openai, gemini, ollama, openai-compatible)", c.API.Provider)
+			return fmt.Errorf("config: invalid provider %q (valid: anthropic, openai, gemini, ollama, openai-compatible, qwen)", c.API.Provider)
 		}
 	}
 	if c.Serve.Transport != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,10 @@ func TestValidation(t *testing.T) {
 			wantErr: "invalid provider",
 		},
 		{
+			name: "valid qwen provider",
+			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, API: APIConfig{Provider: "qwen"}},
+		},
+		{
 			name:    "invalid transport",
 			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Serve: ServeConfig{Transport: "websocket"}},
 			wantErr: "invalid transport",

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -216,6 +216,11 @@ func newProvider(name string, apiKey string, baseURL string) (Provider, error) {
 	switch name {
 	case "openai", "openai-compatible":
 		return newOpenAIProvider(apiKey, baseURL), nil
+	case "qwen":
+		if baseURL == "" {
+			baseURL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+		}
+		return newOpenAIProvider(apiKey, baseURL), nil
 	case "anthropic":
 		return newAnthropicProvider(apiKey, baseURL), nil
 	case "gemini":
@@ -235,6 +240,8 @@ func defaultRateLimit(provider string) int {
 	case "anthropic":
 		return 50
 	case "openai":
+		return 60
+	case "qwen":
 		return 60
 	case "gemini":
 		return 60

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -249,6 +249,16 @@ func TestOllamaUsesOpenAIFormat(t *testing.T) {
 	}
 }
 
+func TestQwenUsesOpenAIFormatWithDefaultBaseURL(t *testing.T) {
+	client, err := NewClient("qwen", "sk-test", "", 0)
+	if err != nil {
+		t.Fatalf("NewClient qwen: %v", err)
+	}
+	if client.ProviderName() != "openai" {
+		t.Errorf("qwen should use openai provider, got %s", client.ProviderName())
+	}
+}
+
 func TestStripThinkTags(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/llm/cost.go
+++ b/internal/llm/cost.go
@@ -142,7 +142,7 @@ func (ct *CostTracker) getPrice(model string) ModelPrice {
 	providerPrices, ok := prices[ct.provider]
 	if !ok {
 		// Try to match openai-compatible to openai prices
-		if ct.provider == "openai-compatible" {
+		if ct.provider == "openai-compatible" || ct.provider == "qwen" {
 			providerPrices = prices["openai"]
 		}
 	}

--- a/internal/wiki/init.go
+++ b/internal/wiki/init.go
@@ -188,10 +188,13 @@ sources:
 output: wiki
 
 # LLM provider configuration
-# Supported: anthropic, openai, gemini, ollama, openai-compatible
+# Supported: anthropic, openai, gemini, ollama, openai-compatible, qwen
 # For OpenRouter or other OpenAI-compatible providers, set:
 #   provider: openai-compatible
 #   base_url: https://openrouter.ai/api/v1
+# For Alibaba Cloud DashScope Qwen, set:
+#   provider: qwen
+#   api_key: ${DASHSCOPE_API_KEY}
 api:
   provider: gemini
   api_key: ${GEMINI_API_KEY}
@@ -275,10 +278,13 @@ output: %s
 ignore:
 %s
 # LLM provider configuration
-# Supported: anthropic, openai, gemini, ollama, openai-compatible
+# Supported: anthropic, openai, gemini, ollama, openai-compatible, qwen
 # For OpenRouter or other OpenAI-compatible providers, set:
 #   provider: openai-compatible
 #   base_url: https://openrouter.ai/api/v1
+# For Alibaba Cloud DashScope Qwen, set:
+#   provider: qwen
+#   api_key: ${DASHSCOPE_API_KEY}
 api:
   provider: gemini
   api_key: ${GEMINI_API_KEY}


### PR DESCRIPTION
## 描述 (Description)
本 PR **新增「Qwen（阿里云 DashScope）」LLM 提供方支持**，用于在 `sage-wiki` 中直接使用千问模型完成摘要、概念提取、文章生成与问答检索等流程。  
主要变更包括：
- **配置能力**：新增 `api.provider: qwen`，支持通过 `DASHSCOPE_API_KEY` 鉴权。
- **模型接入**：支持在 `models` 中配置 Qwen 模型（如 `qwen-plus`），并可按任务维度（summarize/extract/write/lint/query）分别指定。
- **请求链路**：在现有 LLM 调用链中接入 Qwen provider 的请求构建、鉴权与响应处理，保持与既有 provider 行为一致。
- **兼容性处理**：对配置读取与 provider 分发逻辑做兼容，确保未使用 Qwen 的现有用户行为不受影响。

## 变更类型 (Type of Change)
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] 💥 破坏性变更 (Breaking change)
- [x] 📚 文档更新 (Documentation update)
- [ ] 🎨 代码重构 (Code refactoring)
- [ ] ⚡ 性能优化 (Performance improvement)
- [ ] 🧪 测试相关 (Test related)
- [x] 🔧 配置变更 (Configuration change)
- [ ] 🐳 Docker 相关 (Docker related)
- [ ] 🎨 前端 UI/UX (Frontend UI/UX)

## 影响范围 (Scope)
- [x] 后端 API (Backend API)
- [ ] 前端界面 (Frontend UI)
- [ ] 数据库 (Database)
- [ ] 文档解析服务 (Document Reader Service)
- [ ] MCP 服务器 (MCP Server)
- [ ] Docker 配置 (Docker Configuration)
- [x] 配置文件 (Configuration)
- [x] 其他 (Other)

## 测试 (Testing)
- [x] 单元测试 (Unit tests)
- [ ] 集成测试 (Integration tests)
- [x] 手动测试 (Manual testing)
- [ ] 前端测试 (Frontend testing)
- [x] API 测试 (API testing)

### 测试步骤 (Test Steps)
1. 在 `config.yaml` 中配置：
   - `api.provider: qwen`
   - `api.api_key: ${DASHSCOPE_API_KEY}`
   - `models.*: qwen-plus`（或其他可用 Qwen 模型）
2. 执行 `sage-wiki compile --no-cache`，确认可正常完成 summarize / extract / write 全流程。
3. 执行 `sage-wiki search "<关键词>"` 与 `sage-wiki query "<问题>"`，确认检索与问答链路正常。
4. 将 provider 改回其他已支持提供方（如 gemini/openai），确认原有链路无回归。

## 检查清单 (Checklist)
- [x] 代码遵循项目的编码规范
- [x] 已进行自我代码审查
- [ ] 代码变更已添加适当的注释
- [x] 相关文档已更新
- [x] 变更不会产生新的警告
- [ ] 已添加测试用例证明修复有效或功能正常
- [x] 新功能和变更已更新到相关文档
- [ ] 破坏性变更已在描述中明确说明

## 相关 Issue
Fixes #

## 截图/录屏 (Screenshots/Recordings)
<img width="1919" height="1054" alt="image" src="https://github.com/user-attachments/assets/ee642041-273f-4482-b1ef-145d6849efe7" />
<img width="1546" height="639" alt="image" src="https://github.com/user-attachments/assets/3ab35984-ebc6-4d0c-a671-e5d07418feff" />
配置
<img width="673" height="265" alt="image" src="https://github.com/user-attachments/assets/b6e6f536-1f59-4fac-8d06-40ffa819daa1" />

## 数据库迁移 (Database Migration)
- [ ] 需要数据库迁移
- [x] 不需要数据库迁移

## 配置变更 (Configuration Changes)
新增 provider 配置用法：
- `api.provider: qwen`
- `api.api_key: ${DASHSCOPE_API_KEY}`
- `models.<task>: qwen-*`

## 部署说明 (Deployment Notes)
常规部署即可。  
如使用 Qwen，请在运行环境注入 `DASHSCOPE_API_KEY` 环境变量，并确保模型名为账号可用模型。

## 其他信息 (Additional Information)
- 成本估算可能提示 `unknown model pricing`，仅影响估算精度，不影响功能可用性。
- 若未配置 embedding provider，向量检索会降级为 BM25（不影响基础搜索与编译主链路）。