### PR TITLE
fix(compiler): skip LLM call when summary file already exists

### DIFF
--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -137,25 +137,37 @@ func summarizeOne(
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
 
-	// Skip LLM call if a valid summary file already exists on disk.
-	// Restores resume-from-checkpoint behavior when compile-state.json is missing
-	// (e.g. a prior failed run cleared it). Source of truth for "already summarized"
-	// becomes the filesystem, not just the JSON checkpoint.
+	// Skip LLM call if a valid summary file already exists on disk with a matching
+	// source hash. Restores resume-from-checkpoint behavior when compile-state.json is
+	// missing (e.g. a prior failed run cleared it). The source_hash field in the
+	// frontmatter guards against serving stale summaries for modified sources.
 	baseName := strings.TrimSuffix(filepath.Base(info.Path), filepath.Ext(info.Path))
 	summaryPath := filepath.Join(outputDir, "summaries", baseName+".md")
 	absSummary := filepath.Join(projectDir, summaryPath)
 	if existing, err := os.ReadFile(absSummary); err == nil {
 		body := string(existing)
-		// Strip YAML frontmatter if present
+		// Parse source_hash from YAML frontmatter and verify it matches the current
+		// source file. This prevents stale summaries being served for modified sources.
+		var storedHash string
 		if strings.HasPrefix(body, "---\n") {
 			if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
+				frontmatter := body[4 : 4+end]
+				for _, line := range strings.Split(frontmatter, "\n") {
+					if strings.HasPrefix(line, "source_hash: ") {
+						storedHash = strings.TrimPrefix(line, "source_hash: ")
+						break
+					}
+				}
 				body = body[4+end+5:]
 			}
 		}
 		body = strings.TrimSpace(body)
-		if len(body) >= 100 {
+		if len(body) >= 100 && storedHash == info.Hash {
+			log.Info("reusing existing summary", "path", info.Path)
 			result.Summary = body
 			result.SummaryPath = summaryPath
+			// Note: result.Concepts is left nil; concept extraction runs separately
+			// in Pass 2 and does not depend on this field.
 			return result
 		}
 	}
@@ -259,11 +271,12 @@ func writeSummaryFile(projectDir, outputDir string, info SourceInfo, content *ex
 	frontmatter := fmt.Sprintf(`---
 source: %s
 source_type: %s
+source_hash: %s
 compiled_at: %s
 chunk_count: %d
 ---
 
-`, info.Path, content.Type, timeNow(loc), content.ChunkCount)
+`, info.Path, content.Type, info.Hash, timeNow(loc), content.ChunkCount)
 
 	if err := os.WriteFile(absOutputPath, []byte(frontmatter+summaryText), 0644); err != nil {
 		result.Error = fmt.Errorf("write summary: %w", err)

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -137,6 +137,29 @@ func summarizeOne(
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
 
+	// Skip LLM call if a valid summary file already exists on disk.
+	// Restores resume-from-checkpoint behavior when compile-state.json is missing
+	// (e.g. a prior failed run cleared it). Source of truth for "already summarized"
+	// becomes the filesystem, not just the JSON checkpoint.
+	baseName := strings.TrimSuffix(filepath.Base(info.Path), filepath.Ext(info.Path))
+	summaryPath := filepath.Join(outputDir, "summaries", baseName+".md")
+	absSummary := filepath.Join(projectDir, summaryPath)
+	if existing, err := os.ReadFile(absSummary); err == nil {
+		body := string(existing)
+		// Strip YAML frontmatter if present
+		if strings.HasPrefix(body, "---\n") {
+			if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
+				body = body[4+end+5:]
+			}
+		}
+		body = strings.TrimSpace(body)
+		if len(body) >= 100 {
+			result.Summary = body
+			result.SummaryPath = summaryPath
+			return result
+		}
+	}
+
 	// Extract source content
 	absPath := filepath.Join(projectDir, info.Path)
 	content, err := extract.Extract(absPath, info.Type)

--- a/internal/compiler/summarize_test.go
+++ b/internal/compiler/summarize_test.go
@@ -1,10 +1,103 @@
 package compiler
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/xoai/sage-wiki/internal/extract"
 )
+
+// buildSummaryFile writes a fake summary file with the given frontmatter hash and body.
+func buildSummaryFile(t *testing.T, dir, name, hash, body string) {
+	t.Helper()
+	summaryDir := filepath.Join(dir, "summaries")
+	if err := os.MkdirAll(summaryDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("---\nsource: %s\nsource_type: article\nsource_hash: %s\ncompiled_at: 2024-01-01\nchunk_count: 1\n---\n\n%s", name, hash, body)
+	if err := os.WriteFile(filepath.Join(summaryDir, name+".md"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSummarizeOneReusesExistingSummaryOnHashMatch(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := "output"
+	sourceHash := "sha256:abc123"
+	longBody := strings.Repeat("x", 120)
+
+	buildSummaryFile(t, filepath.Join(projectDir, outputDir), "doc", sourceHash, longBody)
+
+	info := SourceInfo{Path: "sources/doc.md", Hash: sourceHash, Type: "article"}
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+
+	if result.Error != nil {
+		t.Fatalf("expected no error, got: %v", result.Error)
+	}
+	if result.Summary != longBody {
+		t.Errorf("expected reused summary body, got %q", result.Summary)
+	}
+	if result.SummaryPath != filepath.Join(outputDir, "summaries", "doc.md") {
+		t.Errorf("unexpected SummaryPath: %q", result.SummaryPath)
+	}
+}
+
+func TestSummarizeOneSkipsReusedWhenHashMismatch(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := "output"
+	longBody := strings.Repeat("x", 120)
+
+	buildSummaryFile(t, filepath.Join(projectDir, outputDir), "doc", "sha256:old", longBody)
+
+	// Hash differs → must not reuse; extraction of missing source returns an error
+	info := SourceInfo{Path: "sources/doc.md", Hash: "sha256:new", Type: "article"}
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+
+	if result.Error == nil {
+		t.Fatal("expected an error (extract should fail on missing source), got nil")
+	}
+	if result.Summary != "" {
+		t.Errorf("expected no summary to be reused, got %q", result.Summary)
+	}
+}
+
+func TestSummarizeOneSkipsReusedWhenSummaryTooShort(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := "output"
+	sourceHash := "sha256:abc123"
+
+	buildSummaryFile(t, filepath.Join(projectDir, outputDir), "doc", sourceHash, "too short")
+
+	// Body below 100 chars → must not reuse
+	info := SourceInfo{Path: "sources/doc.md", Hash: sourceHash, Type: "article"}
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+
+	if result.Error == nil {
+		t.Fatal("expected an error (extract should fail on missing source), got nil")
+	}
+	if result.Summary != "" {
+		t.Errorf("expected no summary to be reused, got %q", result.Summary)
+	}
+}
+
+func TestSummarizeOneSkipsReusedWhenNoSummaryFile(t *testing.T) {
+	projectDir := t.TempDir()
+	outputDir := "output"
+
+	// No summary file exists → must not reuse
+	info := SourceInfo{Path: "sources/doc.md", Hash: "sha256:abc123", Type: "article"}
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+
+	if result.Error == nil {
+		t.Fatal("expected an error (extract should fail on missing source), got nil")
+	}
+	if result.Summary != "" {
+		t.Errorf("expected no summary to be reused, got %q", result.Summary)
+	}
+}
 
 func TestGroupChunksNoGroupingNeeded(t *testing.T) {
 	chunks := make([]extract.Chunk, 5)


### PR DESCRIPTION
## Summary

Make `summarizeOne()` check the filesystem for an existing summary file before calling the LLM. If a valid summary file exists (≥100 chars after stripping YAML frontmatter), load it and skip the LLM call.

## Motivation

Currently, resume from a prior compile relies solely on `compile-state.json`. When a prior run crashed or was cancelled in a way that cleared the checkpoint — e.g. a \"completed with errors\" flow that wipes the checkpoint as part of its cleanup — the next invocation re-summarizes every source from scratch, burning quota to regenerate thousands of already-valid summaries.

Real-world trigger: during a large-corpus compile (~3700 docs, Gemini 2.0 Flash), a mid-run failure in Pass 2 (concept extraction) left us wanting to restart from Pass 2. But a preceding failed run had already wiped `compile-state.json`, so restart went back to Pass 1 and re-summarized everything — a full re-run cost despite all summary files still being present on disk and identical in content to what would be regenerated.

## Behavior

- **Existing valid summary file**: load body into `SummaryResult`, return immediately — no LLM call
- **Missing/empty/too-short file**: fall through to normal extract + summarize path
- **Fresh project**: no files on disk → no change from current behavior

Threshold of 100 chars matches the existing `validateSummary()` minimum, so we only skip on summaries the project would itself accept.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/compiler/...`
- [ ] Manual: start a compile, let Pass 1 write some summaries, interrupt, delete `compile-state.json`, re-run — verify those docs are skipped with no LLM calls for them
- [ ] Manual: fresh project with no summaries → Pass 1 runs normally end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)