### PR TITLE
fix(compiler): unblock N-wide concurrency — rate limiter mutex across sleep

### DIFF
--- a/internal/compiler/concepts.go
+++ b/internal/compiler/concepts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/xoai/sage-wiki/internal/llm"
 	"github.com/xoai/sage-wiki/internal/log"
@@ -22,6 +23,9 @@ type ExtractedConcept struct {
 // ExtractConcepts runs Pass 2: concept extraction from summaries.
 // It takes new/updated summaries and the existing concept list,
 // asks the LLM to identify and deduplicate concepts.
+// concurrency > 1 runs batches in parallel; each batch receives the same
+// existingConcepts snapshot as dedup context (not the growing allConcepts),
+// so deduplicateConcepts at the end handles cross-batch merging.
 func ExtractConcepts(
 	summaries []SummaryResult,
 	existingConcepts map[string]manifest.Concept,
@@ -29,12 +33,16 @@ func ExtractConcepts(
 	model string,
 	batchSize int,
 	maxTokens int,
+	concurrency int,
 ) ([]ExtractedConcept, error) {
 	if batchSize <= 0 {
 		batchSize = 20
 	}
 	if maxTokens <= 0 {
 		maxTokens = 8192
+	}
+	if concurrency <= 1 {
+		concurrency = 1
 	}
 	if len(summaries) == 0 {
 		return nil, nil
@@ -51,67 +59,85 @@ func ExtractConcepts(
 		return nil, nil
 	}
 
-	// Build existing concept list for dedup context
+	// Build existing concept list for dedup context (shared snapshot for all batches)
 	var existingList []string
 	for name := range existingConcepts {
 		existingList = append(existingList, name)
 	}
+	dedupSnapshot := strings.Join(existingList, ", ")
 
-	// Process in batches
-	var allConcepts []ExtractedConcept
-
+	// Split into batches
+	type batchWork struct {
+		index int
+		items []SummaryResult
+	}
+	var batches []batchWork
 	for i := 0; i < len(validSummaries); i += batchSize {
 		end := i + batchSize
 		if end > len(validSummaries) {
 			end = len(validSummaries)
 		}
-		batch := validSummaries[i:end]
+		batches = append(batches, batchWork{index: i / batchSize, items: validSummaries[i:end]})
+	}
 
-		log.Info("extracting concepts batch", "batch", i/batchSize+1, "summaries", len(batch), "total", len(validSummaries))
+	totalBatches := len(batches)
+	results := make([][]ExtractedConcept, totalBatches)
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
 
-		var summaryTexts []string
-		for _, s := range batch {
-			// Use truncated summary to stay within context limits
-			summary := s.Summary
-			if len(summary) > 1000 {
-				summary = summary[:1000] + "\n..."
+	for _, b := range batches {
+		wg.Add(1)
+		go func(b batchWork) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			log.Info("extracting concepts batch", "batch", b.index+1, "of", totalBatches, "summaries", len(b.items))
+
+			var summaryTexts []string
+			for _, s := range b.items {
+				summary := s.Summary
+				if len(summary) > 1000 {
+					summary = summary[:1000] + "\n..."
+				}
+				summaryTexts = append(summaryTexts, fmt.Sprintf("### Source: %s\n%s", s.SourcePath, summary))
 			}
-			summaryTexts = append(summaryTexts, fmt.Sprintf("### Source: %s\n%s", s.SourcePath, summary))
-		}
 
-		// Include previously extracted concepts in the dedup list
-		dedup := make([]string, len(existingList))
-		copy(dedup, existingList)
-		for _, c := range allConcepts {
-			dedup = append(dedup, c.Name)
-		}
+			prompt, err := prompts.Render("extract_concepts", prompts.ExtractData{
+				ExistingConcepts: dedupSnapshot,
+				Summaries:        strings.Join(summaryTexts, "\n\n---\n\n"),
+			}, "")
+			if err != nil {
+				log.Error("render extract_concepts prompt failed", "batch", b.index+1, "error", err)
+				return
+			}
 
-		prompt, err := prompts.Render("extract_concepts", prompts.ExtractData{
-			ExistingConcepts: strings.Join(dedup, ", "),
-			Summaries:        strings.Join(summaryTexts, "\n\n---\n\n"),
-		}, "")
-		if err != nil {
-			log.Error("render extract_concepts prompt failed", "batch", i/batchSize+1, "error", err)
-			continue
-		}
+			resp, err := client.ChatCompletion([]llm.Message{
+				{Role: "system", Content: "You are a concept extraction system for a knowledge wiki. Output valid JSON only."},
+				{Role: "user", Content: prompt},
+			}, llm.CallOpts{Model: model, MaxTokens: maxTokens})
+			if err != nil {
+				log.Error("concept extraction batch failed", "batch", b.index+1, "error", err)
+				return
+			}
 
-		resp, err := client.ChatCompletion([]llm.Message{
-			{Role: "system", Content: "You are a concept extraction system for a knowledge wiki. Output valid JSON only."},
-			{Role: "user", Content: prompt},
-		}, llm.CallOpts{Model: model, MaxTokens: maxTokens})
-		if err != nil {
-			log.Error("concept extraction batch failed", "batch", i/batchSize+1, "error", err)
-			continue // skip failed batch, continue with others
-		}
+			concepts, err := parseConceptsJSON(resp.Content)
+			if err != nil {
+				log.Error("concept extraction parse failed", "batch", b.index+1, "error", err)
+				return
+			}
 
-		concepts, err := parseConceptsJSON(resp.Content)
-		if err != nil {
-			log.Error("concept extraction parse failed", "batch", i/batchSize+1, "error", err)
-			continue
-		}
+			results[b.index] = concepts
+			log.Info("batch concepts extracted", "batch", b.index+1, "count", len(concepts))
+		}(b)
+	}
 
-		allConcepts = append(allConcepts, concepts...)
-		log.Info("batch concepts extracted", "batch", i/batchSize+1, "count", len(concepts))
+	wg.Wait()
+
+	// Flatten results in original batch order
+	var allConcepts []ExtractedConcept
+	for _, r := range results {
+		allConcepts = append(allConcepts, r...)
 	}
 
 	// Filter noise

--- a/internal/compiler/fullpipeline.go
+++ b/internal/compiler/fullpipeline.go
@@ -180,7 +180,7 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 		extCacheID, _ = client.SetupCache("You are an expert knowledge organizer. Extract structured concepts from source summaries.", extractModel)
 	}
 	progress.StartPhase("Pass 2: Extract concepts", len(successfulSummaries))
-	concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
+	concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens, cfg.Compiler.MaxParallel)
 	if err != nil {
 		progress.ItemError("concept extraction", err)
 		result.Errors++

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -740,7 +740,7 @@ func resumeBatch(
 		client.SetPass("extract")
 		extCacheID, _ := client.SetupCache("You are an expert knowledge organizer. Extract structured concepts from source summaries.", model)
 		progress.StartPhase("Pass 2: Extract concepts", len(successfulSummaries))
-		concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, model, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
+		concepts, err := ExtractConcepts(successfulSummaries, mf.Concepts, client, model, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens, cfg.Compiler.MaxParallel)
 		if err != nil {
 			progress.ItemError("concept extraction", err)
 			result.Errors++

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -94,7 +94,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 	}
 
 	log.Info("Pass 2: extracting concepts", "from_summaries", len(summaries))
-	concepts, err := ExtractConcepts(summaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens)
+	concepts, err := ExtractConcepts(summaries, mf.Concepts, client, extractModel, cfg.Compiler.ExtractBatchSize, cfg.Compiler.ExtractMaxTokens, cfg.Compiler.MaxParallel)
 	if err != nil {
 		return nil, fmt.Errorf("re-extract: concept extraction: %w", err)
 	}

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -93,6 +93,7 @@ func NewCascade(provider string, apiKey string, baseURL string, override *EmbedO
 				apiKey:   key,
 				baseURL:  url,
 				dims:     dims,
+				client:   newEmbedHTTPClient(),
 			}
 			if dims > 0 {
 				log.Info("embedding provider detected", "tier", 0, "provider", p, "model", override.Model, "dims", dims)
@@ -112,6 +113,7 @@ func NewCascade(provider string, apiKey string, baseURL string, override *EmbedO
 			apiKey:   apiKey,
 			baseURL:  baseURL,
 			dims:     dims,
+			client:   newEmbedHTTPClient(),
 		}
 		log.Info("embedding provider detected", "tier", 1, "provider", provider, "model", model, "dims", dims)
 		return embedder
@@ -121,13 +123,36 @@ func NewCascade(provider string, apiKey string, baseURL string, override *EmbedO
 	if ollamaAvailable() {
 		log.Info("embedding provider detected", "tier", 2, "provider", "ollama", "model", "nomic-embed-text", "dims", 768)
 		return &OllamaEmbedder{
-			model: "nomic-embed-text",
-			dims:  768,
+			model:  "nomic-embed-text",
+			dims:   768,
+			client: newEmbedHTTPClient(),
 		}
 	}
 
 	log.Warn("no embedding provider available — vector search disabled. Install Ollama or configure an embedding-capable provider.")
 	return nil
+}
+
+// sharedEmbedTransport is a process-wide HTTP transport for embedding API
+// calls. It overrides http.DefaultTransport's MaxIdleConnsPerHost=2 — which
+// causes TCP/TLS churn when Pass-3 write.go and Tier-1 index.go fire many
+// concurrent Embed() calls at a single embedding endpoint. Mirrors the fix in
+// internal/llm/client.go:sharedTransport (PER-116).
+var sharedEmbedTransport http.RoundTripper = func() http.RoundTripper {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.MaxIdleConns = 512
+	tr.MaxIdleConnsPerHost = 256
+	tr.MaxConnsPerHost = 0
+	tr.IdleConnTimeout = 90 * time.Second
+	return tr
+}()
+
+// newEmbedHTTPClient returns a stdlib http.Client that uses sharedEmbedTransport.
+func newEmbedHTTPClient() http.Client {
+	return http.Client{
+		Transport: sharedEmbedTransport,
+		Timeout:   120 * time.Second,
+	}
 }
 
 // APIEmbedder calls a provider's embedding API.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -57,6 +57,23 @@ type Client struct {
 	cacheID  string       // active cache ID (empty = no caching)
 }
 
+// sharedTransport is the HTTP transport reused by every llm.Client.
+// It overrides Go's http.DefaultTransport (which caps MaxIdleConnsPerHost at 2,
+// forcing TCP/TLS churn on ~every concurrent call) and sets MaxConnsPerHost=0
+// (unlimited). This matters when the compiler fires cfg.Compiler.MaxParallel
+// concurrent requests at a single vLLM/Ollama/OpenAI host.
+//
+// Kept as a package-level var so embedding connection pool is shared across
+// Clients in the same process (matches Go's DefaultTransport ergonomics).
+var sharedTransport http.RoundTripper = func() http.RoundTripper {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.MaxIdleConns = 512
+	tr.MaxIdleConnsPerHost = 256
+	tr.MaxConnsPerHost = 0 // unlimited (do not throttle concurrent dials)
+	tr.IdleConnTimeout = 90 * time.Second
+	return tr
+}()
+
 // NewClient creates a new LLM client for the given provider.
 // extraParams (if provided) are merged into every request body — use for
 // provider-specific parameters like Qwen's enable_thinking or DeepSeek's
@@ -67,7 +84,9 @@ func NewClient(providerName string, apiKey string, baseURL string, rateLimit int
 		return nil, err
 	}
 
-	if rateLimit <= 0 {
+	// rateLimit == 0 (omitted) → use provider default (may be 0 for self-hosted).
+	// rateLimit  < 0          → explicit opt-out, disable client-side rate limiting.
+	if rateLimit == 0 {
 		rateLimit = defaultRateLimit(providerName)
 	}
 
@@ -87,7 +106,10 @@ func NewClient(providerName string, apiKey string, baseURL string, rateLimit int
 	return &Client{
 		provider: p,
 		limiter:  newRateLimiter(rateLimit),
-		client:   http.Client{Timeout: 120 * time.Second},
+		client: http.Client{
+			Transport: sharedTransport,
+			Timeout:   120 * time.Second,
+		},
 	}, nil
 }
 
@@ -235,6 +257,16 @@ func newProvider(name string, apiKey string, baseURL string) (Provider, error) {
 	}
 }
 
+// defaultRateLimit returns the default RPM for a provider.
+//
+//   - Public paid APIs get conservative defaults matching their published limits.
+//   - Self-hosted backends (openai-compatible = vLLM/LocalAI/etc., ollama) return
+//     0, meaning "no client-side rate limiting": the compiler's BackpressureController
+//     + server-side capacity are the real governors, and a 1/sec (or 1/2sec) cap
+//     was the hidden reason sage-wiki could not saturate a local GPU endpoint
+//     despite cfg.Compiler.MaxParallel >= 8 (PER-116 / per-112-concurrency-fix).
+//   - Unknown providers keep the previous conservative 30 RPM default — do not
+//     surprise users with unbounded bursts against a new SaaS they wire up.
 func defaultRateLimit(provider string) int {
 	switch provider {
 	case "anthropic":
@@ -245,6 +277,8 @@ func defaultRateLimit(provider string) int {
 		return 60
 	case "gemini":
 		return 60
+	case "openai-compatible", "ollama":
+		return 0 // self-hosted: no client-side RPM cap
 	default:
 		return 30
 	}
@@ -286,28 +320,54 @@ func backoffDelay(attempt int) time.Duration {
 	return time.Duration(delay * float64(time.Second))
 }
 
-// rateLimiter implements a simple token bucket rate limiter.
+// rateLimiter paces outgoing requests so the Client never exceeds a caller-
+// supplied requests-per-minute target. It is an N-goroutine-safe "next available
+// slot" limiter:
+//
+//   - Each goroutine reserves a monotonically advancing wake-up timestamp while
+//     holding the mutex, then releases the mutex BEFORE sleeping. This is the
+//     key fix for PER-116: the previous implementation held the mutex across
+//     time.Sleep(), which serialized ALL concurrent callers to one-per-interval
+//     regardless of cfg.Compiler.MaxParallel. With the mutex released, slots are
+//     still spaced `interval` apart, but goroutines sleep concurrently — so a
+//     burst of N goroutines against a high RPM limit (or a disabled limiter) can
+//     all have their requests in flight simultaneously.
+//
+//   - When requestsPerMinute <= 0 the limiter is disabled (no-op wait). Used by
+//     self-hosted backends where a local GPU endpoint is the real governor.
 type rateLimiter struct {
 	mu       sync.Mutex
-	interval time.Duration
-	lastCall time.Time
+	interval time.Duration // 0 = disabled
+	nextSlot time.Time     // next allowed call start
 }
 
+// newRateLimiter returns a limiter. A non-positive rate means "disabled".
 func newRateLimiter(requestsPerMinute int) *rateLimiter {
-	interval := time.Minute / time.Duration(requestsPerMinute)
-	return &rateLimiter{interval: interval}
+	if requestsPerMinute <= 0 {
+		return &rateLimiter{} // interval=0 → wait() is a no-op
+	}
+	return &rateLimiter{interval: time.Minute / time.Duration(requestsPerMinute)}
 }
 
+// wait blocks just long enough that the calling goroutine's request respects
+// the limiter's spacing. The mutex is NOT held across the sleep.
 func (r *rateLimiter) wait() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	now := time.Now()
-	elapsed := now.Sub(r.lastCall)
-	if elapsed < r.interval {
-		time.Sleep(r.interval - elapsed)
+	if r.interval == 0 {
+		return
 	}
-	r.lastCall = time.Now()
+
+	r.mu.Lock()
+	now := time.Now()
+	wakeAt := r.nextSlot
+	if wakeAt.Before(now) {
+		wakeAt = now
+	}
+	r.nextSlot = wakeAt.Add(r.interval)
+	r.mu.Unlock()
+
+	if d := time.Until(wakeAt); d > 0 {
+		time.Sleep(d)
+	}
 }
 
 // stripThinkTags removes <think>...</think> blocks from LLM responses.

--- a/internal/llm/concurrency_repro_test.go
+++ b/internal/llm/concurrency_repro_test.go
@@ -1,0 +1,150 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestConcurrencyRepro guards against the hidden serialization that caused
+// PER-112 spike #7 to see vllm:num_requests_running ≤ 1 despite
+// cfg.Compiler.MaxParallel = 32 and compiler.backpressure = false.
+//
+// It fires N=32 concurrent ChatCompletion calls against an httptest server
+// whose handler sleeps 500ms per request, and asserts:
+//
+//   - provider "openai-compatible" with the default rate limit (fix: 0 =
+//     disabled): all 32 requests in flight simultaneously, wall ≈ 500ms.
+//   - provider "openai" (public API, default 60 RPM): because wait() no longer
+//     holds the mutex across Sleep, goroutines sleep concurrently. Requests are
+//     SPACED one second apart as intended by the throttle, so peakInFlight
+//     stays small (≤ 2 with a 500ms server + 1s spacing) and wall ≈ 31s — but
+//     critically, the limiter does not serialize across goroutines beyond what
+//     the RPM actually requires.
+//   - explicit rate_limit high enough: acts as "effectively unbounded",
+//     peakInFlight = 32.
+//
+// Before the per-112-concurrency-fix patch, the "openai-compatible" scenario
+// had peakInFlight=1 and wall ≈ 62s (32 × 2s interval × serialized-by-mutex).
+// After the patch, peakInFlight=32 and wall ≈ 500ms.
+//
+// Run:  go test -run TestConcurrencyRepro -v -timeout 180s ./internal/llm/
+func TestConcurrencyRepro(t *testing.T) {
+	server := newMockCompletionServer()
+	defer server.Close()
+
+	type scenario struct {
+		name        string
+		provider    string
+		rateLimit   int
+		wantPeakMin int64         // inclusive lower bound
+		wantWallMax time.Duration // upper bound (per-call latency is 500ms, so gives plenty of margin)
+	}
+
+	scenarios := []scenario{
+		// Sage-wiki's real-world config (provider: openai-compatible, no api.rate_limit
+		// set). With the fix, defaultRateLimit returns 0 for this provider → the
+		// limiter is a no-op and all 32 goroutines' requests fire in parallel.
+		{"openai-compatible-default-is-unlimited", "openai-compatible", 0, 32, 3 * time.Second},
+
+		// Explicit opt-out via rate_limit: -1 (works for any provider).
+		{"explicit-disable-via-negative", "openai", -1, 32, 3 * time.Second},
+
+		// Explicit high cap — effectively unbounded.
+		{"explicit-100krpm", "openai", 100_000, 32, 3 * time.Second},
+
+		// Paid API default stays active: 60 RPM = 1s spacing. Requests overlap
+		// their LLM latency (500ms < 1s spacing) so peakInFlight stays low, but
+		// goroutines SLEEP CONCURRENTLY (fix guarantee) rather than serializing
+		// on the mutex. wall is dominated by RPM pacing: (N-1) * 1s + 0.5s =
+		// 31.5s. Tolerance generous to avoid test flakes.
+		{"openai-60rpm-still-paces-correctly", "openai", 0, 1, 40 * time.Second},
+	}
+
+	for _, sc := range scenarios {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			server.reset()
+			client, err := NewClient(sc.provider, "sk-test", server.URL(), sc.rateLimit)
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+
+			const N = 32
+			var wg sync.WaitGroup
+			start := time.Now()
+			for i := 0; i < N; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, err := client.ChatCompletion([]Message{
+						{Role: "user", Content: "hi"},
+					}, CallOpts{Model: "mock", MaxTokens: 10})
+					if err != nil {
+						t.Errorf("ChatCompletion: %v", err)
+					}
+				}()
+			}
+			wg.Wait()
+			wall := time.Since(start)
+			peak := server.Peak()
+
+			t.Logf("scenario=%s N=%d wall=%s peakInFlight=%d", sc.name, N, wall, peak)
+
+			if peak < sc.wantPeakMin {
+				t.Errorf("peakInFlight = %d, want >= %d", peak, sc.wantPeakMin)
+			}
+			if wall > sc.wantWallMax {
+				t.Errorf("wall = %s, want <= %s", wall, sc.wantWallMax)
+			}
+		})
+	}
+}
+
+// mockCompletionServer is a minimal httptest server that mimics an
+// OpenAI-compatible chat completions endpoint with a fixed 500ms latency.
+// It records the peak number of requests observed in-flight at any one time.
+type mockCompletionServer struct {
+	*httptest.Server
+	inFlight atomic.Int64
+	peak     atomic.Int64
+}
+
+func newMockCompletionServer() *mockCompletionServer {
+	s := &mockCompletionServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := s.inFlight.Add(1)
+		for {
+			p := s.peak.Load()
+			if cur <= p {
+				break
+			}
+			if s.peak.CompareAndSwap(p, cur) {
+				break
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		s.inFlight.Add(-1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": "ok"}},
+			},
+			"model": "mock",
+			"usage": map[string]int{"total_tokens": 10},
+		})
+	}))
+	return s
+}
+
+func (s *mockCompletionServer) URL() string   { return s.Server.URL }
+func (s *mockCompletionServer) Peak() int64   { return s.peak.Load() }
+func (s *mockCompletionServer) reset() {
+	s.inFlight.Store(0)
+	s.peak.Store(0)
+}


### PR DESCRIPTION
## Summary

Follow-up to [#69](https://github.com/xoai/sage-wiki/pull/69). The concurrent-Pass-2 semaphore there is correct on paper, but empirical testing against local vLLM revealed the whole compile pipeline was still effectively N≈1 because of an upstream serialization in `internal/llm/client.go`'s rate limiter. This PR fixes that.

> **Stacked on #69.** Commits visible here = the 3 commits from #69 + this 1 fix commit. When #69 lands, this PR shrinks to the single fix commit and rebases cleanly.

## Empirical evidence

Running `sage-wiki compile` on a real corpus (2 776 LinkedIn markdowns, rented RTX 5090 with vLLM + Jina V5 Nano co-located):

- Config: `compiler.max_parallel: 32`, `compiler.backpressure: false`, `api.provider: openai-compatible`
- `vllm:num_requests_running` sat at **0-1** across hundreds of Prometheus polls over 36 min
- Aggregate: **256 tok/s** — ~10 % of the same hardware's measured synthetic N=32 ceiling (2 628 tok/s)

Pass 2 *appeared* to work with 3-in-flight because per-call latency (~5 s) happened to exceed the limiter interval (2 s), giving steady-state `ceil(5/2) = 3`. Same limiter, same bug — only the visible effect differed by latency ratio.

## Root cause

`rateLimiter.wait()` (called at the top of every `ChatCompletion`):

```go
func (r *rateLimiter) wait() {
    r.mu.Lock()
    defer r.mu.Unlock()                      // held across the Sleep below
    now := time.Now()
    elapsed := now.Sub(r.lastCall)
    if elapsed < r.interval {
        time.Sleep(r.interval - elapsed)     // serializes every concurrent call
    }
    r.lastCall = time.Now()
}
```

At most one goroutine inside `wait()` at any time. Combined with `defaultRateLimit(\"openai-compatible\")` falling into the unlisted `default: 30` arm (= 2 s interval), a local vLLM that decodes in ~2 s per request sees exactly N≈1.

## Fix (three parts)

1. **Release the mutex before sleeping.** `wait()` reserves its next-slot timestamp under the lock, then unlocks and sleeps. RPM pacing for paid APIs is preserved (60 RPM still yields ~1 s start-spacing), but N goroutines now sleep concurrently and overlap actual request latency. Matches `golang.org/x/time/rate` semantics without pulling in the dep.
2. **`defaultRateLimit(\"openai-compatible\")` and `(\"ollama\")` return `0`** — no client-side RPM cap for self-hosted backends. Server-side capacity + `BackpressureController` are the real governors, as intended. Paid providers keep their previous defaults. `rate_limit: -1` is a new explicit opt-out for any provider.
3. **Shared `http.Transport`** with `MaxIdleConnsPerHost: 256, MaxConnsPerHost: 0` in both `internal/llm/client.go` and `internal/embed/embed.go` (stdlib's default of `2` caused TCP/TLS churn under N=32).

Applies uniformly to Pass 1 / Pass 2 / Pass 3 and Tier-1 embed because all share the same `*llm.Client` and both embed constructors now use the shared transport.

## Regression guard

`internal/llm/concurrency_repro_test.go` fires 32 concurrent `ChatCompletion` calls against a 500 ms-per-request `httptest.Server`:

| Scenario | Before | After |
|---|---|---|
| `openai-compatible` default | peakInFlight=**1**, wall=**62 s** | peakInFlight=**32**, wall=**513 ms** |
| `rate_limit: -1` any provider | n/a | peakInFlight=**32** |
| `openai` default 60 RPM | serialized via mutex | paces to ~1 s start-spacing (31.5 s wall), goroutines sleep concurrently |

113× wall reduction at N=32 purely from removing the mutex-across-sleep pattern plus zeroing the self-hosted default.

## Projected impact for self-hosted users

For the LinkedIn corpus run that uncovered this:

- Measured: **\$0.394 / M output** (effective N≈1)
- Projected after fix: **\$0.037 / M output** (true N=32)
- ~10.6× cost reduction, ~11× wall-time reduction

## Notes

- Orthogonal to #69 — fix applies whether that PR merges first or this one does.
- Found during PER-112 / Spike #7 in a downstream HoliMiq project benchmarking inference stacks for LLM-Wiki-style personal knowledge bases. Full root-cause write-up at <https://github.com/ciekawy/obsidian-dashboard/blob/vk/13d2-per-111-vllm-tur/deploy/vastai/reports/sage-wiki-concurrency-fix-20260423.md>.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/llm/...` — `TestConcurrencyRepro` passes under all four scenarios
- [x] Sequential opt-in via `rate_limit: 30` preserves 2 s spacing — no regression for users depending on the old behavior
- [ ] Live compile of a real corpus on self-hosted vLLM — planned as follow-up; will report numbers in the PR thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)