### PR TITLE
feat: 5-dimension zero-LLM article quality scorer (#97)

### DIFF
--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -485,6 +485,7 @@ func runLint(cmd *cobra.Command, args []string) error {
 		DBPath:           filepath.Join(dir, ".sage", "wiki.db"),
 		ValidRelations:   ontology.ValidRelationNames(mergedRels),
 		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
+		QualityThreshold: cfg.Compiler.QualityThreshold(),
 	}
 
 	runner := linter.NewRunner()

--- a/internal/compiler/confidence.go
+++ b/internal/compiler/confidence.go
@@ -4,39 +4,193 @@ import (
 	"strings"
 
 	"github.com/xoai/sage-wiki/internal/manifest"
-	"github.com/xoai/sage-wiki/internal/ontology"
 )
 
-// ConfidenceScores holds quality metrics for a compiled article.
-type ConfidenceScores struct {
-	SourceCoverage         float64 // % of source key phrases found in article
-	ExtractionCompleteness float64 // % of concepts that have articles
-	CrossRefDensity        float64 // % of concepts with ontology relations
-	Combined               float64 // weighted average (0.0-1.0)
+// QualityScores holds the zero-LLM 5-dimension quality metrics for a
+// compiled article (issue #97). Each dimension is in [0,1]; Combined is the
+// normalised weighted average.
+type QualityScores struct {
+	Format      float64 // valid frontmatter, section headings, balanced code fences
+	Grounding   float64 // fraction of source key phrases present in the article
+	Coverage    float64 // article length adequacy vs. source size
+	Wikilink    float64 // fraction of [[wikilinks]] that resolve to known concepts
+	AntiPattern float64 // inverse of filler/meta-phrase density
+	Combined    float64 // weighted average (0.0–1.0)
 }
 
-// ScoreArticle computes confidence for a compiled article.
-// sourceText is the raw source content, articleText is the compiled article.
-// Scores are per-concept: ExtractionCompleteness and CrossRefDensity evaluate
-// THIS concept specifically, not the global manifest.
-func ScoreArticle(articleText string, sourceText string, conceptName string, mf *manifest.Manifest, ontStore *ontology.Store) ConfidenceScores {
-	scores := ConfidenceScores{}
+// QualityWeights are the per-dimension weights for the composite score.
+type QualityWeights struct {
+	Format      float64
+	Grounding   float64
+	Coverage    float64
+	Wikilink    float64
+	AntiPattern float64
+}
 
-	// Source coverage: what fraction of source key phrases appear in the article
-	scores.SourceCoverage = computeSourceCoverage(articleText, sourceText)
+// DefaultQualityWeights returns the issue #97 proposed weights.
+func DefaultQualityWeights() QualityWeights {
+	return QualityWeights{
+		Format:      0.15,
+		Grounding:   0.30,
+		Coverage:    0.20,
+		Wikilink:    0.15,
+		AntiPattern: 0.20,
+	}
+}
 
-	// Extraction completeness: does THIS concept have an article?
-	scores.ExtractionCompleteness = computeExtractionCompleteness(conceptName, mf)
+// Normalized scales the weights so they sum to 1. If the weights sum to
+// zero (or less), it falls back to DefaultQualityWeights — this guards
+// against a mis-configured all-zero weight set.
+func (w QualityWeights) Normalized() QualityWeights {
+	sum := w.Format + w.Grounding + w.Coverage + w.Wikilink + w.AntiPattern
+	if sum <= 0 {
+		return DefaultQualityWeights()
+	}
+	return QualityWeights{
+		Format:      w.Format / sum,
+		Grounding:   w.Grounding / sum,
+		Coverage:    w.Coverage / sum,
+		Wikilink:    w.Wikilink / sum,
+		AntiPattern: w.AntiPattern / sum,
+	}
+}
 
-	// Cross-reference density: does THIS concept have ontology relations?
-	scores.CrossRefDensity = computeCrossRefDensity(conceptName, ontStore)
+// fillerPhrases are lowercased meta/filler phrases the article prompt is
+// expected to suppress. Hits penalise the AntiPattern dimension. Fixed list
+// (issue #97); refine during calibration.
+var fillerPhrases = []string{
+	"in conclusion",
+	"in summary",
+	"it is important to note",
+	"it's important to note",
+	"it is worth noting",
+	"it's worth noting",
+	"as an ai",
+	"this article discusses",
+	"in this article",
+	"this article will",
+	"delve into",
+	"needless to say",
+	"at the end of the day",
+	"when it comes to",
+	"in today's world",
+	"last but not least",
+}
 
-	// Weighted combination
-	scores.Combined = scores.SourceCoverage*0.4 +
-		scores.ExtractionCompleteness*0.3 +
-		scores.CrossRefDensity*0.3
+// ScoreArticle computes the 5-dimension quality score for a compiled article.
+// articleText is the final on-disk article (frontmatter already built),
+// sourceText is the concatenated raw source content, mf provides the set of
+// known concepts for wikilink resolution, and w supplies the dimension
+// weights (normalised internally). conceptName is retained for signature
+// stability and future per-concept heuristics.
+func ScoreArticle(articleText, sourceText, conceptName string, mf *manifest.Manifest, w QualityWeights) QualityScores {
+	nw := w.Normalized()
 
-	return scores
+	s := QualityScores{
+		Format:      scoreFormat(articleText),
+		Grounding:   scoreGrounding(articleText, sourceText),
+		Coverage:    scoreCoverage(articleText, sourceText),
+		Wikilink:    scoreWikilink(articleText, mf),
+		AntiPattern: scoreAntiPattern(articleText),
+	}
+
+	s.Combined = s.Format*nw.Format +
+		s.Grounding*nw.Grounding +
+		s.Coverage*nw.Coverage +
+		s.Wikilink*nw.Wikilink +
+		s.AntiPattern*nw.AntiPattern
+
+	return s
+}
+
+// scoreFormat averages three structural sub-checks (each 0 or 1):
+// valid frontmatter, at least one section heading, and balanced code fences.
+func scoreFormat(article string) float64 {
+	var score float64
+
+	// Sub-check 1: frontmatter present and carries the concept key.
+	trimmed := strings.TrimSpace(article)
+	if strings.HasPrefix(trimmed, "---") && strings.Contains(article, "concept:") {
+		score++
+	}
+
+	// Sub-check 2: at least one "## " section heading.
+	for _, line := range strings.Split(article, "\n") {
+		if strings.HasPrefix(line, "## ") {
+			score++
+			break
+		}
+	}
+
+	// Sub-check 3: balanced (even) count of code fences.
+	if strings.Count(article, "```")%2 == 0 {
+		score++
+	}
+
+	return score / 3.0
+}
+
+// scoreGrounding measures how well the article reflects the source: the
+// fraction of source key phrases that appear in the article.
+func scoreGrounding(article, source string) float64 {
+	return computeSourceCoverage(article, source)
+}
+
+// scoreCoverage measures article length adequacy relative to source size.
+// expected = clamp(len(source)*0.15, 400, 6000) chars; score = min(1, len/expected).
+func scoreCoverage(article, source string) float64 {
+	if source == "" || article == "" {
+		return 0
+	}
+	expected := clampFloat(float64(len(source))*0.15, 400, 6000)
+	ratio := float64(len(article)) / expected
+	if ratio > 1 {
+		return 1
+	}
+	return ratio
+}
+
+// scoreWikilink returns the fraction of [[wikilinks]] in the article that
+// resolve to a known concept. Resolution uses the manifest concept keyset
+// (fully populated before the write loop), NOT on-disk files, so the score
+// is stable regardless of article write ordering. No links (or no manifest)
+// → 1.0 (nothing broken).
+func scoreWikilink(article string, mf *manifest.Manifest) float64 {
+	links := wikilinkRe.FindAllStringSubmatch(article, -1)
+	if len(links) == 0 || mf == nil {
+		return 1.0
+	}
+	resolved := 0
+	for _, m := range links {
+		if _, ok := mf.Concepts[m[1]]; ok {
+			resolved++
+		}
+	}
+	return float64(resolved) / float64(len(links))
+}
+
+// scoreAntiPattern penalises filler/meta phrases: 1 - min(1, 0.1*hits).
+func scoreAntiPattern(article string) float64 {
+	lower := strings.ToLower(article)
+	hits := 0
+	for _, p := range fillerPhrases {
+		hits += strings.Count(lower, p)
+	}
+	penalty := 0.1 * float64(hits)
+	if penalty > 1 {
+		penalty = 1
+	}
+	return 1 - penalty
+}
+
+func clampFloat(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
 }
 
 // computeSourceCoverage extracts key phrases from the source and checks
@@ -98,37 +252,4 @@ func extractKeyPhrases(text string) []string {
 	}
 
 	return phrases
-}
-
-// computeExtractionCompleteness checks if THIS concept has an article.
-// Returns 1.0 if the concept has an article path, 0.0 otherwise.
-func computeExtractionCompleteness(conceptName string, mf *manifest.Manifest) float64 {
-	if mf == nil || conceptName == "" {
-		return 0
-	}
-	c, ok := mf.Concepts[conceptName]
-	if ok && c.ArticlePath != "" {
-		return 1.0
-	}
-	return 0.0
-}
-
-// computeCrossRefDensity checks if THIS concept has ontology relations.
-// Returns min(1.0, relationsCount / 2.0) — a concept with 2+ relations
-// scores 1.0 (diminishing returns beyond that).
-func computeCrossRefDensity(conceptName string, ontStore *ontology.Store) float64 {
-	if ontStore == nil || conceptName == "" {
-		return 0
-	}
-
-	entity, _ := ontStore.GetEntity(conceptName)
-	if entity == nil {
-		return 0
-	}
-	relations, _ := ontStore.GetRelations(entity.ID, ontology.Both, "")
-	count := float64(len(relations))
-	if count >= 2 {
-		return 1.0
-	}
-	return count / 2.0
 }

--- a/internal/compiler/confidence_test.go
+++ b/internal/compiler/confidence_test.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/xoai/sage-wiki/internal/manifest"
@@ -28,46 +29,6 @@ func TestComputeSourceCoverage_Empty(t *testing.T) {
 	}
 }
 
-func TestComputeExtractionCompleteness_PerConcept(t *testing.T) {
-	mf := manifest.New()
-	mf.AddConcept("concept-a", "wiki/concepts/concept-a.md", []string{"raw/a.md"})
-	mf.AddConcept("concept-b", "", []string{"raw/b.md"}) // no article path
-
-	// concept-a has an article → 1.0
-	if c := computeExtractionCompleteness("concept-a", mf); c != 1.0 {
-		t.Errorf("concept-a completeness = %.2f, want 1.0 (has article)", c)
-	}
-
-	// concept-b has no article → 0.0
-	if c := computeExtractionCompleteness("concept-b", mf); c != 0.0 {
-		t.Errorf("concept-b completeness = %.2f, want 0.0 (no article)", c)
-	}
-
-	// unknown concept → 0.0
-	if c := computeExtractionCompleteness("unknown", mf); c != 0.0 {
-		t.Errorf("unknown completeness = %.2f, want 0.0", c)
-	}
-}
-
-func TestScoreArticle_Combined(t *testing.T) {
-	source := "Neural networks learn hierarchical features. Backpropagation computes gradients efficiently."
-	article := "Neural networks learn hierarchical features through multiple layers. Backpropagation is used to compute gradients."
-
-	mf := manifest.New()
-	mf.AddConcept("neural-networks", "wiki/concepts/neural-networks.md", []string{"raw/nn.md"})
-
-	scores := ScoreArticle(article, source, "neural-networks", mf, nil)
-	if scores.Combined < 0 || scores.Combined > 1 {
-		t.Errorf("combined score = %.2f, should be 0-1", scores.Combined)
-	}
-	if scores.SourceCoverage <= 0 {
-		t.Error("source coverage should be positive")
-	}
-	if scores.ExtractionCompleteness != 1.0 {
-		t.Errorf("extraction completeness = %.2f, want 1.0", scores.ExtractionCompleteness)
-	}
-}
-
 func TestExtractKeyPhrases(t *testing.T) {
 	text := "Self-attention computes contextual representations by weighing tokens. This enables parallel processing of sequences."
 	phrases := extractKeyPhrases(text)
@@ -76,5 +37,124 @@ func TestExtractKeyPhrases(t *testing.T) {
 	}
 	if len(phrases) > 50 {
 		t.Errorf("phrases should be capped at 50, got %d", len(phrases))
+	}
+}
+
+func TestScoreFormat(t *testing.T) {
+	good := "---\nconcept: x\n---\n\nIntro.\n\n## Definition\n\nBody text here."
+	if s := scoreFormat(good); s != 1.0 {
+		t.Errorf("well-formed article Format = %.2f, want 1.0", s)
+	}
+
+	// Heading-less stub still scores > 0 (frontmatter + balanced fences pass).
+	stub := "---\nconcept: x\n---\n\nJust a sentence, no headings."
+	if s := scoreFormat(stub); s <= 0 {
+		t.Errorf("heading-less stub Format = %.2f, want > 0", s)
+	}
+
+	// Unbalanced code fence drops the fence sub-check.
+	unbalanced := "---\nconcept: x\n---\n\n## H\n\n```go\ncode"
+	full := "---\nconcept: x\n---\n\n## H\n\n```go\ncode\n```"
+	if scoreFormat(unbalanced) >= scoreFormat(full) {
+		t.Errorf("unbalanced fences should score lower: %.2f !< %.2f",
+			scoreFormat(unbalanced), scoreFormat(full))
+	}
+}
+
+func TestScoreCoverage(t *testing.T) {
+	// Empty source → 0.
+	if c := scoreCoverage("article", ""); c != 0 {
+		t.Errorf("empty source coverage = %.2f, want 0", c)
+	}
+	// Long article vs small source → capped at 1.0.
+	src := strings.Repeat("x", 1000)
+	long := strings.Repeat("y", 5000)
+	if c := scoreCoverage(long, src); c != 1.0 {
+		t.Errorf("long article coverage = %.2f, want 1.0 (capped)", c)
+	}
+	// Very short article vs large source → < 1.0.
+	bigSrc := strings.Repeat("x", 100000)
+	short := strings.Repeat("y", 100)
+	if c := scoreCoverage(short, bigSrc); c >= 1.0 {
+		t.Errorf("short article vs huge source = %.2f, want < 1.0", c)
+	}
+}
+
+func TestScoreWikilink(t *testing.T) {
+	mf := manifest.New()
+	mf.AddConcept("alpha", "wiki/concepts/alpha.md", []string{"raw/a.md"})
+	mf.AddConcept("beta", "wiki/concepts/beta.md", []string{"raw/b.md"})
+
+	// No links → 1.0 (nothing broken).
+	if w := scoreWikilink("plain text, no links", mf); w != 1.0 {
+		t.Errorf("no-links Wikilink = %.2f, want 1.0", w)
+	}
+	// Nil manifest → 1.0.
+	if w := scoreWikilink("see [[alpha]]", nil); w != 1.0 {
+		t.Errorf("nil-manifest Wikilink = %.2f, want 1.0", w)
+	}
+	// All resolve → 1.0.
+	if w := scoreWikilink("see [[alpha]] and [[beta]]", mf); w != 1.0 {
+		t.Errorf("all-resolve Wikilink = %.2f, want 1.0", w)
+	}
+	// Half resolve → 0.5.
+	if w := scoreWikilink("see [[alpha]] and [[ghost]]", mf); w != 0.5 {
+		t.Errorf("half-resolve Wikilink = %.2f, want 0.5", w)
+	}
+}
+
+func TestScoreAntiPattern(t *testing.T) {
+	clean := "Self-attention computes weighted token representations efficiently."
+	if a := scoreAntiPattern(clean); a != 1.0 {
+		t.Errorf("clean article AntiPattern = %.2f, want 1.0", a)
+	}
+	// Filler phrases drop the score.
+	filler := "In conclusion, it is important to note that this article will delve into the topic."
+	if a := scoreAntiPattern(filler); a >= 1.0 {
+		t.Errorf("filler-laden article AntiPattern = %.2f, want < 1.0", a)
+	}
+	// Heavy filler floors at 0 (never negative).
+	heavy := strings.Repeat("in conclusion ", 50)
+	if a := scoreAntiPattern(heavy); a < 0 {
+		t.Errorf("AntiPattern = %.2f, must not go negative", a)
+	}
+}
+
+func TestQualityWeightsNormalized(t *testing.T) {
+	w := QualityWeights{Format: 1, Grounding: 1, Coverage: 1, Wikilink: 1, AntiPattern: 1}.Normalized()
+	sum := w.Format + w.Grounding + w.Coverage + w.Wikilink + w.AntiPattern
+	if sum < 0.999 || sum > 1.001 {
+		t.Errorf("normalized weights sum = %.4f, want 1.0", sum)
+	}
+	if w.Format < 0.199 || w.Format > 0.201 {
+		t.Errorf("equal weights should each normalize to 0.2, got %.4f", w.Format)
+	}
+
+	// All-zero weights fall back to defaults.
+	zero := QualityWeights{}.Normalized()
+	if zero != DefaultQualityWeights() {
+		t.Errorf("all-zero weights should fall back to defaults, got %+v", zero)
+	}
+}
+
+func TestScoreArticle_Combined(t *testing.T) {
+	source := "Neural networks learn hierarchical features. Backpropagation computes gradients efficiently."
+	article := "---\nconcept: neural-networks\n---\n\n## Definition\n\nNeural networks learn hierarchical features through multiple layers. Backpropagation is used to compute gradients."
+
+	mf := manifest.New()
+	mf.AddConcept("neural-networks", "wiki/concepts/neural-networks.md", []string{"raw/nn.md"})
+
+	scores := ScoreArticle(article, source, "neural-networks", mf, DefaultQualityWeights())
+	if scores.Combined < 0 || scores.Combined > 1 {
+		t.Errorf("combined score = %.2f, should be 0-1", scores.Combined)
+	}
+	if scores.Format != 1.0 {
+		t.Errorf("well-formed article Format = %.2f, want 1.0", scores.Format)
+	}
+	if scores.Grounding <= 0 {
+		t.Error("grounding should be positive (source phrases present)")
+	}
+	if scores.Wikilink != 1.0 {
+		t.Errorf("no wikilinks → Wikilink = %.2f, want 1.0", scores.Wikilink)
 	}
 }

--- a/internal/compiler/fullpipeline.go
+++ b/internal/compiler/fullpipeline.go
@@ -313,6 +313,12 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 		Backpressure:     opts.Backpressure,
 	}, concepts)
 
+	// Quality scoring config (issue #97): weights + warning threshold.
+	wf, wg, wc, ww, wa := cfg.Compiler.QualityWeights()
+	qualityWeights := QualityWeights{Format: wf, Grounding: wg, Coverage: wc, Wikilink: ww, AntiPattern: wa}
+	qualityThreshold := cfg.Compiler.QualityThreshold()
+	belowThreshold := 0
+
 	for _, ar := range articles {
 		if ar.Error != nil {
 			result.Errors++
@@ -324,7 +330,15 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 			// Per-article quality scoring
 			if opts.ItemStore != nil {
 				articlePath := filepath.Join(opts.ProjectDir, ar.ArticlePath)
-				articleContent, _ := os.ReadFile(articlePath)
+				articleContent, readErr := os.ReadFile(articlePath)
+				if readErr != nil {
+					// Don't score an unreadable article — an empty read would
+					// produce a spurious near-zero score and false low-quality
+					// warning. Surface the error and skip scoring (no silent fail).
+					log.Warn("quality scoring skipped: read article failed",
+						"concept", ar.ConceptName, "path", ar.ArticlePath, "error", readErr)
+					continue
+				}
 
 				// Read source content for coverage scoring
 				var sourceText string
@@ -337,21 +351,30 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 					}
 				}
 
-				scores := ScoreArticle(string(articleContent), sourceText, ar.ConceptName, mf, writeOntStore)
+				scores := ScoreArticle(string(articleContent), sourceText, ar.ConceptName, mf, qualityWeights)
 				for _, srcPath := range mf.Concepts[ar.ConceptName].Sources {
 					if err := opts.ItemStore.SetQualityScore(srcPath, scores.Combined); err != nil {
 						log.Warn("set quality score failed", "path", srcPath, "error", err)
 					}
 				}
 
-				if scores.Combined < 0.5 {
+				if scores.Combined < qualityThreshold {
+					belowThreshold++
 					log.Warn("low quality article", "concept", ar.ConceptName,
-						"score", scores.Combined, "coverage", scores.SourceCoverage,
-						"completeness", scores.ExtractionCompleteness, "crossref", scores.CrossRefDensity)
+						"score", scores.Combined, "format", scores.Format,
+						"grounding", scores.Grounding, "coverage", scores.Coverage,
+						"wikilink", scores.Wikilink, "antipattern", scores.AntiPattern)
 				}
 			}
 		}
 	}
+
+	// Compile-end summary: surface how many articles fell below the threshold.
+	if belowThreshold > 0 {
+		log.Warn("articles below quality threshold",
+			"count", belowThreshold, "total", result.ArticlesWritten, "threshold", qualityThreshold)
+	}
+
 	progress.EndPhase()
 	client.TeardownCache(writeCacheID)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,18 +16,18 @@ var typeNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 // Config represents the sage-wiki project configuration.
 type Config struct {
-	Extends     string       `yaml:"extends,omitempty"`
-	Version     int          `yaml:"version"`
-	Project     string       `yaml:"project"`
-	Description string       `yaml:"description"`
-	Language    string       `yaml:"language,omitempty"`
-	Vault       *VaultConfig `yaml:"vault,omitempty"`
-	Sources     []Source     `yaml:"sources"`
-	Output      string       `yaml:"output"`
-	Ignore      []string     `yaml:"ignore,omitempty"`
-	API         APIConfig    `yaml:"api"`
-	Models      ModelsConfig `yaml:"models"`
-	Embed       *EmbedConfig `yaml:"embed,omitempty"`
+	Extends     string         `yaml:"extends,omitempty"`
+	Version     int            `yaml:"version"`
+	Project     string         `yaml:"project"`
+	Description string         `yaml:"description"`
+	Language    string         `yaml:"language,omitempty"`
+	Vault       *VaultConfig   `yaml:"vault,omitempty"`
+	Sources     []Source       `yaml:"sources"`
+	Output      string         `yaml:"output"`
+	Ignore      []string       `yaml:"ignore,omitempty"`
+	API         APIConfig      `yaml:"api"`
+	Models      ModelsConfig   `yaml:"models"`
+	Embed       *EmbedConfig   `yaml:"embed,omitempty"`
 	Compiler    CompilerConfig `yaml:"compiler"`
 	Search      SearchConfig   `yaml:"search"`
 	Linting     LintingConfig  `yaml:"linting"`
@@ -50,7 +50,7 @@ type Source struct {
 
 type APIConfig struct {
 	Provider    string                 `yaml:"provider"`
-	Auth        string                 `yaml:"auth,omitempty"`         // "api_key" (default) or "subscription"
+	Auth        string                 `yaml:"auth,omitempty"` // "api_key" (default) or "subscription"
 	APIKey      string                 `yaml:"api_key"`
 	BaseURL     string                 `yaml:"base_url,omitempty"`
 	RateLimit   int                    `yaml:"rate_limit,omitempty"`
@@ -75,36 +75,36 @@ type EmbedConfig struct {
 }
 
 type CompilerConfig struct {
-	MaxParallel      int     `yaml:"max_parallel"`
-	DebounceSeconds  int     `yaml:"debounce_seconds"`
-	SummaryMaxTokens int     `yaml:"summary_max_tokens"`
-	ArticleMaxTokens int     `yaml:"article_max_tokens"`
-	ExtractMaxTokens int     `yaml:"extract_max_tokens,omitempty"`  // max output tokens for concept extraction (default: 8192)
-	ExtractBatchSize int     `yaml:"extract_batch_size,omitempty"`  // summaries per concept extraction call (default: 20)
-	AutoCommit       bool    `yaml:"auto_commit"`
-	AutoLint         bool    `yaml:"auto_lint"`
-	Mode             string  `yaml:"mode,omitempty"`              // standard, batch, or auto
-	EstimateBefore   bool    `yaml:"estimate_before,omitempty"`   // prompt with cost estimate before compiling
-	PromptCache      *bool   `yaml:"prompt_cache,omitempty"`      // enable prompt caching (default: true)
-	BatchThreshold   int     `yaml:"batch_threshold,omitempty"`   // min sources to auto-select batch mode
-	TokenPriceOverride float64 `yaml:"token_price_per_million,omitempty"` // override price per 1M input tokens
-	Timezone         string   `yaml:"timezone,omitempty"`          // IANA timezone for user-facing timestamps (default: UTC)
-	ArticleFields    []string `yaml:"article_fields,omitempty"`    // custom frontmatter fields extracted from LLM response
+	MaxParallel        int      `yaml:"max_parallel"`
+	DebounceSeconds    int      `yaml:"debounce_seconds"`
+	SummaryMaxTokens   int      `yaml:"summary_max_tokens"`
+	ArticleMaxTokens   int      `yaml:"article_max_tokens"`
+	ExtractMaxTokens   int      `yaml:"extract_max_tokens,omitempty"` // max output tokens for concept extraction (default: 8192)
+	ExtractBatchSize   int      `yaml:"extract_batch_size,omitempty"` // summaries per concept extraction call (default: 20)
+	AutoCommit         bool     `yaml:"auto_commit"`
+	AutoLint           bool     `yaml:"auto_lint"`
+	Mode               string   `yaml:"mode,omitempty"`                    // standard, batch, or auto
+	EstimateBefore     bool     `yaml:"estimate_before,omitempty"`         // prompt with cost estimate before compiling
+	PromptCache        *bool    `yaml:"prompt_cache,omitempty"`            // enable prompt caching (default: true)
+	BatchThreshold     int      `yaml:"batch_threshold,omitempty"`         // min sources to auto-select batch mode
+	TokenPriceOverride float64  `yaml:"token_price_per_million,omitempty"` // override price per 1M input tokens
+	Timezone           string   `yaml:"timezone,omitempty"`                // IANA timezone for user-facing timestamps (default: UTC)
+	ArticleFields      []string `yaml:"article_fields,omitempty"`          // custom frontmatter fields extracted from LLM response
 
 	// Tiered compilation
-	DefaultTier      int            `yaml:"default_tier,omitempty"`       // default tier for sources (default: 3)
-	TierDefaults     map[string]int `yaml:"tier_defaults,omitempty"`      // file extension → default tier
-	AutoPromote      *bool          `yaml:"auto_promote,omitempty"`       // auto-promote based on signals (default: true)
-	PromoteSignals   PromoteSignals `yaml:"promote_signals,omitempty"`
-	AutoDemote       *bool          `yaml:"auto_demote,omitempty"`        // auto-demote stale articles (default: true)
-	DemoteSignals    DemoteSignals  `yaml:"demote_signals,omitempty"`
+	DefaultTier    int            `yaml:"default_tier,omitempty"`  // default tier for sources (default: 3)
+	TierDefaults   map[string]int `yaml:"tier_defaults,omitempty"` // file extension → default tier
+	AutoPromote    *bool          `yaml:"auto_promote,omitempty"`  // auto-promote based on signals (default: true)
+	PromoteSignals PromoteSignals `yaml:"promote_signals,omitempty"`
+	AutoDemote     *bool          `yaml:"auto_demote,omitempty"` // auto-demote stale articles (default: true)
+	DemoteSignals  DemoteSignals  `yaml:"demote_signals,omitempty"`
 
 	// Document splitting (Phase B)
-	SplitThreshold   int    `yaml:"split_threshold,omitempty"`    // chars, enable section-aware writing above this (default: 15000)
-	SplitStrategy    string `yaml:"split_strategy,omitempty"`     // "headings" (default)
+	SplitThreshold int    `yaml:"split_threshold,omitempty"` // chars, enable section-aware writing above this (default: 15000)
+	SplitStrategy  string `yaml:"split_strategy,omitempty"`  // "headings" (default)
 
 	// Backpressure
-	BackpressureEnabled *bool `yaml:"backpressure,omitempty"`     // enable adaptive backpressure (default: true)
+	BackpressureEnabled *bool `yaml:"backpressure,omitempty"` // enable adaptive backpressure (default: true)
 
 	// Concept deduplication
 	DedupThreshold float64 `yaml:"dedup_threshold,omitempty"` // cosine similarity for auto-merge (default: 0.85)
@@ -113,16 +113,80 @@ type CompilerConfig struct {
 	// Wikilink validation
 	StripBrokenLinks *bool `yaml:"strip_broken_links,omitempty"` // strip [[wikilinks]] to non-existent concept articles after compile (default: true). Set false to preserve broken links (useful when expecting future compiles to fill them in). Issue #90.
 
+	// Article quality scoring (issue #97)
+	Quality QualityConfig `yaml:"quality,omitempty"`
+
 	resolvedTZ *time.Location `yaml:"-"` // cached by Validate(); not serialized
+}
+
+// QualityConfig configures the zero-LLM 5-dimension article quality scorer
+// (issue #97). All fields default when zero — see CompilerConfig.QualityThreshold
+// and CompilerConfig.QualityWeights. The composite score is stored in
+// compile_items.quality_score and surfaced (not gated) by `sage-wiki lint`.
+type QualityConfig struct {
+	Threshold         float64 `yaml:"threshold,omitempty"`          // warn below this composite score (default: 0.5)
+	WeightFormat      float64 `yaml:"weight_format,omitempty"`      // default: 0.15
+	WeightGrounding   float64 `yaml:"weight_grounding,omitempty"`   // default: 0.30
+	WeightCoverage    float64 `yaml:"weight_coverage,omitempty"`    // default: 0.20
+	WeightWikilink    float64 `yaml:"weight_wikilink,omitempty"`    // default: 0.15
+	WeightAntiPattern float64 `yaml:"weight_antipattern,omitempty"` // default: 0.20
+}
+
+// Default quality weights (issue #97 proposal). Kept here so the config
+// accessors can supply per-field fallbacks without importing the compiler.
+const (
+	defaultQualityThreshold         = 0.5
+	defaultQualityWeightFormat      = 0.15
+	defaultQualityWeightGrounding   = 0.30
+	defaultQualityWeightCoverage    = 0.20
+	defaultQualityWeightWikilink    = 0.15
+	defaultQualityWeightAntiPattern = 0.20
+)
+
+// QualityThreshold returns the configured low-quality warning threshold,
+// or the default (0.5) when unset.
+func (c CompilerConfig) QualityThreshold() float64 {
+	if c.Quality.Threshold > 0 {
+		return c.Quality.Threshold
+	}
+	return defaultQualityThreshold
+}
+
+// QualityWeights returns the five scorer dimension weights as plain floats
+// (config must not import the compiler package). Each field falls back to
+// its #97 default when left at zero, so partial overrides work.
+func (c CompilerConfig) QualityWeights() (format, grounding, coverage, wikilink, antiPattern float64) {
+	q := c.Quality
+	format = q.WeightFormat
+	if format == 0 {
+		format = defaultQualityWeightFormat
+	}
+	grounding = q.WeightGrounding
+	if grounding == 0 {
+		grounding = defaultQualityWeightGrounding
+	}
+	coverage = q.WeightCoverage
+	if coverage == 0 {
+		coverage = defaultQualityWeightCoverage
+	}
+	wikilink = q.WeightWikilink
+	if wikilink == 0 {
+		wikilink = defaultQualityWeightWikilink
+	}
+	antiPattern = q.WeightAntiPattern
+	if antiPattern == 0 {
+		antiPattern = defaultQualityWeightAntiPattern
+	}
+	return format, grounding, coverage, wikilink, antiPattern
 }
 
 // PromoteSignals configures when sources are promoted to higher tiers.
 type PromoteSignals struct {
-	QueryHitCount    int    `yaml:"query_hit_count,omitempty"`    // promote after N search hits (default: 3)
-	ClusterSize      int    `yaml:"cluster_size,omitempty"`       // promote when N+ sources on same topic (default: 5)
-	ManualTag        string `yaml:"manual_tag,omitempty"`         // promote if tagged (default: "compile")
-	ImportCentrality int    `yaml:"import_centrality,omitempty"`  // code: promote when N+ files import this (default: 10)
-	SourceRecencyDays int   `yaml:"source_recency_days,omitempty"` // boost recently modified (default: 7)
+	QueryHitCount     int    `yaml:"query_hit_count,omitempty"`     // promote after N search hits (default: 3)
+	ClusterSize       int    `yaml:"cluster_size,omitempty"`        // promote when N+ sources on same topic (default: 5)
+	ManualTag         string `yaml:"manual_tag,omitempty"`          // promote if tagged (default: "compile")
+	ImportCentrality  int    `yaml:"import_centrality,omitempty"`   // code: promote when N+ files import this (default: 10)
+	SourceRecencyDays int    `yaml:"source_recency_days,omitempty"` // boost recently modified (default: 7)
 }
 
 // DemoteSignals configures when sources are demoted to lower tiers.
@@ -173,10 +237,10 @@ type SearchConfig struct {
 	ChunkSize          int     `yaml:"chunk_size,omitempty"`      // tokens per chunk for indexing (default: 800)
 
 	// Graph-enhanced retrieval
-	GraphExpansion       *bool   `yaml:"graph_expansion,omitempty"`        // enable graph-based context expansion (default: true)
-	GraphMaxExpand       int     `yaml:"graph_max_expand,omitempty"`       // max articles added via graph (default: 10)
-	GraphDepth           int     `yaml:"graph_depth,omitempty"`            // traversal depth for expansion (default: 2)
-	ContextMaxTokens     int     `yaml:"context_max_tokens,omitempty"`     // token budget for query context (default: 8000)
+	GraphExpansion       *bool    `yaml:"graph_expansion,omitempty"`        // enable graph-based context expansion (default: true)
+	GraphMaxExpand       int      `yaml:"graph_max_expand,omitempty"`       // max articles added via graph (default: 10)
+	GraphDepth           int      `yaml:"graph_depth,omitempty"`            // traversal depth for expansion (default: 2)
+	ContextMaxTokens     int      `yaml:"context_max_tokens,omitempty"`     // token budget for query context (default: 8000)
 	WeightDirectLink     *float64 `yaml:"weight_direct_link,omitempty"`     // graph signal weight (default: 3.0, set 0 to disable)
 	WeightSourceOverlap  *float64 `yaml:"weight_source_overlap,omitempty"`  // graph signal weight (default: 4.0, set 0 to disable)
 	WeightCommonNeighbor *float64 `yaml:"weight_common_neighbor,omitempty"` // graph signal weight (default: 1.5, set 0 to disable)
@@ -318,11 +382,11 @@ type EntityTypeConfig struct {
 
 // TrustConfig controls the output trust system (staged QA for query outputs).
 type TrustConfig struct {
-	IncludeOutputs      string   `yaml:"include_outputs,omitempty"`      // "false" (default), "verified", "true"
-	ConsensusThreshold  int      `yaml:"consensus_threshold,omitempty"`  // confirmations for promotion (default: 3)
-	GroundingThreshold  float64  `yaml:"grounding_threshold,omitempty"`  // min grounding score (default: 0.8)
-	AutoPromote         *bool    `yaml:"auto_promote,omitempty"`         // auto-promote when thresholds met (default: true)
-	SimilarityThreshold float64  `yaml:"similarity_threshold,omitempty"` // cosine sim for question matching (default: 0.85)
+	IncludeOutputs      string  `yaml:"include_outputs,omitempty"`      // "false" (default), "verified", "true"
+	ConsensusThreshold  int     `yaml:"consensus_threshold,omitempty"`  // confirmations for promotion (default: 3)
+	GroundingThreshold  float64 `yaml:"grounding_threshold,omitempty"`  // min grounding score (default: 0.8)
+	AutoPromote         *bool   `yaml:"auto_promote,omitempty"`         // auto-promote when thresholds met (default: true)
+	SimilarityThreshold float64 `yaml:"similarity_threshold,omitempty"` // cosine sim for question matching (default: 0.85)
 }
 
 // IncludeOutputsMode returns the effective include_outputs mode.
@@ -603,6 +667,27 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: invalid compiler.timezone %q: %w", c.Compiler.Timezone, err)
 		}
 		c.Compiler.resolvedTZ = loc
+	}
+	// Quality scorer ranges (issue #97). Zero is valid everywhere — it means
+	// "use the default" (see QualityThreshold / QualityWeights). Reject only
+	// out-of-range values, never zero.
+	if t := c.Compiler.Quality.Threshold; t < 0 || t > 1 {
+		return fmt.Errorf("config: compiler.quality.threshold must be in [0,1], got %g", t)
+	}
+	qw := []struct {
+		name string
+		val  float64
+	}{
+		{"weight_format", c.Compiler.Quality.WeightFormat},
+		{"weight_grounding", c.Compiler.Quality.WeightGrounding},
+		{"weight_coverage", c.Compiler.Quality.WeightCoverage},
+		{"weight_wikilink", c.Compiler.Quality.WeightWikilink},
+		{"weight_antipattern", c.Compiler.Quality.WeightAntiPattern},
+	}
+	for _, w := range qw {
+		if w.val < 0 {
+			return fmt.Errorf("config: compiler.quality.%s must be >= 0, got %g", w.name, w.val)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -507,9 +507,9 @@ func TestCostConfigDefaults(t *testing.T) {
 
 func TestInvalidCompilerMode(t *testing.T) {
 	cfg := Config{
-		Project: "test",
-		Output:  "wiki",
-		Sources: []Source{{Path: "raw"}},
+		Project:  "test",
+		Output:   "wiki",
+		Sources:  []Source{{Path: "raw"}},
 		Compiler: CompilerConfig{Mode: "turbo"},
 	}
 	err := cfg.Validate()
@@ -550,9 +550,9 @@ func TestUserTimeLocation(t *testing.T) {
 
 	// Validate() path: timezone resolved and cached during validation
 	cfg := Config{
-		Project: "test",
-		Output:  "wiki",
-		Sources: []Source{{Path: "raw"}},
+		Project:  "test",
+		Output:   "wiki",
+		Sources:  []Source{{Path: "raw"}},
 		Compiler: CompilerConfig{Timezone: "America/New_York"},
 	}
 	if err := cfg.Validate(); err != nil {
@@ -757,4 +757,86 @@ func searchString(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestQualityDefaults(t *testing.T) {
+	cfg := Defaults()
+	if got := cfg.Compiler.QualityThreshold(); got != 0.5 {
+		t.Errorf("default quality threshold = %g, want 0.5", got)
+	}
+	f, g, c, w, a := cfg.Compiler.QualityWeights()
+	if f != 0.15 || g != 0.30 || c != 0.20 || w != 0.15 || a != 0.20 {
+		t.Errorf("default weights = %g/%g/%g/%g/%g, want 0.15/0.30/0.20/0.15/0.20", f, g, c, w, a)
+	}
+}
+
+func TestQualityPartialOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "sage.yaml")
+	content := `project: test
+output: wiki
+api:
+  provider: anthropic
+  api_key: sk-test
+compiler:
+  quality:
+    threshold: 0.7
+    weight_grounding: 0.5
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if got := cfg.Compiler.QualityThreshold(); got != 0.7 {
+		t.Errorf("threshold = %g, want 0.7 (overridden)", got)
+	}
+	f, g, c, w, a := cfg.Compiler.QualityWeights()
+	if g != 0.5 {
+		t.Errorf("weight_grounding = %g, want 0.5 (overridden)", g)
+	}
+	// Unset weights fall back to defaults (partial override).
+	if f != 0.15 || c != 0.20 || w != 0.15 || a != 0.20 {
+		t.Errorf("fallback weights = %g/%g/%g/%g, want 0.15/0.20/0.15/0.20", f, c, w, a)
+	}
+}
+
+func TestQualityValidate(t *testing.T) {
+	base := func() Config {
+		c := Defaults()
+		c.Project = "test"
+		c.Output = "wiki"
+		c.Sources = []Source{{Path: "raw"}}
+		return c
+	}
+
+	// Zero-value Quality MUST validate (DefaultConfig leaves it zero).
+	zv := base()
+	if err := zv.Validate(); err != nil {
+		t.Fatalf("zero-value Quality should validate, got: %v", err)
+	}
+
+	// threshold > 1 rejected.
+	c := base()
+	c.Compiler.Quality.Threshold = 1.5
+	if err := c.Validate(); err == nil {
+		t.Error("threshold 1.5 should be rejected")
+	}
+
+	// negative weight rejected.
+	c = base()
+	c.Compiler.Quality.WeightFormat = -0.1
+	if err := c.Validate(); err == nil {
+		t.Error("negative weight should be rejected")
+	}
+
+	// in-range values accepted.
+	c = base()
+	c.Compiler.Quality.Threshold = 0.6
+	c.Compiler.Quality.WeightCoverage = 0.25
+	if err := c.Validate(); err != nil {
+		t.Errorf("valid quality config rejected: %v", err)
+	}
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1,6 +1,7 @@
 package linter
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -240,5 +241,57 @@ func TestRecallLearnings(t *testing.T) {
 	results, _ := RecallLearnings(db, "attention", 5)
 	if len(results) != 1 {
 		t.Errorf("expected 1 matching learning, got %d", len(results))
+	}
+}
+
+// TestQualityPassThresholdPrecedence verifies the issue #97 threshold
+// precedence: LintContext.QualityThreshold (>0) → pass field (>0) → 0.5.
+func TestQualityPassThresholdPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "wiki.db")
+	db, err := storage.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// One article scoring 0.6.
+	if err := db.WriteTx(func(tx *sql.Tx) error {
+		_, e := tx.Exec("INSERT INTO compile_items (source_path, quality_score) VALUES (?, ?)", "raw/a.md", 0.6)
+		return e
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	flagged := func(ctxThreshold, fieldThreshold float64) bool {
+		pass := &QualityPass{Threshold: fieldThreshold}
+		ctx := &LintContext{DB: db, QualityThreshold: ctxThreshold}
+		findings, err := pass.Run(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range findings {
+			if f.Path == "raw/a.md" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// ctx threshold wins: 0.7 > 0.6 → flagged.
+	if !flagged(0.7, 0) {
+		t.Error("ctx threshold 0.7 should flag score 0.6")
+	}
+	// ctx threshold 0.5 ≤ 0.6 → not flagged (ctx takes precedence).
+	if flagged(0.5, 0.9) {
+		t.Error("ctx threshold 0.5 should win over field and not flag 0.6")
+	}
+	// ctx 0 → fall back to field 0.7 → flagged.
+	if !flagged(0, 0.7) {
+		t.Error("field threshold 0.7 should flag when ctx is 0")
+	}
+	// both 0 → default 0.5 ≤ 0.6 → not flagged.
+	if flagged(0, 0) {
+		t.Error("default 0.5 should not flag score 0.6")
 	}
 }

--- a/internal/linter/passes.go
+++ b/internal/linter/passes.go
@@ -409,7 +409,11 @@ func (p *QualityPass) Fix(_ *LintContext, _ []Finding) error { return nil }
 
 func (p *QualityPass) Run(ctx *LintContext) ([]Finding, error) {
 	var findings []Finding
-	threshold := p.Threshold
+	// Threshold precedence: LintContext (config-driven) → pass field → 0.5.
+	threshold := ctx.QualityThreshold
+	if threshold <= 0 {
+		threshold = p.Threshold
+	}
 	if threshold <= 0 {
 		threshold = 0.5
 	}

--- a/internal/linter/runner.go
+++ b/internal/linter/runner.go
@@ -43,6 +43,7 @@ type LintContext struct {
 	DB               *storage.DB // shared DB connection (optional — opened from DBPath if nil)
 	ValidRelations   []string    // valid ontology relation type names
 	ValidEntityTypes []string    // valid ontology entity type names
+	QualityThreshold float64     // quality_score warning threshold (issue #97); 0 → pass default (0.5)
 }
 
 // LintResult holds the aggregated output of a lint run.

--- a/internal/mcp/tools_compound.go
+++ b/internal/mcp/tools_compound.go
@@ -68,6 +68,7 @@ func (s *Server) handleLint(ctx context.Context, req mcplib.CallToolRequest) (*m
 		DB:               s.db,
 		ValidRelations:   ontology.ValidRelationNames(mergedRels),
 		ValidEntityTypes: ontology.ValidEntityTypeNames(mergedTypes),
+		QualityThreshold: s.cfg.Compiler.QualityThreshold(),
 	}
 
 	runner := linter.NewRunner()


### PR DESCRIPTION
Closes #97.

## What

Evolves the existing 3-dimension article scorer into the **5-dimension weighted-composite** model proposed in #97. Every compiled article is graded `0–1` on five regex/heuristic dimensions (no LLM call); a configurable normalised weighted average becomes the article's `quality_score`.

| Dimension | Default weight | Heuristic |
|-----------|----------------|-----------|
| Format | 0.15 | valid frontmatter, ≥1 `##` heading, balanced code fences |
| Grounding | 0.30 | fraction of source key phrases present in the article |
| Coverage | 0.20 | article length adequacy vs. source size |
| Wikilink | 0.15 | fraction of `[[links]]` resolving to known concepts |
| AntiPattern | 0.20 | inverse of filler/meta-phrase density |

## Policy decisions

- **Surface + warn, no gate** — articles are always written; low scores are logged per-article and summarised at compile end, and surfaced by `sage-wiki lint`.
- **Evolved the existing scorer in place** rather than adding a separate `internal/linter/scorer.go`. The codebase already had a 3-dim scorer wired to `compile_items.quality_score`; #97 (from the older PR #24) assumed none existed. One canonical producer avoids two competing scores.
- Weights + threshold configurable via new `cfg.Compiler.Quality`; the zero-value passes validation (means "use defaults"). Weight calibration is deferred.

## Changes

- `internal/compiler/confidence.go` — `QualityScores` / `QualityWeights` (`Normalized()` with all-zero→default fallback) + five dimension helpers; `ScoreArticle` drops the ontology param (wikilinks resolve via the manifest concept keyset, stable regardless of write ordering).
- `internal/config/config.go` — `QualityConfig` substruct, plain-float accessors (no config→compiler import), `Validate()` ranges.
- `internal/compiler/fullpipeline.go` — stores the new composite, per-dimension low-score log, compile-end below-threshold summary; skips scoring on article-read error.
- `internal/linter` — `QualityPass` threshold now config-driven via `LintContext.QualityThreshold` (precedence ctx → field → 0.5), set at both production sites.

## Out of scope (per design)

No gate; no separate linter scorer pass; no scoring on the incremental/reextract write paths (pre-existing gap); no weight calibration study.

## Testing

Per-dimension + composite + edge cases (compiler), partial-override + Validate + zero-value (config), threshold precedence (linter). `go build ./...`, `go vet ./...`, and `go test ./...` all green (30 packages, 0 failures). Independently reviewed (SHIP-WITH-NITS); the two actionable nits (silent read-error, over-broad filler phrase) were fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)