### PR TITLE
fix(search): cross-lingual query failure — vector path was BM25-prefiltered

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -310,8 +310,10 @@ func buildDocLevelContext(projectDir string, question string, topK int,
 	}
 
 	results, err := searcher.Search(hybrid.SearchOpts{
-		Query: question,
-		Limit: topK,
+		Query:        question,
+		Limit:        topK,
+		BM25Weight:   cfg.Search.HybridWeightBM25,
+		VectorWeight: cfg.Search.HybridWeightVector,
 	}, queryVec)
 	if err != nil {
 		return "", nil, fmt.Errorf("query: search: %w", err)

--- a/internal/search/pipeline.go
+++ b/internal/search/pipeline.go
@@ -85,26 +85,19 @@ func EnhancedSearch(opts EnhancedSearchOpts) ([]SearchResult, error) {
 		}
 
 		if len(queryVecs) > 0 {
-			// BM25-prefiltered: only search vectors for docs from BM25 results
-			docIDs := memory.DocIDs(bm25Results)
-			if len(docIDs) > 0 {
-				for _, qv := range queryVecs {
-					vr, err := opts.VecStore.SearchChunksFiltered(qv, docIDs, candidateLimit)
-					if err != nil {
-						log.Warn("chunk vector search failed", "error", err)
-						continue
-					}
-					vecResults = append(vecResults, vr...)
+			// PATCH (cross-lingual fix): always brute-force vector across ALL
+			// chunks, never filter by BM25 candidate doc IDs. Original behaviour
+			// (BM25-prefiltered vector) was an efficiency optimization that
+			// silently dropped semantically-relevant docs whenever BM25 missed
+			// them — fatal for multilingual corpora where a Polish query has
+			// zero token overlap with English content.
+			for _, qv := range queryVecs {
+				vr, err := opts.VecStore.SearchChunks(qv, candidateLimit)
+				if err != nil {
+					log.Warn("chunk vector search failed", "error", err)
+					continue
 				}
-			} else {
-				// No BM25 results — try brute force vector search
-				for _, qv := range queryVecs {
-					vr, err := opts.VecStore.SearchChunks(qv, candidateLimit)
-					if err != nil {
-						continue
-					}
-					vecResults = append(vecResults, vr...)
-				}
+				vecResults = append(vecResults, vr...)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Two related bugs caused the `query` command to return wrong results for queries against multilingual corpora (e.g., Polish narrative query against predominantly-English content), even when direct cosine similarity proved the right answer was at top-1.

## Bug 1 — `internal/search/pipeline.go` `EnhancedSearch`

After BM25 chunk search, vector search was filtered to only chunks of BM25-hit documents (\`SearchChunksFiltered\`). For cross-lingual queries BM25 returns zero hits in the target-language docs, so vector search never sees the semantically-relevant chunks. **Fix**: always brute-force vector across all chunks; let RRF fusion handle the combination.

The original optimization (BM25-prefilter for vector) makes sense for monolingual English wikis where BM25 has high recall, but silently destroys recall for multilingual corpora.

## Bug 2 — `internal/query/query.go` `buildDocLevelContext`

Doc-level fallback path constructed \`hybrid.SearchOpts\` without passing \`cfg.Search.HybridWeightBM25 / HybridWeightVector\`. The hybrid Searcher defaults both to 1.0 when zero, so users' configured weights had no effect on the \`query\` subcommand. \`search\` and MCP paths did pass them correctly — only \`query\` was broken.

## Reproduction

Tested against a personal wiki with 8164 articles compiled from 3701 Polish-and-English ChatGPT conversations (Gemma 4 26B A4B via OpenRouter, MLX-served Jina v5 nano embeddings).

Query: \`czego dowiedziałem się o rozszerzaniu się wszechświata\` (Polish: \"what did I learn about the expansion of the universe\")

**Before** the fix:
- Returns: \`defense-mechanisms\`, \`fermentacja-ciasta\`, \`inferiority-complex\`, \`oświadczenie-nieskazania-prawomocnym-wyrokiem\`, etc.
- Answer: \"Na podstawie dostarczonych materiałów nie można udzielić odpowiedzi\" (no relevant articles)
- Direct cosine test: query embedding vs \`concept:expanding-universe\` = **0.605** (top-1), wrong articles 0.05-0.19 — vectors are correct, retrieval was filtering them out

**After** the fix:
- Returns: \`expanding-universe\`, \`hubble-law\`, \`cosmological-recession\`, \`dark-energy\`, \`general-relativity\`
- Answer: full Polish synthesis with [[wikilinks]] to all relevant concepts

## Why this matters

Sage-wiki's tagline mentions support for multilingual content (Chinese synonyms in built-in relation patterns, multilingual model recommendations). For any non-English wiki where queries don't lexically overlap with content, the \`query\` command has been silently returning wrong answers. This fix unblocks that use case.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/search/...\` — passes
- [x] \`go test ./internal/query/...\` — passes
- [x] Manual: real Polish query against English wiki — verified before/after diff above
- [ ] Edge case: monolingual English wiki — should still work (vector + BM25 both contribute, just no longer BM25-gated). Maintainers may want to verify.

## Notes for review

The change in \`pipeline.go\` removes an efficiency optimization. On a 65k-chunk corpus, switching from filtered to brute-force vector search added ~50ms per query in our setup — likely negligible compared to LLM rerank latency. If preserving the optimization is preferred, an alternative would be:

1. Always run brute-force vector
2. Additionally include BM25-filtered vector results
3. Union the candidates

This would maintain BM25-relevant boost while not losing semantic-only matches. Happy to implement either approach if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)