### PR TITLE
fix(compiler): pass language into hierarchical summary synthesis

### DIFF
--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -234,7 +234,7 @@ func summarizeOne(
 		}
 
 		// Hierarchical synthesis: reduce in groups until we have a single summary
-		summaryText, err = synthesizeHierarchical(chunkSummaries, info.Path, client, model, maxTokens)
+		summaryText, err = synthesizeHierarchical(chunkSummaries, info.Path, client, model, maxTokens, language)
 		if err != nil {
 			result.Error = err
 			return result
@@ -434,7 +434,7 @@ func groupChunks(chunks []extract.Chunk, maxTokens int) [][]extract.Chunk {
 
 // synthesizeHierarchical reduces summaries in tiers of synthesisGroupSize
 // until a single final summary remains.
-func synthesizeHierarchical(summaries []string, sourcePath string, client *llm.Client, model string, maxTokens int) (string, error) {
+func synthesizeHierarchical(summaries []string, sourcePath string, client *llm.Client, model string, maxTokens int, language string) (string, error) {
 	if len(summaries) == 0 {
 		return "", fmt.Errorf("synthesize: no summaries to combine for %q", sourcePath)
 	}
@@ -461,6 +461,12 @@ func synthesizeHierarchical(summaries []string, sourcePath string, client *llm.C
 				"Combine these %d section summaries into a single coherent summary of the source document %q.\n\n%s",
 				len(group), sourcePath, strings.Join(group, "\n\n---\n\n"),
 			)
+			if language != "" {
+				synthesisPrompt += fmt.Sprintf(
+					"\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.",
+					language,
+				)
+			}
 
 			resp, err := client.ChatCompletion([]llm.Message{
 				{Role: "system", Content: "You are synthesizing partial summaries into a final summary."},

--- a/internal/compiler/summarize_test.go
+++ b/internal/compiler/summarize_test.go
@@ -213,7 +213,7 @@ func TestGroupChunksMaxTokensZero(t *testing.T) {
 }
 
 func TestSynthesizeHierarchicalEmpty(t *testing.T) {
-	_, err := synthesizeHierarchical(nil, "test.md", nil, "", 2000)
+	_, err := synthesizeHierarchical(nil, "test.md", nil, "", 2000, "")
 	if err == nil {
 		t.Error("expected error for empty summaries")
 	}
@@ -221,7 +221,7 @@ func TestSynthesizeHierarchicalEmpty(t *testing.T) {
 
 func TestSynthesizeHierarchicalSingleSummary(t *testing.T) {
 	// Single summary should pass through without LLM call
-	result, err := synthesizeHierarchical([]string{"already done"}, "test.md", nil, "", 2000)
+	result, err := synthesizeHierarchical([]string{"already done"}, "test.md", nil, "", 2000, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- pass `language` into `synthesizeHierarchical(...)`
- add a language instruction to the hierarchical synthesis prompt when a target language is set
- update `summarize_test.go` call sites for the new function signature

This keeps the final synthesized summary aligned with the requested output language for multi-chunk documents, instead of only applying language handling at earlier summarization stages.

## Test Plan
- `docker run --rm -v /home/ubuntu/code/sage-wiki:/src -w /src golang:1.26.1 go test ./internal/compiler`

## Risk
- Low: this only changes the hierarchical synthesis path and only affects prompt content when `language` is provided. Existing behavior for empty language values remains unchanged aside from the added parameter plumbing.
