### PR TITLE
fix: preserve CJK characters in SanitizeFTS for multilingual BM25 search

### DIFF
--- a/internal/memory/entries.go
+++ b/internal/memory/entries.go
@@ -194,15 +194,25 @@ func buildFTSQuery(query string) string {
 }
 
 // SanitizeFTS strips FTS5 special characters to prevent query injection.
+// Preserves CJK ideographs, kana, and hangul for multilingual search.
 func SanitizeFTS(s string) string {
 	var buf strings.Builder
 	for _, r := range s {
-		// Keep only alphanumeric, hyphens, and underscores
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' ||
+			isCJKOrKana(r) {
 			buf.WriteRune(r)
 		}
 	}
 	return buf.String()
+}
+
+func isCJKOrKana(r rune) bool {
+	return (r >= 0x4E00 && r <= 0x9FFF) || // CJK Unified Ideographs
+		(r >= 0x3400 && r <= 0x4DBF) || // CJK Extension A
+		(r >= 0xF900 && r <= 0xFAFF) || // CJK Compatibility Ideographs
+		(r >= 0x3040 && r <= 0x309F) || // Hiragana
+		(r >= 0x30A0 && r <= 0x30FF) || // Katakana
+		(r >= 0xAC00 && r <= 0xD7AF) // Hangul Syllables
 }
 
 var stopwords = map[string]bool{

--- a/internal/memory/entries_test.go
+++ b/internal/memory/entries_test.go
@@ -151,6 +151,70 @@ func TestBuildFTSQuery(t *testing.T) {
 	}
 }
 
+func TestSanitizeFTSPreservesCJK(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"重大资产重组", "重大资产重组"},
+		{"hello世界", "hello世界"},
+		{"注意力机制", "注意力机制"},
+		{"トランスフォーマー", "トランスフォーマー"},       // katakana
+		{"변환기", "변환기"},                         // hangul
+		{"test*注入\"attack", "test注入attack"},     // strips FTS operators, keeps CJK
+		{"「引号」标点", "引号标点"},                     // strips CJK punctuation U+300x
+	}
+	for _, tt := range tests {
+		got := SanitizeFTS(tt.input)
+		if got != tt.expected {
+			t.Errorf("SanitizeFTS(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestBuildFTSQueryCJK(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"重大资产重组", `"重大资产重组"*`},
+		{"注意力 机制", `"注意力"* OR "机制"*`},
+		{"transformer 注意力", `"transformer"* OR "注意力"*`},
+	}
+	for _, tt := range tests {
+		got := buildFTSQuery(tt.input)
+		if got != tt.expected {
+			t.Errorf("buildFTSQuery(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestSearchCJKContent(t *testing.T) {
+	_, store := setupTestDB(t)
+
+	entries := []Entry{
+		{ID: "e1", Content: "重大资产重组是上市公司进行资产置换的重要方式", ArticlePath: "a.md"},
+		{ID: "e2", Content: "注意力机制是Transformer架构的核心组件", ArticlePath: "b.md"},
+		{ID: "e3", Content: "卷积神经网络使用滤波器进行特征提取", ArticlePath: "c.md"},
+	}
+	for _, e := range entries {
+		if err := store.Add(e); err != nil {
+			t.Fatalf("Add %s: %v", e.ID, err)
+		}
+	}
+
+	results, err := store.Search("重大资产重组", nil, 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results for CJK query '重大资产重组', got none")
+	}
+	if results[0].ID != "e1" {
+		t.Errorf("expected e1 as top result, got %s", results[0].ID)
+	}
+}
+
 func TestBuildFTSQueryInjection(t *testing.T) {
 	// FTS5 special characters should be stripped
 	tests := []struct {


### PR DESCRIPTION
## Summary

- `SanitizeFTS()` only kept `a-z 0-9 - _`, stripping all CJK characters before they reached FTS5
- Pure Chinese/Japanese/Korean queries produced empty BM25 results, making hybrid search fall back entirely to vector similarity
- Added `isCJKOrKana()` helper to preserve CJK Unified Ideographs, Extension A, Compatibility Ideographs, Hiragana, Katakana, and Hangul Syllables
- CJK punctuation (U+3000-U+303F) is intentionally excluded as `unicode61` treats it as separators

## Test plan

- [x] `TestSanitizeFTSPreservesCJK` — verifies Chinese, Japanese (katakana), Korean (hangul) characters are preserved while FTS5 operators and CJK punctuation are stripped
- [x] `TestBuildFTSQueryCJK` — verifies query building for pure CJK and mixed CJK/Latin input
- [x] `TestSearchCJKContent` — end-to-end: inserts Chinese content, searches with Chinese query, verifies correct result returned
- [x] `go test ./...` — all 35 packages pass, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)