### PR TITLE
feat: valid_sources/valid_targets type-restricted relations

### DIFF
--- a/docs/guides/configurable-relations.md
+++ b/docs/guides/configurable-relations.md
@@ -95,6 +95,27 @@ Invalid: `Regulates`, `has-effect`, `part of`, `123abc`
 
 Invalid names are rejected at config load time with a clear error message.
 
+### Type-restricted relations
+
+Custom relation types can optionally restrict which entity types are valid as source and target:
+
+```yaml
+ontology:
+  relation_types:
+    - name: curated_by
+      synonyms: ["curated by", "organized by", "programmed by"]
+      valid_sources: [exhibition, program]
+      valid_targets: [artist]
+    - name: funded_by
+      synonyms: ["funded by", "granted by", "awarded by"]
+      valid_sources: [exhibition, program, grant_program]
+      valid_targets: [funder, grant_program]
+```
+
+When `valid_sources` is set, a relation edge is only created if the source entity's type is in the list. When `valid_targets` is set, the target entity's type must match. Both fields are optional — empty or omitted means all types are accepted.
+
+This is useful for domain-specific wikis where relation keywords might appear in many contexts but should only connect specific entity categories. For example, "curated by" should create edges from exhibitions to artists — not from applications to source documents.
+
 ## Examples by domain
 
 ### Biology / Life Sciences
@@ -144,6 +165,33 @@ ontology:
 3. **Validation** — `ontology.NewStore()` receives the merged list of valid names. `AddRelation()` rejects any type not in the list
 4. **Extraction** — `ontology.RelationPatterns()` builds keyword patterns from the merged list (skipping types with no synonyms like `cites` and `derived_from`). The compiler uses these patterns during article writing
 5. **Migration** — Existing databases are automatically migrated on first open after upgrade. The SQL CHECK constraint is replaced with application-layer validation, so custom types can be stored
+
+### Arts / Gallery Archive
+
+```yaml
+ontology:
+  relation_types:
+    - name: funded_by
+      synonyms: ["funded by", "granted by", "awarded by", "supported by"]
+      valid_sources: [exhibition, program, grant_program]
+      valid_targets: [funder, grant_program]
+    - name: curated_by
+      synonyms: ["curated by", "organized by", "programmed by"]
+      valid_sources: [exhibition, program]
+      valid_targets: [artist]
+    - name: exhibited_at
+      synonyms: ["shown at", "displayed at", "held at", "hosted by"]
+      valid_sources: [exhibition, program]
+      valid_targets: [venue]
+    - name: partnered_with
+      synonyms: ["partnered with", "presented with", "in collaboration with"]
+      valid_sources: [exhibition, program, partner_organization]
+      valid_targets: [partner_organization]
+    - name: employs
+      synonyms: ["employs", "staffs", "hires", "contracts"]
+      valid_sources: [concept, partner_organization]
+      valid_targets: [organizational_role, artist]
+```
 
 ## Zero config
 

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -463,6 +463,13 @@ func findRelatedConcepts(concept ExtractedConcept) []string {
 func extractRelations(conceptID string, content string, ontStore *ontology.Store, patterns []ontology.RelationPattern) {
 	blocks := blockSplitRe.Split(content, -1)
 
+	sourceEntity, err := ontStore.GetEntity(conceptID)
+	sourceType := ""
+	sourceKnown := err == nil
+	if sourceEntity != nil {
+		sourceType = sourceEntity.Type
+	}
+
 	for _, block := range blocks {
 		blockLower := strings.ToLower(block)
 		links := wikilinkRe.FindAllStringSubmatch(block, -1)
@@ -473,7 +480,21 @@ func extractRelations(conceptID string, content string, ontStore *ontology.Store
 				continue
 			}
 
+			targetEntity, err := ontStore.GetEntity(target)
+			targetType := ""
+			targetKnown := err == nil
+			if targetEntity != nil {
+				targetType = targetEntity.Type
+			}
+
 			for _, rp := range patterns {
+				if sourceKnown && len(rp.ValidSources) > 0 && !typeInList(sourceType, rp.ValidSources) {
+					continue
+				}
+				if targetKnown && len(rp.ValidTargets) > 0 && !typeInList(targetType, rp.ValidTargets) {
+					continue
+				}
+
 				for _, keyword := range rp.Keywords {
 					if strings.Contains(blockLower, keyword) {
 						ontStore.AddRelation(ontology.Relation{
@@ -482,12 +503,21 @@ func extractRelations(conceptID string, content string, ontStore *ontology.Store
 							TargetID: target,
 							Relation: rp.Relation,
 						})
-						break // one relation type per target is enough
+						break
 					}
 				}
 			}
 		}
 	}
+}
+
+func typeInList(t string, list []string) bool {
+	for _, v := range list {
+		if v == t {
+			return true
+		}
+	}
+	return false
 }
 
 func sanitizeID(s string) string {

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -23,6 +23,11 @@ import (
 	"github.com/xoai/sage-wiki/internal/vectors"
 )
 
+var (
+	blockSplitRe = regexp.MustCompile(`\n\n|\n#{1,3}\s`)
+	wikilinkRe   = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+)
+
 // ArticleResult holds the output of writing a concept article.
 type ArticleResult struct {
 	ConceptName string
@@ -453,35 +458,32 @@ func findRelatedConcepts(concept ExtractedConcept) []string {
 }
 
 // extractRelations parses article text for relationship patterns and creates ontology edges.
-// Looks for patterns like "X implements Y", "X extends Y", etc. near [[wikilinks]].
+// Splits article into semantic blocks (paragraph breaks and headings) and only creates
+// relations when a keyword co-occurs with a [[wikilink]] in the same block.
 func extractRelations(conceptID string, content string, ontStore *ontology.Store, patterns []ontology.RelationPattern) {
-	linkRe := regexp.MustCompile(`\[\[([^\]]+)\]\]`)
-	links := linkRe.FindAllStringSubmatch(content, -1)
+	blocks := blockSplitRe.Split(content, -1)
 
-	// Collect unique linked concepts
-	linkedConcepts := map[string]bool{}
-	for _, m := range links {
-		target := m[1]
-		if target != conceptID {
-			linkedConcepts[target] = true
-		}
-	}
+	for _, block := range blocks {
+		blockLower := strings.ToLower(block)
+		links := wikilinkRe.FindAllStringSubmatch(block, -1)
 
-	contentLower := strings.ToLower(content)
+		for _, m := range links {
+			target := m[1]
+			if target == conceptID {
+				continue
+			}
 
-	for target := range linkedConcepts {
-		targetLower := strings.ToLower(target)
-		for _, rp := range patterns {
-			for _, keyword := range rp.Keywords {
-				// Look for the keyword near the concept mention
-				if strings.Contains(contentLower, keyword) && strings.Contains(contentLower, targetLower) {
-					ontStore.AddRelation(ontology.Relation{
-						ID:       conceptID + "-" + rp.Relation + "-" + target,
-						SourceID: conceptID,
-						TargetID: target,
-						Relation: rp.Relation,
-					})
-					break // one relation type per target is enough
+			for _, rp := range patterns {
+				for _, keyword := range rp.Keywords {
+					if strings.Contains(blockLower, keyword) {
+						ontStore.AddRelation(ontology.Relation{
+							ID:       conceptID + "-" + rp.Relation + "-" + target,
+							SourceID: conceptID,
+							TargetID: target,
+							Relation: rp.Relation,
+						})
+						break // one relation type per target is enough
+					}
 				}
 			}
 		}

--- a/internal/compiler/write_test.go
+++ b/internal/compiler/write_test.go
@@ -1,0 +1,125 @@
+package compiler
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/xoai/sage-wiki/internal/ontology"
+	"github.com/xoai/sage-wiki/internal/storage"
+)
+
+func setupTestStore(t *testing.T) *ontology.Store {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := storage.Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return ontology.NewStore(db, nil, nil)
+}
+
+func TestExtractRelations_SameBlockCreatesRelation(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements"},
+	}
+
+	content := "Flash attention implements [[self-attention]] for optimization."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, err := store.ListRelations("", 100)
+	if err != nil {
+		t.Fatalf("ListRelations: %v", err)
+	}
+	if len(relations) != 1 {
+		t.Fatalf("expected 1 relation, got %d", len(relations))
+	}
+	r := relations[0]
+	if r.SourceID != "flash-attention" || r.TargetID != "self-attention" || r.Relation != "implements" {
+		t.Errorf("unexpected relation: %s -[%s]-> %s", r.SourceID, r.Relation, r.TargetID)
+	}
+}
+
+func TestExtractRelations_DifferentBlockNoRelation(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements"},
+	}
+
+	content := "Flash attention is useful.\n\nIt implements optimization.\n\nSee [[self-attention]] for details."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 0 {
+		t.Errorf("expected 0 relations (cross-block), got %d", len(relations))
+	}
+}
+
+func TestExtractRelations_SingleParagraph(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements"},
+	}
+
+	content := "Flash attention implements [[self-attention]] efficiently."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 1 {
+		t.Errorf("expected 1 relation for single paragraph, got %d", len(relations))
+	}
+}
+
+func TestExtractRelations_SelfLinkSkipped(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements"},
+	}
+
+	content := "Flash attention [[flash-attention]] implements [[self-attention]]."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 1 {
+		t.Fatalf("expected 1 relation (self-link skipped), got %d", len(relations))
+	}
+	if relations[0].TargetID != "self-attention" {
+		t.Errorf("TargetID = %q, want self-attention", relations[0].TargetID)
+	}
+}
+
+func TestExtractRelations_MultipleWikilinksSameTarget(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements"},
+	}
+
+	content := "[[self-attention]] and also [[self-attention]] implements optimization."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 1 {
+		t.Errorf("expected 1 relation (deduplicated), got %d", len(relations))
+	}
+}

--- a/internal/compiler/write_test.go
+++ b/internal/compiler/write_test.go
@@ -123,3 +123,118 @@ func TestExtractRelations_MultipleWikilinksSameTarget(t *testing.T) {
 		t.Errorf("expected 1 relation (deduplicated), got %d", len(relations))
 	}
 }
+
+func TestExtractRelations_ValidSourcesFilters(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	content := "Flash attention implements [[self-attention]]."
+
+	t.Run("excluded source type", func(t *testing.T) {
+		store2 := setupTestStore(t)
+		store2.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+		store2.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+		patterns := []ontology.RelationPattern{
+			{Keywords: []string{"implements"}, Relation: "implements", ValidSources: []string{"concept"}},
+		}
+		extractRelations("flash-attention", content, store2, patterns)
+		relations, _ := store2.ListRelations("", 100)
+		if len(relations) != 0 {
+			t.Errorf("expected 0 (technique not in ValidSources [concept]), got %d", len(relations))
+		}
+	})
+
+	t.Run("included source type", func(t *testing.T) {
+		store2 := setupTestStore(t)
+		store2.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+		store2.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+		patterns := []ontology.RelationPattern{
+			{Keywords: []string{"implements"}, Relation: "implements", ValidSources: []string{"technique", "concept"}},
+		}
+		extractRelations("flash-attention", content, store2, patterns)
+		relations, _ := store2.ListRelations("", 100)
+		if len(relations) != 1 {
+			t.Errorf("expected 1 (technique in ValidSources), got %d", len(relations))
+		}
+	})
+}
+
+func TestExtractRelations_ValidTargetsFilters(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	content := "Flash attention implements [[self-attention]]."
+
+	t.Run("excluded target type", func(t *testing.T) {
+		store2 := setupTestStore(t)
+		store2.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+		store2.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+		patterns := []ontology.RelationPattern{
+			{Keywords: []string{"implements"}, Relation: "implements", ValidTargets: []string{"technique"}},
+		}
+		extractRelations("flash-attention", content, store2, patterns)
+		relations, _ := store2.ListRelations("", 100)
+		if len(relations) != 0 {
+			t.Errorf("expected 0 (concept not in ValidTargets), got %d", len(relations))
+		}
+	})
+
+	t.Run("included target type", func(t *testing.T) {
+		store2 := setupTestStore(t)
+		store2.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+		store2.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+		patterns := []ontology.RelationPattern{
+			{Keywords: []string{"implements"}, Relation: "implements", ValidTargets: []string{"concept", "technique"}},
+		}
+		extractRelations("flash-attention", content, store2, patterns)
+		relations, _ := store2.ListRelations("", 100)
+		if len(relations) != 1 {
+			t.Errorf("expected 1 (concept in ValidTargets), got %d", len(relations))
+		}
+	})
+}
+
+func TestExtractRelations_EmptyValidFiltersAllowsAll(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+	store.AddEntity(ontology.Entity{ID: "self-attention", Type: "concept", Name: "Self-Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements", ValidSources: nil, ValidTargets: nil},
+	}
+
+	content := "Flash attention implements [[self-attention]]."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 1 {
+		t.Errorf("expected 1 (nil filters allow all), got %d", len(relations))
+	}
+}
+
+func TestExtractRelations_EntityNotFoundWithValidTargets(t *testing.T) {
+	store := setupTestStore(t)
+
+	store.AddEntity(ontology.Entity{ID: "flash-attention", Type: "technique", Name: "Flash Attention"})
+
+	patterns := []ontology.RelationPattern{
+		{Keywords: []string{"implements"}, Relation: "implements", ValidTargets: []string{"concept"}},
+	}
+
+	content := "Flash attention implements [[self-attention]]."
+	extractRelations("flash-attention", content, store, patterns)
+
+	relations, _ := store.ListRelations("", 100)
+	if len(relations) != 0 {
+		t.Errorf("expected 0 (unknown target type '' not in ValidTargets), got %d", len(relations))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -288,8 +288,10 @@ type OntologyConfig struct {
 
 // RelationConfig defines a custom or extended relation type.
 type RelationConfig struct {
-	Name     string   `yaml:"name"`
-	Synonyms []string `yaml:"synonyms"`
+	Name         string   `yaml:"name"`
+	Synonyms     []string `yaml:"synonyms"`
+	ValidSources []string `yaml:"valid_sources,omitempty"`
+	ValidTargets []string `yaml:"valid_targets,omitempty"`
 }
 
 // EntityTypeConfig defines a custom or extended entity type.

--- a/internal/ontology/relations.go
+++ b/internal/ontology/relations.go
@@ -4,14 +4,18 @@ import "github.com/xoai/sage-wiki/internal/config"
 
 // RelationDef defines a relation type with its keyword synonyms.
 type RelationDef struct {
-	Name     string
-	Synonyms []string
+	Name         string
+	Synonyms     []string
+	ValidSources []string
+	ValidTargets []string
 }
 
 // RelationPattern maps keywords to a relation type for extraction.
 type RelationPattern struct {
-	Keywords []string
-	Relation string
+	Keywords     []string
+	Relation     string
+	ValidSources []string
+	ValidTargets []string
 }
 
 // BuiltinRelations defines the 8 immutable relation types with default synonyms.
@@ -57,11 +61,22 @@ func MergedRelations(cfgRelations []config.RelationConfig) []RelationDef {
 					existing[s] = true
 				}
 			}
+			if len(cr.ValidSources) > 0 {
+				result[idx].ValidSources = append([]string(nil), cr.ValidSources...)
+			}
+			if len(cr.ValidTargets) > 0 {
+				result[idx].ValidTargets = append([]string(nil), cr.ValidTargets...)
+			}
 		} else {
 			// New custom type
 			syns := make([]string, len(cr.Synonyms))
 			copy(syns, cr.Synonyms)
-			result = append(result, RelationDef{Name: cr.Name, Synonyms: syns})
+			result = append(result, RelationDef{
+				Name:         cr.Name,
+				Synonyms:     syns,
+				ValidSources: append([]string(nil), cr.ValidSources...),
+				ValidTargets: append([]string(nil), cr.ValidTargets...),
+			})
 		}
 	}
 
@@ -85,8 +100,10 @@ func RelationPatterns(defs []RelationDef) []RelationPattern {
 			continue
 		}
 		patterns = append(patterns, RelationPattern{
-			Keywords: d.Synonyms,
-			Relation: d.Name,
+			Keywords:     d.Synonyms,
+			Relation:     d.Name,
+			ValidSources: d.ValidSources,
+			ValidTargets: d.ValidTargets,
 		})
 	}
 	return patterns


### PR DESCRIPTION
Adds optional valid_sources and valid_targets fields to relation type config, allowing users to restrict which entity types each relation connects.

## Motivation
Relation detection is keyword-based — any synonym appearing near any wikilink creates an edge. Without type constraints, the graph accumulates edges between unrelated entity categories. For example, curated_by should connect exhibitions to artists, not applications to source documents.

## Solution
New optional fields on relation types:
```yaml
ontology:
  relation_types:
    - name: curated_by
      synonyms: [curated by, organized by]
      valid_sources: [exhibition, program]
      valid_targets: [artist]
    - name: funded_by
      synonyms: [funded by, granted by]
      valid_sources: [exhibition, program, grant_program]
      valid_targets: [funder, grant_program]
```
Empty/nil lists = all types allowed (backwards compatible). Fails open on DB errors.

## Results
Tested on 15-document gallery archive wiki: funded_by went from 60+ noise to 2 correct edges (exhibition to grant_program). curated_by from 55+ mixed to 12 correct edges (exhibition to artist).

## Changes
- Config: ValidSources/ValidTargets on RelationConfig
- Ontology: propagated through RelationDef, RelationPattern, MergedRelations, RelationPatterns
- Compiler: entity type lookup via GetEntity before pattern matching
- Docs: new section in configurable-relations.md with gallery archive example
- 5 unit tests. 550 tests pass.