### PR TITLE
fix: OpenAI-compatible API returns empty SSE content

### DIFF
--- a/internal/llm/stream.go
+++ b/internal/llm/stream.go
@@ -61,11 +61,11 @@ func (c *Client) ChatCompletionStream(ctx context.Context, messages []Message, o
 
 		line := scanner.Text()
 
-		if !strings.HasPrefix(line, "data: ") {
+		if !strings.HasPrefix(line, "data:") {
 			continue
 		}
 
-		data := strings.TrimPrefix(line, "data: ")
+		data := strings.TrimPrefix(line, "data:")
 		if data == "[DONE]" {
 			break
 		}


### PR DESCRIPTION
some LLM infer framework like vllm, can return the stream like `data:{` which without the space after `data: `