### PR TITLE
fix: wire --config flag to all command handlers

### DIFF
--- a/cmd/sage-wiki/capture.go
+++ b/cmd/sage-wiki/capture.go
@@ -54,7 +54,7 @@ func runCapture(cmd *cobra.Command, args []string) error {
 		return cli.CLIError(outputFormat, fmt.Errorf("content too large (%d bytes, max 100KB)", len(content)))
 	}
 
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return cli.CLIError(outputFormat, err)
 	}

--- a/cmd/sage-wiki/diff.go
+++ b/cmd/sage-wiki/diff.go
@@ -20,7 +20,7 @@ var diffCmd = &cobra.Command{
 func runDiff(cmd *cobra.Command, args []string) error {
 	dir, _ := filepath.Abs(projectDir)
 
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return cli.CLIError(outputFormat, err)
 	}

--- a/cmd/sage-wiki/hub.go
+++ b/cmd/sage-wiki/hub.go
@@ -99,7 +99,7 @@ func runHubAdd(cmd *cobra.Command, args []string) error {
 	dir, _ := filepath.Abs(args[0])
 
 	// Check project has config.yaml
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		errMsg := fmt.Sprintf("not a sage-wiki project (no config.yaml): %s", dir)
 		if outputFormat == "json" {

--- a/cmd/sage-wiki/list.go
+++ b/cmd/sage-wiki/list.go
@@ -53,7 +53,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Entities: need DB + ontology
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return cli.CLIError(outputFormat, err)
 	}

--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -187,7 +187,15 @@ func init() {
 	rootCmd.AddCommand(initCmd, compileCmd, serveCmd, lintCmd, searchCmd, queryCmd, statusCmd, ingestCmd, doctorCmd, tuiCmd, provenanceCmd, scribeCmd, diffCmd, listCmd, ontologyCmd, writeCmd, learnCmd, captureCmd, addSourceCmd, sourceCmd, hubCmd, skillCmd)
 }
 
-// Placeholder implementations — will be filled in subsequent tasks
+func resolveConfigPath(dir string) string {
+	if configPath != "" {
+		if filepath.IsAbs(configPath) {
+			return configPath
+		}
+		return filepath.Join(dir, configPath)
+	}
+	return filepath.Join(dir, "config.yaml")
+}
 
 func runInit(cmd *cobra.Command, args []string) error {
 	vaultMode, _ := cmd.Flags().GetBool("vault")
@@ -199,7 +207,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// If --skill is set on an already-initialized project, skip project creation
 	skillTarget, _ := cmd.Flags().GetString("skill")
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 	_, cfgExists := os.Stat(cfgPath)
 	skipInit := skillTarget != "" && cfgExists == nil
 
@@ -417,7 +425,7 @@ func runLint(cmd *cobra.Command, args []string) error {
 	fix, _ := cmd.Flags().GetBool("fix")
 	passName, _ := cmd.Flags().GetString("pass")
 
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return err
@@ -470,7 +478,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	searcher := hybrid.NewSearcher(memStore, vecStore)
 
 	// Load config to get embed and search weight settings
-	cfg, cfgErr := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, cfgErr := config.Load(resolveConfigPath(dir))
 
 	var queryVec []float32
 	if cfgErr == nil {
@@ -584,7 +592,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 // maybePromptEstimate shows a cost estimate and asks for confirmation
 // if config.compiler.estimate_before is true.
 func maybePromptEstimate(dir string) error {
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return nil // non-fatal — compile will catch config errors
@@ -635,7 +643,7 @@ func maybePromptEstimate(dir string) error {
 }
 
 func runEstimate(dir string) error {
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return err
@@ -742,7 +750,7 @@ func runScribe(cmd *cobra.Command, args []string) error {
 	filePath := args[0]
 
 	// Load config
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 	cfg, err := config.Load(cfgPath)
 	if err != nil {
 		return fmt.Errorf("scribe: load config: %w", err)

--- a/cmd/sage-wiki/ontology_cmd.go
+++ b/cmd/sage-wiki/ontology_cmd.go
@@ -57,7 +57,7 @@ func init() {
 }
 
 func openOntStore(dir string) (*storage.DB, *ontology.Store, error) {
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/sage-wiki/skill_cmd.go
+++ b/cmd/sage-wiki/skill_cmd.go
@@ -38,7 +38,7 @@ func init() {
 
 func loadSkillConfig(cmd *cobra.Command) (*config.Config, skill.AgentTarget, skill.PackName, error) {
 	dir, _ := filepath.Abs(projectDir)
-	cfgPath := filepath.Join(dir, "config.yaml")
+	cfgPath := resolveConfigPath(dir)
 
 	cfg, err := config.Load(cfgPath)
 	if err != nil {

--- a/cmd/sage-wiki/write_cmd.go
+++ b/cmd/sage-wiki/write_cmd.go
@@ -55,7 +55,7 @@ func runWriteSummary(cmd *cobra.Command, args []string) error {
 	content, _ := cmd.Flags().GetString("content")
 	conceptsStr, _ := cmd.Flags().GetString("concepts")
 
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return cli.CLIError(outputFormat, err)
 	}
@@ -112,7 +112,7 @@ func runWriteArticle(cmd *cobra.Command, args []string) error {
 	conceptID, _ := cmd.Flags().GetString("concept")
 	content, _ := cmd.Flags().GetString("content")
 
-	cfg, err := config.Load(filepath.Join(dir, "config.yaml"))
+	cfg, err := config.Load(resolveConfigPath(dir))
 	if err != nil {
 		return cli.CLIError(outputFormat, err)
 	}


### PR DESCRIPTION
## Summary

The `--config` persistent flag is defined in `rootCmd` but never used by any command handler. All 6 places that call `config.Load()` hardcode `filepath.Join(dir, "config.yaml")`, silently ignoring the user-supplied path. This also makes it impossible to load alternate config files that use the `extends` inheritance feature.

## Changes

- Add `resolveConfigPath(dir string) string` helper that returns the `--config` value when set (resolving relative paths against the project directory) and falls back to `<project>/config.yaml` otherwise
- Replace all 6 hardcoded config path constructions with `resolveConfigPath(dir)`

## Test plan

- [x] `go build ./cmd/sage-wiki/` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `sage-wiki --config /path/to/custom.yaml lint` now reads from the specified file
- [x] `sage-wiki --config /nonexistent.yaml lint` errors with config path (previously silently ignored)
- [x] Default behavior (no `--config` flag) unchanged — reads `<project>/config.yaml`