### PR TITLE
feat(llm): add Gemini batch API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ compiler:
   debounce_seconds: 2 # watch mode debounce
   summary_max_tokens: 2000
   article_max_tokens: 4000
+  # extract_batch_size: 20     # summaries per concept-extraction call (reduce to avoid JSON truncation on large corpora)
+  # extract_max_tokens: 8192   # max output tokens for concept extraction (increase to 16384 if extraction is truncating)
   auto_commit: true # git commit after compile
   auto_lint: true # run lint after compile
   mode: auto # standard, batch, or auto (auto = batch when 10+ sources)

--- a/README_zh.md
+++ b/README_zh.md
@@ -240,6 +240,8 @@ compiler:
   debounce_seconds: 2 # watch 模式防抖
   summary_max_tokens: 2000
   article_max_tokens: 4000
+  # extract_batch_size: 20     # 每次概念提取调用的摘要数 (大语料库时减小以避免 JSON 截断)
+  # extract_max_tokens: 8192   # 概念提取的最大输出 token 数 (截断时可调大至 16384)
   auto_commit: true # 编译后自动 git commit
   auto_lint: true # 编译后自动 lint
   mode: auto # standard, batch 或 auto (auto = 10+ 源文件时自动 batch)

--- a/internal/compiler/concepts.go
+++ b/internal/compiler/concepts.go
@@ -22,14 +22,20 @@ type ExtractedConcept struct {
 // ExtractConcepts runs Pass 2: concept extraction from summaries.
 // It takes new/updated summaries and the existing concept list,
 // asks the LLM to identify and deduplicate concepts.
-const conceptBatchSize = 20 // summaries per LLM call
-
 func ExtractConcepts(
 	summaries []SummaryResult,
 	existingConcepts map[string]manifest.Concept,
 	client *llm.Client,
 	model string,
+	batchSize int,
+	maxTokens int,
 ) ([]ExtractedConcept, error) {
+	if batchSize <= 0 {
+		batchSize = 20
+	}
+	if maxTokens <= 0 {
+		maxTokens = 8192
+	}
 	if len(summaries) == 0 {
 		return nil, nil
 	}
@@ -54,14 +60,14 @@ func ExtractConcepts(
 	// Process in batches
 	var allConcepts []ExtractedConcept
 
-	for i := 0; i < len(validSummaries); i += conceptBatchSize {
-		end := i + conceptBatchSize
+	for i := 0; i < len(validSummaries); i += batchSize {
+		end := i + batchSize
 		if end > len(validSummaries) {
 			end = len(validSummaries)
 		}
 		batch := validSummaries[i:end]
 
-		log.Info("extracting concepts batch", "batch", i/conceptBatchSize+1, "summaries", len(batch), "total", len(validSummaries))
+		log.Info("extracting concepts batch", "batch", i/batchSize+1, "summaries", len(batch), "total", len(validSummaries))
 
 		var summaryTexts []string
 		for _, s := range batch {
@@ -85,27 +91,27 @@ func ExtractConcepts(
 			Summaries:        strings.Join(summaryTexts, "\n\n---\n\n"),
 		}, "")
 		if err != nil {
-			log.Error("render extract_concepts prompt failed", "batch", i/conceptBatchSize+1, "error", err)
+			log.Error("render extract_concepts prompt failed", "batch", i/batchSize+1, "error", err)
 			continue
 		}
 
 		resp, err := client.ChatCompletion([]llm.Message{
 			{Role: "system", Content: "You are a concept extraction system for a knowledge wiki. Output valid JSON only."},
 			{Role: "user", Content: prompt},
-		}, llm.CallOpts{Model: model, MaxTokens: 8192})
+		}, llm.CallOpts{Model: model, MaxTokens: maxTokens})
 		if err != nil {
-			log.Error("concept extraction batch failed", "batch", i/conceptBatchSize+1, "error", err)
+			log.Error("concept extraction batch failed", "batch", i/batchSize+1, "error", err)
 			continue // skip failed batch, continue with others
 		}
 
 		concepts, err := parseConceptsJSON(resp.Content)
 		if err != nil {
-			log.Error("concept extraction parse failed", "batch", i/conceptBatchSize+1, "error", err)
+			log.Error("concept extraction parse failed", "batch", i/batchSize+1, "error", err)
 			continue
 		}
 
 		allConcepts = append(allConcepts, concepts...)
-		log.Info("batch concepts extracted", "batch", i/conceptBatchSize+1, "count", len(concepts))
+		log.Info("batch concepts extracted", "batch", i/batchSize+1, "count", len(concepts))
 	}
 
 	// Filter noise

--- a/internal/compiler/fullpipeline.go
+++ b/internal/compiler/fullpipeline.go
@@ -180,7 +180,7 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 		extCacheID, _ = client.SetupCache("You are an expert knowledge organizer. Extract structured concepts from source summaries.", extractModel)
 	}
 	progress.StartPhase("Pass 2: Extract concepts", len(successfulSummaries))
-	concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, extractModel)
+	concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
 	if err != nil {
 		progress.ItemError("concept extraction", err)
 		result.Errors++

--- a/internal/compiler/index.go
+++ b/internal/compiler/index.go
@@ -1,6 +1,8 @@
 package compiler
 
 import (
+	"database/sql"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -11,6 +13,7 @@ import (
 	"github.com/xoai/sage-wiki/internal/llm"
 	"github.com/xoai/sage-wiki/internal/log"
 	"github.com/xoai/sage-wiki/internal/memory"
+	"github.com/xoai/sage-wiki/internal/storage"
 	"github.com/xoai/sage-wiki/internal/vectors"
 )
 
@@ -78,6 +81,9 @@ func indexAndEmbedSources(
 	embedder embed.Embedder,
 	items *CompileItemStore,
 	bp *BackpressureController,
+	chunkStore *memory.ChunkStore,
+	chunkSize int,
+	db *storage.DB,
 ) (indexed, embedded int) {
 	// Step 1: FTS5 index any sources not yet indexed
 	for _, src := range sources {
@@ -135,6 +141,10 @@ func indexAndEmbedSources(
 		return indexed, 0
 	}
 
+	if chunkSize <= 0 {
+		chunkSize = 800
+	}
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	embeddedCount := 0
@@ -167,24 +177,78 @@ func indexAndEmbedSources(
 				return
 			}
 
-			vec, err := embedder.Embed(content.Text)
-			if err != nil {
-				if bp != nil && llm.IsRateLimitError(err) {
-					delay := bp.OnRateLimit()
-					log.Warn("embedding rate limited", "delay", delay)
-				}
-				log.Warn("tier 1 embed: embedding failed", "path", s.SourcePath, "error", err)
-				if merr := items.MarkError(s.SourcePath, err); merr != nil {
-					log.Warn("mark error failed", "path", s.SourcePath, "error", merr)
-				}
+			if content.Text == "" {
 				return
 			}
 
-			if bp != nil {
-				bp.OnSuccess()
+			chunks := extract.ChunkText(content.Text, chunkSize)
+
+			// Embed each chunk sequentially (same pattern as write.go:250-260)
+			chunkEmbeddings := make([][]float32, len(chunks))
+			for i, c := range chunks {
+				vec, err := embedder.Embed(c.Text)
+				if err != nil {
+					if bp != nil && llm.IsRateLimitError(err) {
+						delay := bp.OnRateLimit()
+						log.Warn("embedding rate limited", "delay", delay)
+					}
+					log.Warn("tier 1 chunk embed failed", "path", s.SourcePath, "chunk", i, "error", err)
+					continue
+				}
+				chunkEmbeddings[i] = vec
+				if bp != nil {
+					bp.OnSuccess()
+				}
 			}
 
-			vecStore.Upsert("src:"+s.SourcePath, vec)
+			docID := "src:" + s.SourcePath
+
+			if chunkStore != nil && db != nil {
+				// Clean up legacy whole-document vector
+				vecStore.Delete(docID)
+
+				if err := db.WriteTx(func(tx *sql.Tx) error {
+					if err := chunkStore.DeleteDocChunks(tx, docID); err != nil {
+						return err
+					}
+
+					entries := make([]memory.ChunkEntry, len(chunks))
+					for i, c := range chunks {
+						entries[i] = memory.ChunkEntry{
+							ChunkID:    fmt.Sprintf("%s:c%d", docID, i),
+							ChunkIndex: c.Index,
+							Heading:    c.Heading,
+							Content:    c.Text,
+						}
+					}
+
+					if err := chunkStore.IndexChunks(tx, docID, entries); err != nil {
+						return err
+					}
+
+					for i, emb := range chunkEmbeddings {
+						if emb != nil {
+							if err := vecStore.UpsertChunk(tx, entries[i].ChunkID, docID, emb); err != nil {
+								log.Warn("tier 1 chunk vector upsert failed", "chunk", entries[i].ChunkID, "error", err)
+							}
+						}
+					}
+
+					return nil
+				}); err != nil {
+					log.Error("tier 1 chunk indexing failed", "path", s.SourcePath, "error", err)
+					if merr := items.MarkError(s.SourcePath, err); merr != nil {
+						log.Warn("mark error failed", "path", s.SourcePath, "error", merr)
+					}
+					return
+				}
+			} else {
+				// Fallback: single-vector embed (legacy path when chunk infra unavailable)
+				if len(chunkEmbeddings) > 0 && chunkEmbeddings[0] != nil {
+					vecStore.Upsert(docID, chunkEmbeddings[0])
+				}
+			}
+
 			if err := items.MarkPass(s.SourcePath, "embedded"); err != nil {
 				log.Warn("mark pass failed", "path", s.SourcePath, "pass", "embedded", "error", err)
 			}

--- a/internal/compiler/index_test.go
+++ b/internal/compiler/index_test.go
@@ -3,9 +3,12 @@ package compiler
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/xoai/sage-wiki/internal/memory"
+	"github.com/xoai/sage-wiki/internal/storage"
+	"github.com/xoai/sage-wiki/internal/vectors"
 )
 
 func TestIndexRawSources_SkipsCompiledEntry(t *testing.T) {
@@ -103,5 +106,158 @@ func TestIndexRawSources_IndexesNewSource(t *testing.T) {
 	srcEntry, _ := memStore.Get("src:" + srcPath)
 	if srcEntry == nil {
 		t.Error("expected 'src:' entry for new source")
+	}
+}
+
+func TestIndexAndEmbedSources_ChunkLongSource(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build text with paragraph breaks so splitByParagraphs can split it
+	var sb strings.Builder
+	for i := 0; i < 200; i++ {
+		sb.WriteString("The quick brown fox jumps over the lazy dog. This sentence adds more tokens to ensure chunking works correctly across paragraph boundaries.")
+		if i%5 == 4 {
+			sb.WriteString("\n\n")
+		} else {
+			sb.WriteString(" ")
+		}
+	}
+	longText := sb.String()
+	srcDir := filepath.Join(dir, "raw")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "long.md"), []byte(longText), 0644)
+
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	memStore := memory.NewStore(db)
+	vecStore := vectors.NewStore(db)
+	chunkStore := memory.NewChunkStore(db)
+	itemStore := NewCompileItemStore(db)
+	embedder := &mockEmbedder{embeddings: map[string][]float32{}}
+
+	sources := []CompileItem{{SourcePath: "raw/long.md", FileType: "article"}}
+
+	indexed, embedded := indexAndEmbedSources(dir, sources, memStore, vecStore, embedder, itemStore, nil, chunkStore, 800, db)
+
+	if indexed != 1 {
+		t.Errorf("expected 1 indexed, got %d", indexed)
+	}
+	if embedded != 1 {
+		t.Errorf("expected 1 embedded, got %d", embedded)
+	}
+
+	results, err := chunkStore.SearchChunks("quick brown fox", 10)
+	if err != nil {
+		t.Fatalf("chunk search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected chunk search results for long source")
+	}
+	if results[0].DocID != "src:raw/long.md" {
+		t.Errorf("expected doc_id 'src:raw/long.md', got %q", results[0].DocID)
+	}
+
+	// Count chunk vectors and FTS entries
+	var chunkVecCount int
+	db.ReadDB().QueryRow("SELECT COUNT(*) FROM vec_chunks").Scan(&chunkVecCount)
+	var chunkFTSCount int
+	db.ReadDB().QueryRow("SELECT COUNT(*) FROM chunks_meta WHERE doc_id = ?", "src:raw/long.md").Scan(&chunkFTSCount)
+	t.Logf("chunk vectors: %d, chunk FTS entries: %d", chunkVecCount, chunkFTSCount)
+	if chunkFTSCount < 2 {
+		t.Errorf("expected multiple chunks for long source, got %d", chunkFTSCount)
+	}
+}
+
+func TestIndexAndEmbedSources_ShortSource(t *testing.T) {
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "raw")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "short.md"), []byte("Short document content."), 0644)
+
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	memStore := memory.NewStore(db)
+	vecStore := vectors.NewStore(db)
+	chunkStore := memory.NewChunkStore(db)
+	itemStore := NewCompileItemStore(db)
+	embedder := &mockEmbedder{embeddings: map[string][]float32{}}
+
+	sources := []CompileItem{{SourcePath: "raw/short.md", FileType: "article"}}
+	_, embedded := indexAndEmbedSources(dir, sources, memStore, vecStore, embedder, itemStore, nil, chunkStore, 800, db)
+
+	if embedded != 1 {
+		t.Errorf("expected 1 embedded, got %d", embedded)
+	}
+
+	vecResults, _ := vecStore.SearchChunks([]float32{0.1, 0.2, 0.3, 0.4}, 10)
+	if len(vecResults) != 1 {
+		t.Errorf("expected 1 chunk vector for short source, got %d", len(vecResults))
+	}
+}
+
+func TestIndexAndEmbedSources_EmptyText(t *testing.T) {
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "raw")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "empty.md"), []byte(""), 0644)
+
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	memStore := memory.NewStore(db)
+	vecStore := vectors.NewStore(db)
+	chunkStore := memory.NewChunkStore(db)
+	itemStore := NewCompileItemStore(db)
+	embedder := &mockEmbedder{embeddings: map[string][]float32{}}
+
+	sources := []CompileItem{{SourcePath: "raw/empty.md", FileType: "article"}}
+	_, embedded := indexAndEmbedSources(dir, sources, memStore, vecStore, embedder, itemStore, nil, chunkStore, 800, db)
+
+	if embedded != 0 {
+		t.Errorf("expected 0 embedded for empty source, got %d", embedded)
+	}
+}
+
+func TestIndexAndEmbedSources_NilChunkStore(t *testing.T) {
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "raw")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "doc.md"), []byte("Some content for embedding."), 0644)
+
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	memStore := memory.NewStore(db)
+	vecStore := vectors.NewStore(db)
+	itemStore := NewCompileItemStore(db)
+	embedder := &mockEmbedder{embeddings: map[string][]float32{}}
+
+	sources := []CompileItem{{SourcePath: "raw/doc.md", FileType: "article"}}
+	_, embedded := indexAndEmbedSources(dir, sources, memStore, vecStore, embedder, itemStore, nil, nil, 800, nil)
+
+	if embedded != 1 {
+		t.Errorf("expected 1 embedded (legacy path), got %d", embedded)
+	}
+
+	vec, err := vecStore.Get("src:raw/doc.md")
+	if err != nil || vec == nil {
+		t.Error("expected legacy vector in vec_entries")
 	}
 }

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -740,7 +740,7 @@ func resumeBatch(
 		client.SetPass("extract")
 		extCacheID, _ := client.SetupCache("You are an expert knowledge organizer. Extract structured concepts from source summaries.", model)
 		progress.StartPhase("Pass 2: Extract concepts", len(successfulSummaries))
-		concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, model)
+		concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, model, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
 		if err != nil {
 			progress.ItemError("concept extraction", err)
 			result.Errors++

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -273,7 +273,7 @@ func Compile(projectDir string, opts CompileOpts) (*CompileResult, error) {
 	tier1Pending, _ := itemStore.ListPending(1)
 	if len(tier1Pending) > 0 {
 		progress.StartPhase("Tier 1: Index + embed sources", len(tier1Pending))
-		indexed, embedded := indexAndEmbedSources(projectDir, tier1Pending, memStore, vecStore, embedder, itemStore, bp)
+		indexed, embedded := indexAndEmbedSources(projectDir, tier1Pending, memStore, vecStore, embedder, itemStore, bp, chunkStore, cfg.Search.ChunkSizeOrDefault(), db)
 		result.TierIndexed += indexed
 		result.TierEmbedded = embedded
 		log.Info("tier 1 indexing complete", "indexed", indexed, "embedded", embedded)

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -94,7 +94,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	}
 
 	log.Info("Pass 2: extracting concepts", "from_summaries", len(summaries))
-	concepts, err := ExtractConcepts(summaries, mf.Concepts, client, extractModel)
+	concepts, err := ExtractConcepts(summaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
 	if err != nil {
 		return nil, fmt.Errorf("re-extract: concept extraction: %w", err)
 	}

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -137,41 +137,6 @@ func summarizeOne(
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
 
-	// Skip LLM call if a valid summary file already exists on disk with a matching
-	// source hash. Restores resume-from-checkpoint behavior when compile-state.json is
-	// missing (e.g. a prior failed run cleared it). The source_hash field in the
-	// frontmatter guards against serving stale summaries for modified sources.
-	baseName := strings.TrimSuffix(filepath.Base(info.Path), filepath.Ext(info.Path))
-	summaryPath := filepath.Join(outputDir, "summaries", baseName+".md")
-	absSummary := filepath.Join(projectDir, summaryPath)
-	if existing, err := os.ReadFile(absSummary); err == nil {
-		body := string(existing)
-		// Parse source_hash from YAML frontmatter and verify it matches the current
-		// source file. This prevents stale summaries being served for modified sources.
-		var storedHash string
-		if strings.HasPrefix(body, "---\n") {
-			if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
-				frontmatter := body[4 : 4+end]
-				for _, line := range strings.Split(frontmatter, "\n") {
-					if strings.HasPrefix(line, "source_hash: ") {
-						storedHash = strings.TrimPrefix(line, "source_hash: ")
-						break
-					}
-				}
-				body = body[4+end+5:]
-			}
-		}
-		body = strings.TrimSpace(body)
-		if len(body) >= 100 && storedHash == info.Hash {
-			log.Info("reusing existing summary", "path", info.Path)
-			result.Summary = body
-			result.SummaryPath = summaryPath
-			// Note: result.Concepts is left nil; concept extraction runs separately
-			// in Pass 2 and does not depend on this field.
-			return result
-		}
-	}
-
 	// Extract source content
 	absPath := filepath.Join(projectDir, info.Path)
 	content, err := extract.Extract(absPath, info.Type)
@@ -271,12 +236,11 @@ func writeSummaryFile(projectDir, outputDir string, info SourceInfo, content *ex
 	frontmatter := fmt.Sprintf(`---
 source: %s
 source_type: %s
-source_hash: %s
 compiled_at: %s
 chunk_count: %d
 ---
 
-`, info.Path, content.Type, info.Hash, timeNow(loc), content.ChunkCount)
+`, info.Path, content.Type, timeNow(loc), content.ChunkCount)
 
 	if err := os.WriteFile(absOutputPath, []byte(frontmatter+summaryText), 0644); err != nil {
 		result.Error = fmt.Errorf("write summary: %w", err)

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -137,6 +137,41 @@ func summarizeOne(
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
 
+	// Skip LLM call if a valid summary file already exists on disk with a matching
+	// source hash. Restores resume-from-checkpoint behavior when compile-state.json is
+	// missing (e.g. a prior failed run cleared it). The source_hash field in the
+	// frontmatter guards against serving stale summaries for modified sources.
+	baseName := strings.TrimSuffix(filepath.Base(info.Path), filepath.Ext(info.Path))
+	summaryPath := filepath.Join(outputDir, "summaries", baseName+".md")
+	absSummary := filepath.Join(projectDir, summaryPath)
+	if existing, err := os.ReadFile(absSummary); err == nil {
+		body := string(existing)
+		// Parse source_hash from YAML frontmatter and verify it matches the current
+		// source file. This prevents stale summaries being served for modified sources.
+		var storedHash string
+		if strings.HasPrefix(body, "---\n") {
+			if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
+				frontmatter := body[4 : 4+end]
+				for _, line := range strings.Split(frontmatter, "\n") {
+					if strings.HasPrefix(line, "source_hash: ") {
+						storedHash = strings.TrimPrefix(line, "source_hash: ")
+						break
+					}
+				}
+				body = body[4+end+5:]
+			}
+		}
+		body = strings.TrimSpace(body)
+		if len(body) >= 100 && storedHash == info.Hash {
+			log.Info("reusing existing summary", "path", info.Path)
+			result.Summary = body
+			result.SummaryPath = summaryPath
+			// Note: result.Concepts is left nil; concept extraction runs separately
+			// in Pass 2 and does not depend on this field.
+			return result
+		}
+	}
+
 	// Extract source content
 	absPath := filepath.Join(projectDir, info.Path)
 	content, err := extract.Extract(absPath, info.Type)
@@ -236,11 +271,12 @@ func writeSummaryFile(projectDir, outputDir string, info SourceInfo, content *ex
 	frontmatter := fmt.Sprintf(`---
 source: %s
 source_type: %s
+source_hash: %s
 compiled_at: %s
 chunk_count: %d
 ---
 
-`, info.Path, content.Type, timeNow(loc), content.ChunkCount)
+`, info.Path, content.Type, info.Hash, timeNow(loc), content.ChunkCount)
 
 	if err := os.WriteFile(absOutputPath, []byte(frontmatter+summaryText), 0644); err != nil {
 		result.Error = fmt.Errorf("write summary: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,8 @@ type CompilerConfig struct {
 	DebounceSeconds  int     `yaml:"debounce_seconds"`
 	SummaryMaxTokens int     `yaml:"summary_max_tokens"`
 	ArticleMaxTokens int     `yaml:"article_max_tokens"`
+	ExtractMaxTokens int     `yaml:"extract_max_tokens,omitempty"`  // max output tokens for concept extraction (default: 8192)
+	ExtractBatchSize int     `yaml:"extract_batch_size,omitempty"`  // summaries per concept extraction call (default: 20)
 	AutoCommit       bool    `yaml:"auto_commit"`
 	AutoLint         bool    `yaml:"auto_lint"`
 	Mode             string  `yaml:"mode,omitempty"`              // standard, batch, or auto
@@ -307,6 +309,8 @@ func Defaults() Config {
 			DebounceSeconds:  2,
 			SummaryMaxTokens: 2000,
 			ArticleMaxTokens: 4000,
+			ExtractMaxTokens: 8192,
+			ExtractBatchSize: 20,
 			AutoCommit:       true,
 			AutoLint:         true,
 			DefaultTier:      3,

--- a/internal/llm/batch.go
+++ b/internal/llm/batch.go
@@ -64,7 +64,7 @@ type BatchResult struct {
 }
 
 // BatchProvider extends Provider with async batch API support.
-// Only Anthropic and OpenAI support batch; Gemini does not.
+// Anthropic, OpenAI, and Gemini providers implement this interface.
 type BatchProvider interface {
 	// SubmitBatch sends a batch of requests. Returns the batch ID.
 	SubmitBatch(requests []BatchRequest) (batchID string, err error)

--- a/internal/llm/batch_test.go
+++ b/internal/llm/batch_test.go
@@ -13,9 +13,10 @@ import (
 // --- BatchProvider interface tests ---
 
 func TestBatchProviderInterface(t *testing.T) {
-	// Verify both providers implement BatchProvider
+	// Verify all three providers implement BatchProvider
 	var _ BatchProvider = &anthropicProvider{}
 	var _ BatchProvider = &openaiProvider{}
+	var _ BatchProvider = &geminiProvider{}
 }
 
 // --- Anthropic batch tests ---
@@ -249,10 +250,17 @@ func TestOpenAIBatchRetrieve(t *testing.T) {
 
 // --- Client-level batch tests ---
 
+// noBatchProvider is a minimal Provider stub that does not implement BatchProvider.
+type noBatchProvider struct{}
+
+func (noBatchProvider) Name() string                                                    { return "nobatch" }
+func (noBatchProvider) SupportsVision() bool                                            { return false }
+func (noBatchProvider) FormatRequest([]Message, CallOpts) (*http.Request, error)        { return nil, nil }
+func (noBatchProvider) ParseResponse([]byte) (*Response, error)                         { return nil, nil }
+
 func TestClientBatchNotSupported(t *testing.T) {
-	// Gemini doesn't support batch — should return error
-	p := newGeminiProvider("key", "http://localhost")
-	client := &Client{provider: p}
+	// A provider that doesn't implement BatchProvider should return an error.
+	client := &Client{provider: noBatchProvider{}}
 
 	_, err := client.SubmitBatch(nil)
 	if err == nil {
@@ -298,5 +306,184 @@ func TestAnthropicBatchExpired(t *testing.T) {
 	}
 	if status.Status != BatchExpired {
 		t.Errorf("expected expired, got %s", status.Status)
+	}
+}
+
+// --- Gemini batch tests ---
+
+func TestParseGeminiBatchResults(t *testing.T) {
+	tests := []struct {
+		name      string
+		jsonl     string
+		wantCount int
+		check     func(t *testing.T, results []BatchResult)
+	}{
+		{
+			name: "successful response",
+			jsonl: `{"key":"req-1","response":{"candidates":[{"content":{"parts":[{"text":"hello world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15},"modelVersion":"gemini-2.5-flash"}}`,
+			wantCount: 1,
+			check: func(t *testing.T, results []BatchResult) {
+				r := results[0]
+				if r.CustomID != "req-1" {
+					t.Errorf("CustomID = %q, want %q", r.CustomID, "req-1")
+				}
+				if r.Error != "" {
+					t.Errorf("unexpected error: %s", r.Error)
+				}
+				if r.Response == nil {
+					t.Fatal("expected non-nil response")
+				}
+				if r.Response.Content != "hello world" {
+					t.Errorf("Content = %q, want %q", r.Response.Content, "hello world")
+				}
+				if r.Response.Model != "gemini-2.5-flash" {
+					t.Errorf("Model = %q, want %q", r.Response.Model, "gemini-2.5-flash")
+				}
+				if r.Response.TokensUsed != 15 {
+					t.Errorf("TokensUsed = %d, want 15", r.Response.TokensUsed)
+				}
+				if r.Response.Usage.InputTokens != 10 {
+					t.Errorf("InputTokens = %d, want 10", r.Response.Usage.InputTokens)
+				}
+				if r.Response.Usage.OutputTokens != 5 {
+					t.Errorf("OutputTokens = %d, want 5", r.Response.Usage.OutputTokens)
+				}
+			},
+		},
+		{
+			name:      "per-request error",
+			jsonl:     `{"key":"req-2","status":{"code":429,"message":"quota exceeded"}}`,
+			wantCount: 1,
+			check: func(t *testing.T, results []BatchResult) {
+				r := results[0]
+				if r.CustomID != "req-2" {
+					t.Errorf("CustomID = %q, want %q", r.CustomID, "req-2")
+				}
+				if r.Response != nil {
+					t.Error("expected nil response on error")
+				}
+				if r.Error != "code 429: quota exceeded" {
+					t.Errorf("Error = %q, want %q", r.Error, "code 429: quota exceeded")
+				}
+			},
+		},
+		{
+			name:      "empty candidate list gives empty-response error",
+			jsonl:     `{"key":"req-3","response":{"candidates":[]}}`,
+			wantCount: 1,
+			check: func(t *testing.T, results []BatchResult) {
+				if results[0].Error != "empty response" {
+					t.Errorf("Error = %q, want %q", results[0].Error, "empty response")
+				}
+			},
+		},
+		{
+			name: "multiple entries mixed",
+			jsonl: strings.Join([]string{
+				`{"key":"a","response":{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{}}}`,
+				`{"key":"b","status":{"code":500,"message":"internal error"}}`,
+				``,
+				`{"key":"c","response":{"candidates":[{"content":{"parts":[{"text":"also ok"}]},"finishReason":"STOP"}],"usageMetadata":{}}}`,
+			}, "\n"),
+			wantCount: 3,
+			check: func(t *testing.T, results []BatchResult) {
+				ids := []string{results[0].CustomID, results[1].CustomID, results[2].CustomID}
+				if ids[0] != "a" || ids[1] != "b" || ids[2] != "c" {
+					t.Errorf("unexpected IDs: %v", ids)
+				}
+				if results[0].Error != "" {
+					t.Errorf("entry a: unexpected error %q", results[0].Error)
+				}
+				if results[1].Response != nil {
+					t.Error("entry b: expected nil response")
+				}
+				if results[2].Response == nil || results[2].Response.Content != "also ok" {
+					t.Errorf("entry c: unexpected response %v", results[2].Response)
+				}
+			},
+		},
+		{
+			name:      "malformed line is skipped",
+			jsonl:     "not-json\n{\"key\":\"good\",\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]}}],\"usageMetadata\":{}}}",
+			wantCount: 1,
+			check: func(t *testing.T, results []BatchResult) {
+				if results[0].CustomID != "good" {
+					t.Errorf("CustomID = %q, want %q", results[0].CustomID, "good")
+				}
+			},
+		},
+		{
+			name:      "empty input",
+			jsonl:     "",
+			wantCount: 0,
+			check:     func(t *testing.T, results []BatchResult) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := parseGeminiBatchResults(strings.NewReader(tt.jsonl))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(results) != tt.wantCount {
+				t.Fatalf("got %d results, want %d", len(results), tt.wantCount)
+			}
+			tt.check(t, results)
+		})
+	}
+}
+
+func TestGeminiBatchState(t *testing.T) {
+	tests := []struct {
+		state string
+		want  BatchStatus
+	}{
+		{"JOB_STATE_SUCCEEDED", BatchEnded},
+		{"JOB_STATE_EXPIRED", BatchExpired},
+		{"JOB_STATE_FAILED", BatchFailed},
+		{"JOB_STATE_CANCELLED", BatchFailed},
+		{"JOB_STATE_RUNNING", BatchInProgress},
+		{"", BatchInProgress},
+	}
+	for _, tt := range tests {
+		got := geminiBatchState(tt.state)
+		if got != tt.want {
+			t.Errorf("geminiBatchState(%q) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestNewGeminiProviderURLDerivation(t *testing.T) {
+	tests := []struct {
+		baseURL         string
+		wantUpload      string
+		wantDownload    string
+		wantBatchHost   string
+	}{
+		{
+			baseURL:       "https://generativelanguage.googleapis.com/v1beta",
+			wantUpload:    "https://generativelanguage.googleapis.com/upload/v1beta",
+			wantDownload:  "https://generativelanguage.googleapis.com/download/v1beta",
+			wantBatchHost: "generativelanguage.googleapis.com",
+		},
+		{
+			baseURL:       "https://my-proxy.example.com/v1beta",
+			wantUpload:    "https://my-proxy.example.com/upload/v1beta",
+			wantDownload:  "https://my-proxy.example.com/download/v1beta",
+			wantBatchHost: "my-proxy.example.com",
+		},
+	}
+	for _, tt := range tests {
+		p := newGeminiProvider("key", tt.baseURL)
+		if p.uploadBaseURL != tt.wantUpload {
+			t.Errorf("baseURL=%q: uploadBaseURL = %q, want %q", tt.baseURL, p.uploadBaseURL, tt.wantUpload)
+		}
+		if p.downloadBaseURL != tt.wantDownload {
+			t.Errorf("baseURL=%q: downloadBaseURL = %q, want %q", tt.baseURL, p.downloadBaseURL, tt.wantDownload)
+		}
+		if p.batchHost != tt.wantBatchHost {
+			t.Errorf("baseURL=%q: batchHost = %q, want %q", tt.baseURL, p.batchHost, tt.wantBatchHost)
+		}
 	}
 }

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -1,12 +1,19 @@
 package llm
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"regexp"
+	"strings"
 	"time"
+
+	"github.com/xoai/sage-wiki/internal/log"
 )
 
 // geminiKeySanitizer redacts API keys from Gemini URLs in error messages.
@@ -326,4 +333,330 @@ func (p *geminiProvider) ParseResponse(body []byte) (*Response, error) {
 			CachedTokens: result.UsageMetadata.CachedContentTokenCount,
 		},
 	}, nil
+}
+
+// --- BatchProvider implementation ---
+//
+// Gemini batch jobs use the Developer API (api-key auth, no OAuth needed).
+// Flow: upload JSONL input → submit batch → poll until done → download JSONL results.
+// Batch quota is separate from live quota and runs at 50% of standard pricing.
+
+const geminiUploadBaseURL = "https://generativelanguage.googleapis.com/upload/v1beta"
+const geminiDownloadBaseURL = "https://generativelanguage.googleapis.com/download/v1beta"
+
+// geminiBatchState maps Gemini job state strings to BatchStatus.
+func geminiBatchState(state string) BatchStatus {
+	switch state {
+	case "JOB_STATE_SUCCEEDED":
+		return BatchEnded
+	case "JOB_STATE_EXPIRED":
+		return BatchExpired
+	case "JOB_STATE_FAILED", "JOB_STATE_CANCELLED":
+		return BatchFailed
+	default:
+		return BatchInProgress
+	}
+}
+
+// uploadBatchInputFile uploads a JSONL payload to the Gemini File API.
+// Returns the resource name (e.g. "files/abc123") used to reference the file in batch submission.
+func (p *geminiProvider) uploadBatchInputFile(jsonl []byte) (string, error) {
+	const boundary = "sage_wiki_batch_boundary"
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.SetBoundary(boundary); err != nil {
+		return "", fmt.Errorf("gemini batch: set boundary: %w", err)
+	}
+
+	// Metadata part: tells the File API the MIME type of the content.
+	metaPart, err := w.CreatePart(textproto.MIMEHeader{
+		"Content-Type": {"application/json; charset=utf-8"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("gemini batch: create metadata part: %w", err)
+	}
+	metaJSON, _ := json.Marshal(map[string]any{
+		"file": map[string]string{
+			"displayName": "sage-wiki-batch-input",
+			"mimeType":    "text/plain",
+		},
+	})
+	if _, err := metaPart.Write(metaJSON); err != nil {
+		return "", fmt.Errorf("gemini batch: write metadata: %w", err)
+	}
+
+	// Data part: the actual JSONL content.
+	dataPart, err := w.CreatePart(textproto.MIMEHeader{
+		"Content-Type": {"text/plain"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("gemini batch: create data part: %w", err)
+	}
+	if _, err := dataPart.Write(jsonl); err != nil {
+		return "", fmt.Errorf("gemini batch: write data: %w", err)
+	}
+	w.Close()
+
+	uploadURL := fmt.Sprintf("%s/files?key=%s", geminiUploadBaseURL, p.apiKey)
+	req, err := http.NewRequest("POST", uploadURL, &buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "multipart/related; boundary="+boundary)
+	req.Header.Set("X-Goog-Upload-Protocol", "multipart")
+
+	client := http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini batch: upload file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini batch: upload returned %d: %s", resp.StatusCode, sanitizeGeminiError(string(body)))
+	}
+
+	var result struct {
+		File struct {
+			Name string `json:"name"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("gemini batch: parse upload response: %w", err)
+	}
+	if result.File.Name == "" {
+		return "", fmt.Errorf("gemini batch: upload returned empty file name")
+	}
+
+	return result.File.Name, nil
+}
+
+// SubmitBatch implements BatchProvider for Gemini.
+// Serialises requests as JSONL (one per line, with a "key" field for correlation),
+// uploads to the File API, then submits an async batch job.
+func (p *geminiProvider) SubmitBatch(requests []BatchRequest) (string, error) {
+	if len(requests) == 0 {
+		return "", fmt.Errorf("gemini batch: no requests")
+	}
+
+	// All requests in a batch share the same model; use the first request's model.
+	model := requests[0].Opts.Model
+	if model == "" {
+		model = "gemini-2.5-flash"
+	}
+
+	// Build JSONL — one GenerateContentRequest per line, keyed by CustomID.
+	var buf bytes.Buffer
+	for _, r := range requests {
+		body, _ := p.formatBody(r.Messages, r.Opts)
+		line := map[string]any{
+			"key":     r.CustomID,
+			"request": body,
+		}
+		data, err := json.Marshal(line)
+		if err != nil {
+			return "", fmt.Errorf("gemini batch: marshal request %q: %w", r.CustomID, err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+
+	// Upload JSONL to the File API.
+	fileName, err := p.uploadBatchInputFile(buf.Bytes())
+	if err != nil {
+		return "", err
+	}
+	log.Info("gemini batch: uploaded input file", "file", fileName, "requests", len(requests))
+
+	// Submit the batch job referencing the uploaded file.
+	payload := map[string]any{
+		"batch": map[string]any{
+			"displayName": "sage-wiki-batch",
+			"inputConfig": map[string]any{
+				"fileName": fileName,
+			},
+		},
+	}
+
+	submitURL := fmt.Sprintf("%s/models/%s:batchGenerateContent?key=%s", p.baseURL, model, p.apiKey)
+	req, err := http.NewRequest("POST", submitURL, jsonBody(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	hc := http.Client{Timeout: 120 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("gemini batch: submit: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("gemini batch: submit returned %d: %s", resp.StatusCode, sanitizeGeminiError(string(respBody)))
+	}
+
+	var result struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("gemini batch: parse submit response: %w", err)
+	}
+	if result.Name == "" {
+		return "", fmt.Errorf("gemini batch: submit returned empty batch name")
+	}
+
+	log.Info("gemini batch submitted", "batch", result.Name, "requests", len(requests))
+	return result.Name, nil
+}
+
+// PollBatch checks the status of a Gemini batch job.
+// batchID is the resource name returned by SubmitBatch (e.g. "batches/abc123").
+func (p *geminiProvider) PollBatch(batchID string) (*BatchStatusResponse, error) {
+	pollURL := fmt.Sprintf("%s/%s?key=%s", p.baseURL, batchID, p.apiKey)
+	req, err := http.NewRequest("GET", pollURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	hc := http.Client{Timeout: 30 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gemini batch: poll: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gemini batch: poll returned %d: %s", resp.StatusCode, sanitizeGeminiError(string(body)))
+	}
+
+	var result struct {
+		Name     string `json:"name"`
+		State    string `json:"state"`
+		Response struct {
+			ResponsesFile string `json:"responsesFile"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("gemini batch: parse poll response: %w", err)
+	}
+
+	return &BatchStatusResponse{
+		BatchID:    result.Name,
+		Status:     geminiBatchState(result.State),
+		ResultsURL: result.Response.ResponsesFile, // e.g. "files/abc123-responses"
+	}, nil
+}
+
+// RetrieveBatch downloads and parses results from a completed Gemini batch.
+// resultsRef is the file resource name from PollBatch (e.g. "files/abc123-responses").
+func (p *geminiProvider) RetrieveBatch(resultsRef string) ([]BatchResult, error) {
+	// Validate the download URL points to the expected Gemini host to prevent SSRF.
+	expectedHost := "generativelanguage.googleapis.com"
+	if err := validateBatchURL(
+		fmt.Sprintf("%s/%s:download", geminiDownloadBaseURL, resultsRef),
+		expectedHost,
+	); err != nil {
+		return nil, fmt.Errorf("gemini batch: %w", err)
+	}
+
+	downloadURL := fmt.Sprintf("%s/%s:download?alt=media&key=%s", geminiDownloadBaseURL, resultsRef, p.apiKey)
+	req, err := http.NewRequest("GET", downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	hc := http.Client{Timeout: 300 * time.Second}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("gemini batch: download results: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("gemini batch: download returned %d: %s", resp.StatusCode, sanitizeGeminiError(string(body)))
+	}
+
+	return parseGeminiBatchResults(resp.Body)
+}
+
+// parseGeminiBatchResults parses the JSONL results file returned by a completed Gemini batch job.
+// Each line is: {"key": "<CustomID>", "response": <GenerateContentResponse>}
+// or:            {"key": "<CustomID>", "status": {"code": N, "message": "..."}}  on per-request error.
+func parseGeminiBatchResults(r io.Reader) ([]BatchResult, error) {
+	var results []BatchResult
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var entry struct {
+			Key      string `json:"key"`
+			Response *struct {
+				Candidates []struct {
+					Content struct {
+						Parts []struct {
+							Text string `json:"text"`
+						} `json:"parts"`
+					} `json:"content"`
+					FinishReason string `json:"finishReason"`
+				} `json:"candidates"`
+				UsageMetadata struct {
+					PromptTokenCount     int `json:"promptTokenCount"`
+					CandidatesTokenCount int `json:"candidatesTokenCount"`
+					TotalTokenCount      int `json:"totalTokenCount"`
+				} `json:"usageMetadata"`
+				ModelVersion string `json:"modelVersion"`
+			} `json:"response"`
+			Status *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"status"`
+		}
+
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			truncated := line
+			if len(truncated) > 200 {
+				truncated = truncated[:200] + "..."
+			}
+			log.Warn("gemini batch: skipping malformed JSONL line", "error", err, "line", truncated)
+			continue
+		}
+
+		br := BatchResult{CustomID: entry.Key}
+
+		switch {
+		case entry.Status != nil && entry.Status.Code != 0:
+			br.Error = fmt.Sprintf("code %d: %s", entry.Status.Code, entry.Status.Message)
+		case entry.Response != nil && len(entry.Response.Candidates) > 0:
+			var text string
+			for _, part := range entry.Response.Candidates[0].Content.Parts {
+				text += part.Text
+			}
+			br.Response = &Response{
+				Content:    stripThinkTags(text),
+				Model:      entry.Response.ModelVersion,
+				TokensUsed: entry.Response.UsageMetadata.TotalTokenCount,
+				Usage: Usage{
+					InputTokens:  entry.Response.UsageMetadata.PromptTokenCount,
+					OutputTokens: entry.Response.UsageMetadata.CandidatesTokenCount,
+				},
+			}
+		default:
+			br.Error = "empty response"
+		}
+
+		results = append(results, br)
+	}
+
+	return results, scanner.Err()
 }

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -379,13 +379,8 @@ func geminiBatchState(state string) BatchStatus {
 // uploadBatchInputFile uploads a JSONL payload to the Gemini File API.
 // Returns the resource name (e.g. "files/abc123") used to reference the file in batch submission.
 func (p *geminiProvider) uploadBatchInputFile(jsonl []byte) (string, error) {
-	const boundary = "sage_wiki_batch_boundary"
-
 	var buf bytes.Buffer
-	w := multipart.NewWriter(&buf)
-	if err := w.SetBoundary(boundary); err != nil {
-		return "", fmt.Errorf("gemini batch: set boundary: %w", err)
-	}
+	w := multipart.NewWriter(&buf) // uses a randomly generated boundary
 
 	// Metadata part: tells the File API the MIME type of the content.
 	metaPart, err := w.CreatePart(textproto.MIMEHeader{
@@ -421,7 +416,7 @@ func (p *geminiProvider) uploadBatchInputFile(jsonl []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Content-Type", "multipart/related; boundary="+boundary)
+	req.Header.Set("Content-Type", "multipart/related; boundary="+w.Boundary())
 	req.Header.Set("X-Goog-Upload-Protocol", "multipart")
 
 	client := http.Client{Timeout: 120 * time.Second}

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -45,6 +45,12 @@ func newGeminiProvider(apiKey string, baseURL string) *geminiProvider {
 	// pattern is not found (non-standard endpoint).
 	uploadBase := strings.Replace(baseURL, "/v1beta", "/upload/v1beta", 1)
 	downloadBase := strings.Replace(baseURL, "/v1beta", "/download/v1beta", 1)
+	if uploadBase == baseURL {
+		// baseURL does not contain the expected "/v1beta" suffix — batch File API
+		// upload and download URLs could not be derived. Batch operations will use
+		// baseURL unchanged, which will likely fail for non-standard endpoints.
+		log.Warn("gemini: baseURL does not contain '/v1beta'; batch upload/download URLs may be incorrect", "base_url", baseURL)
+	}
 	var batchHost string
 	if u, err := url.Parse(baseURL); err == nil {
 		batchHost = u.Hostname()

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -26,15 +27,35 @@ func sanitizeGeminiError(s string) string {
 
 // geminiProvider implements the Google Gemini API format.
 type geminiProvider struct {
-	apiKey  string
-	baseURL string
+	apiKey          string
+	baseURL         string
+	uploadBaseURL   string // derived from baseURL; used by batch File API uploads
+	downloadBaseURL string // derived from baseURL; used by batch result downloads
+	batchHost       string // hostname extracted from baseURL; used for SSRF validation
 }
 
 func newGeminiProvider(apiKey string, baseURL string) *geminiProvider {
 	if baseURL == "" {
 		baseURL = "https://generativelanguage.googleapis.com/v1beta"
 	}
-	return &geminiProvider{apiKey: apiKey, baseURL: baseURL}
+	// Derive upload/download URL prefixes from baseURL so that a custom proxy
+	// or regional endpoint is honoured consistently across all batch operations.
+	// Standard pattern: baseURL ends in "/v1beta"; upload is "/upload/v1beta",
+	// download is "/download/v1beta". Falls back to baseURL unchanged if the
+	// pattern is not found (non-standard endpoint).
+	uploadBase := strings.Replace(baseURL, "/v1beta", "/upload/v1beta", 1)
+	downloadBase := strings.Replace(baseURL, "/v1beta", "/download/v1beta", 1)
+	var batchHost string
+	if u, err := url.Parse(baseURL); err == nil {
+		batchHost = u.Hostname()
+	}
+	return &geminiProvider{
+		apiKey:          apiKey,
+		baseURL:         baseURL,
+		uploadBaseURL:   uploadBase,
+		downloadBaseURL: downloadBase,
+		batchHost:       batchHost,
+	}
 }
 
 func (p *geminiProvider) Name() string        { return "gemini" }
@@ -341,9 +362,6 @@ func (p *geminiProvider) ParseResponse(body []byte) (*Response, error) {
 // Flow: upload JSONL input → submit batch → poll until done → download JSONL results.
 // Batch quota is separate from live quota and runs at 50% of standard pricing.
 
-const geminiUploadBaseURL = "https://generativelanguage.googleapis.com/upload/v1beta"
-const geminiDownloadBaseURL = "https://generativelanguage.googleapis.com/download/v1beta"
-
 // geminiBatchState maps Gemini job state strings to BatchStatus.
 func geminiBatchState(state string) BatchStatus {
 	switch state {
@@ -398,7 +416,7 @@ func (p *geminiProvider) uploadBatchInputFile(jsonl []byte) (string, error) {
 	}
 	w.Close()
 
-	uploadURL := fmt.Sprintf("%s/files?key=%s", geminiUploadBaseURL, p.apiKey)
+	uploadURL := fmt.Sprintf("%s/files?key=%s", p.uploadBaseURL, p.apiKey)
 	req, err := http.NewRequest("POST", uploadURL, &buf)
 	if err != nil {
 		return "", err
@@ -555,16 +573,16 @@ func (p *geminiProvider) PollBatch(batchID string) (*BatchStatusResponse, error)
 // RetrieveBatch downloads and parses results from a completed Gemini batch.
 // resultsRef is the file resource name from PollBatch (e.g. "files/abc123-responses").
 func (p *geminiProvider) RetrieveBatch(resultsRef string) ([]BatchResult, error) {
-	// Validate the download URL points to the expected Gemini host to prevent SSRF.
-	expectedHost := "generativelanguage.googleapis.com"
+	// Validate the download URL points to the expected host to prevent SSRF.
+	// p.batchHost is derived from p.baseURL so custom endpoints are honoured.
 	if err := validateBatchURL(
-		fmt.Sprintf("%s/%s:download", geminiDownloadBaseURL, resultsRef),
-		expectedHost,
+		fmt.Sprintf("%s/%s:download", p.downloadBaseURL, resultsRef),
+		p.batchHost,
 	); err != nil {
 		return nil, fmt.Errorf("gemini batch: %w", err)
 	}
 
-	downloadURL := fmt.Sprintf("%s/%s:download?alt=media&key=%s", geminiDownloadBaseURL, resultsRef, p.apiKey)
+	downloadURL := fmt.Sprintf("%s/%s:download?alt=media&key=%s", p.downloadBaseURL, resultsRef, p.apiKey)
 	req, err := http.NewRequest("GET", downloadURL, nil)
 	if err != nil {
 		return nil, err

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -432,6 +432,9 @@ func docIDToArticlePath(docID string, outputDir string) string {
 		name := docID[7:]
 		return filepath.Join(outputDir, "outputs", name)
 	}
+	if strings.HasPrefix(docID, "src:") {
+		return docID[4:]
+	}
 	return ""
 }
 

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -67,6 +67,24 @@ func TestExtractSeedIDsFromEnhanced(t *testing.T) {
 	}
 }
 
+func TestDocIDToArticlePath_SrcPrefix(t *testing.T) {
+	tests := []struct {
+		docID string
+		want  string
+	}{
+		{"src:raw/notes/doc.md", "raw/notes/doc.md"},
+		{"src:raw/papers/paper.pdf", "raw/papers/paper.pdf"},
+		{"concept:attention", filepath.Join("wiki", "concepts", "attention.md")},
+		{"unknown:foo", ""},
+	}
+	for _, tt := range tests {
+		got := docIDToArticlePath(tt.docID, "wiki")
+		if got != tt.want {
+			t.Errorf("docIDToArticlePath(%q) = %q, want %q", tt.docID, got, tt.want)
+		}
+	}
+}
+
 func TestComputeGraphExpansion_EmptySeeds(t *testing.T) {
 	cfg := &config.Config{Search: config.SearchConfig{}}
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- Implements `BatchProvider` for the Gemini provider using the **Developer API** (api-key auth — no OAuth/Vertex AI required)
- Gemini batch runs at **50% of standard pricing** with a **separate quota bucket** that doesn't consume live RPM/TPM limits — solving the rate-limit issue users hit when compiling large corpora with `gemini-2.0-flash`
- Works transparently with `compile --batch` and `compiler.mode: batch` / `compiler.mode: auto`

## How it works

**`SubmitBatch`**
1. Serialises all `BatchRequest`s as JSONL — one per line with a `"key"` field matching `CustomID` for result correlation
2. Uploads the JSONL to the Gemini **File API** (`/upload/v1beta/files`) — handles arbitrarily large batches (up to 2 GB), unlike inline mode which caps at 20 MB
3. Submits an async batch job via `POST /models/{model}:batchGenerateContent` referencing the uploaded file

**`PollBatch`**
- Polls `GET /batches/{id}` and maps `JOB_STATE_*` → `BatchStatus` (`BatchInProgress`, `BatchEnded`, `BatchExpired`, `BatchFailed`)
- Returns the results file resource name in `ResultsURL` for `RetrieveBatch`

**`RetrieveBatch`**
- Downloads the results JSONL via `GET /download/v1beta/{file}:download?alt=media`
- Parses each line back to `BatchResult`, preserving the `"key"` → `CustomID` mapping
- Handles per-request errors via the `"status"` field (Gemini returns these inline rather than failing the whole batch)
- Applies SSRF validation on the download URL (same pattern as Anthropic provider)

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./internal/llm/...` — all existing tests pass
- [ ] Live integration test with a real Gemini API key and a small batch (~10 requests)
- [ ] Verify `compile --batch` selects Gemini batch when provider is `gemini`
- [ ] Verify results map correctly back to source paths via `CustomID`

## Notes

- All requests in a batch must use the same model (set at the batch level via the URL); multi-model batches are not supported by the Gemini API
- The File API upload uses `multipart/related` encoding as required by Google
- Batch job expiry is 48 hours (same as the existing expiry message in `resumeBatch`)
- The `geminiDownloadBaseURL` uses a different base host (`/download/v1beta`) than the regular API — this is the Gemini media download endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)