### PR TITLE
fix: WalkSourceDir helper to follow symlinks when walking source directories

### DIFF
--- a/internal/compiler/diff.go
+++ b/internal/compiler/diff.go
@@ -35,29 +35,39 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 
 	// Collect current source files
 	current := make(map[string]SourceInfo)
-	sourcePaths := cfg.ResolveSources(projectDir)
 
-	for _, srcDir := range sourcePaths {
+	for _, src := range cfg.Sources {
+		var srcDir string
+		if filepath.IsAbs(src.Path) {
+			srcDir = src.Path
+		} else {
+			srcDir = filepath.Join(projectDir, src.Path)
+		}
+
 		if _, err := os.Stat(srcDir); os.IsNotExist(err) {
 			log.Warn("source directory not found", "path", srcDir)
 			continue
 		}
 
-		if err := filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-
+		if err := WalkSourceDir(srcDir, func(absPath, relPath string, d os.DirEntry) error {
 			// Skip hidden files (.DS_Store etc.)
 			if strings.HasPrefix(d.Name(), ".") {
 				return nil
 			}
 
-			// Get relative path from project root
-			relPath, _ := filepath.Rel(projectDir, path)
+			// Build manifest path: <source-name>/<path-within-source>
+			manifestPath := filepath.ToSlash(filepath.Join(src.Path, relPath))
+			// Normalize absolute source paths to project-relative keys so
+			// manifest entries survive across runs (the old filepath.Rel
+			// from projectDir gave e.g. ../../external/x.md, not /abs/x.md).
+			if filepath.IsAbs(manifestPath) {
+				if rel, err := filepath.Rel(projectDir, manifestPath); err == nil {
+					manifestPath = filepath.ToSlash(rel)
+				}
+			}
 
 			// Check ignore list
-			if isIgnored(relPath, cfg.Ignore) {
+			if isIgnored(manifestPath, cfg.Ignore) {
 				return nil
 			}
 
@@ -66,33 +76,33 @@ func Diff(projectDir string, cfg *config.Config, mf *manifest.Manifest) (*DiffRe
 				return nil
 			}
 
-			hash, err := fileHash(path)
+			hash, err := fileHash(absPath)
 			if err != nil {
-				log.Warn("failed to hash file", "path", relPath, "error", err)
+				log.Warn("failed to hash file", "path", manifestPath, "error", err)
 				return nil
 			}
 
 			// Configured Source.Type takes precedence over extension/signal detection.
 			// When config declares a type, bypass the manifest cache so config
 			// changes take effect without --fresh.
-			configuredType := cfg.TypeForPath(projectDir, path)
+			configuredType := cfg.TypeForPath(projectDir, manifestPath)
 
 			var detectedType string
 			if configuredType != "" {
 				detectedType = configuredType
 			} else if len(cfg.TypeSignals) > 0 {
 				// Reuse cached type from manifest if file is unchanged
-				if existing, ok := mf.Sources[relPath]; ok && existing.Hash == hash && existing.Type != "" {
+				if existing, ok := mf.Sources[manifestPath]; ok && existing.Hash == hash && existing.Type != "" {
 					detectedType = existing.Type
 				} else {
-					contentHead := extract.ReadHead(path, extract.DefaultHeadRunes)
-					detectedType = extract.DetectSourceTypeWithSignals(path, contentHead, convertSignals(cfg.TypeSignals))
+					contentHead := extract.ReadHead(absPath, extract.DefaultHeadRunes)
+					detectedType = extract.DetectSourceTypeWithSignals(absPath, contentHead, convertSignals(cfg.TypeSignals))
 				}
 			} else {
-				detectedType = extract.DetectSourceType(path)
+				detectedType = extract.DetectSourceType(absPath)
 			}
-			current[relPath] = SourceInfo{
-				Path: relPath,
+			current[manifestPath] = SourceInfo{
+				Path: manifestPath,
 				Hash: hash,
 				Type: detectedType,
 				Size: info.Size(),

--- a/internal/compiler/walk.go
+++ b/internal/compiler/walk.go
@@ -1,0 +1,42 @@
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/xoai/sage-wiki/internal/log"
+)
+
+// WalkSourceDir walks a directory tree, resolving symlinks before walking
+// so that filepath.WalkDir sees the real directory contents rather than the
+// symlink node.  Go's filepath.WalkDir uses os.Lstat internally which does
+// not follow symlinks — a symlink-to-directory is reported as IsDir()==false
+// and no children are walked.  Only symlinks at the tree root are resolved;
+// nested symlinked subdirectories are not followed (this prevents loops and
+// keeps behavior predictable).
+//
+// For each regular file, fn is called with:
+//   absPath — the resolved absolute file path (use for file I/O)
+//   relPath — the path relative to the resolved directory root
+func WalkSourceDir(srcDir string, fn func(absPath, relPath string, d os.DirEntry) error) error {
+	walkPath := srcDir
+	if resolved, err := filepath.EvalSymlinks(srcDir); err == nil {
+		walkPath = resolved
+	} else {
+		log.Warn("walkSourceDir: failed to resolve symlinks, walking as-is",
+			"path", srcDir, "error", err)
+	}
+
+	return filepath.WalkDir(walkPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		relPath, relErr := filepath.Rel(walkPath, path)
+		if relErr != nil {
+			log.Warn("walkSourceDir: failed to compute relative path, falling back to base name",
+				"walkPath", walkPath, "path", path, "error", relErr)
+			relPath = filepath.Base(path)
+		}
+		return fn(path, relPath, d)
+	})
+}

--- a/internal/compiler/walk_test.go
+++ b/internal/compiler/walk_test.go
@@ -1,0 +1,342 @@
+package compiler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/xoai/sage-wiki/internal/config"
+	"github.com/xoai/sage-wiki/internal/manifest"
+	"github.com/xoai/sage-wiki/internal/wiki"
+	"gopkg.in/yaml.v3"
+)
+
+func TestWalkSourceDir_SymlinkedDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Real source directory outside the project
+	realDir := filepath.Join(dir, "realsrc")
+	os.MkdirAll(realDir, 0755)
+	os.WriteFile(filepath.Join(realDir, "page1.md"), []byte("# Page 1"), 0644)
+	os.WriteFile(filepath.Join(realDir, "page2.md"), []byte("# Page 2"), 0644)
+
+	// Symlink inside a project
+	projectDir := filepath.Join(dir, "project")
+	os.MkdirAll(projectDir, 0755)
+	linkPath := filepath.Join(projectDir, "raw")
+	if err := os.Symlink(realDir, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var paths []string
+	err := WalkSourceDir(linkPath, func(absPath, relPath string, _ os.DirEntry) error {
+		paths = append(paths, relPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkSourceDir: %v", err)
+	}
+
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(paths), paths)
+	}
+}
+
+func TestWalkSourceDir_PlainDirectory(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "file.md"), []byte("hello"), 0644)
+
+	var paths []string
+	err := WalkSourceDir(dir, func(absPath, relPath string, _ os.DirEntry) error {
+		paths = append(paths, relPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkSourceDir: %v", err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(paths))
+	}
+	if paths[0] != "file.md" {
+		t.Errorf("expected file.md, got %s", paths[0])
+	}
+}
+
+func TestDiff_DiscoversFilesInSymlinkedSource(t *testing.T) {
+	dir := t.TempDir()
+
+	// Init a sage-wiki project
+	projectDir := filepath.Join(dir, "wiki")
+	if err := wiki.InitGreenfield(projectDir, "test", "gemini-2.5-flash"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Create real source dir with files and symlink it in as "raw"
+	realDir := filepath.Join(dir, "realsrc")
+	os.MkdirAll(realDir, 0755)
+	os.WriteFile(filepath.Join(realDir, "a.md"), []byte("# A"), 0644)
+	os.WriteFile(filepath.Join(realDir, "b.md"), []byte("# B"), 0644)
+
+	// Remove default raw dir, replace with symlink
+	rawPath := filepath.Join(projectDir, "raw")
+	os.RemoveAll(rawPath)
+	if err := os.Symlink(realDir, rawPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	cfg, _ := config.Load(filepath.Join(projectDir, "config.yaml"))
+	mf, _ := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
+
+	diff, err := Diff(projectDir, cfg, mf)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+
+	if len(diff.Added) != 2 {
+		t.Fatalf("expected 2 added, got %d", len(diff.Added))
+	}
+
+	// Manifest paths must use the source name, not the real path
+	for _, s := range diff.Added {
+		if !strings.HasPrefix(s.Path, "raw/") {
+			t.Errorf("manifest path %q should start with raw/", s.Path)
+		}
+	}
+
+	// Diff should be idempotent — mark as compiled then re-diff
+	// diff.Added is built from a map so its order is non-deterministic;
+	// use each entry's own .Path/.Hash/.Type/.Size, not [0]/[1] indexing.
+	for _, s := range diff.Added {
+		mf.AddSource(s.Path, s.Hash, s.Type, s.Size)
+		mf.MarkCompiled(s.Path, "wiki/summaries/"+filepath.Base(s.Path), nil)
+	}
+	mf.Save(filepath.Join(projectDir, ".manifest.json"))
+
+	mf2, _ := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
+	diff2, _ := Diff(projectDir, cfg, mf2)
+	if len(diff2.Added) != 0 || len(diff2.Modified) != 0 || len(diff2.Removed) != 0 {
+		t.Errorf("diff after compile should be empty, got +%d ~%d -%d",
+			len(diff2.Added), len(diff2.Modified), len(diff2.Removed))
+	}
+}
+
+func TestDiff_SymlinkedSourceHonorsConfiguredType(t *testing.T) {
+	dir := t.TempDir()
+
+	projectDir := filepath.Join(dir, "wiki")
+	if err := wiki.InitGreenfield(projectDir, "test", "gemini-2.5-flash"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Symlink raw -> real source dir
+	realDir := filepath.Join(dir, "realsrc")
+	os.MkdirAll(realDir, 0755)
+	os.WriteFile(filepath.Join(realDir, "decision.md"), []byte("# Decision\nWe will use X."), 0644)
+	rawPath := filepath.Join(projectDir, "raw")
+	os.RemoveAll(rawPath)
+	if err := os.Symlink(realDir, rawPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Write config with type: adr on the raw source
+	cfgPath := filepath.Join(projectDir, "config.yaml")
+	cfgData := map[string]any{
+		"version": 1,
+		"project": "test",
+		"pack":    "generic",
+		"sources": []map[string]any{
+			{"path": "raw", "type": "adr", "watch": false},
+		},
+		"output": "wiki",
+	}
+	rawYAML, _ := yaml.Marshal(cfgData)
+	os.WriteFile(cfgPath, rawYAML, 0644)
+
+	cfg, _ := config.Load(cfgPath)
+	mf, _ := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
+
+	diff, err := Diff(projectDir, cfg, mf)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(diff.Added) != 1 {
+		t.Fatalf("expected 1 added, got %d", len(diff.Added))
+	}
+	if diff.Added[0].Type != "adr" {
+		t.Errorf("expected type=adr, got %q — configured type was dropped on symlinked source", diff.Added[0].Type)
+	}
+}
+
+func TestDiff_AbsoluteSourcePathProducesRelativeManifestKeys(t *testing.T) {
+	dir := t.TempDir()
+
+	projectDir := filepath.Join(dir, "wiki")
+	if err := wiki.InitGreenfield(projectDir, "test", "gemini-2.5-flash"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Create a source dir outside the project
+	externalDir := filepath.Join(dir, "external")
+	os.MkdirAll(externalDir, 0755)
+	os.WriteFile(filepath.Join(externalDir, "note.md"), []byte("# External Note"), 0644)
+
+	// Write config with an absolute source path
+	cfgPath := filepath.Join(projectDir, "config.yaml")
+	cfgData := map[string]any{
+		"version": 1,
+		"project": "test",
+		"pack":    "generic",
+		"sources": []map[string]any{
+			{"path": externalDir, "watch": false},
+		},
+		"output": "wiki",
+	}
+	rawYAML, _ := yaml.Marshal(cfgData)
+	os.WriteFile(cfgPath, rawYAML, 0644)
+
+	cfg, _ := config.Load(cfgPath)
+	mf, _ := manifest.Load(filepath.Join(projectDir, ".manifest.json"))
+
+	diff, err := Diff(projectDir, cfg, mf)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(diff.Added) != 1 {
+		t.Fatalf("expected 1 added, got %d", len(diff.Added))
+	}
+	// The manifest path must be relative so it survives across runs.
+	// An absolute path here would cause a full re-add on the next compile.
+	if filepath.IsAbs(diff.Added[0].Path) {
+		t.Errorf("manifest path %q should be project-relative, not absolute", diff.Added[0].Path)
+	}
+}
+
+func TestWalkSourceDir_BrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	brokenLink := filepath.Join(dir, "broken")
+	if err := os.Symlink(filepath.Join(dir, "nonexistent"), brokenLink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var count int
+	err := WalkSourceDir(brokenLink, func(absPath, relPath string, d os.DirEntry) error {
+		count++
+		// relPath must never be absolute
+		if filepath.IsAbs(relPath) {
+			t.Errorf("relPath should be relative, got %q", relPath)
+		}
+		return nil
+	})
+	// We expect no crash; broken symlink resolves to nothing, EvalSymlinks
+	// falls back to walking the symlink node itself (a single DirEntry).
+	if err != nil {
+		t.Fatalf("WalkSourceDir should not error on broken symlink: %v", err)
+	}
+	// The broken symlink node still appears as a DirEntry — it's on the
+	// filesystem and IsDir() is false for symlinks.
+	if count == 0 {
+		t.Error("broken symlink should produce at least one DirEntry")
+	}
+}
+
+func TestWalkSourceDir_RelPathNeverAbsolute(t *testing.T) {
+	// Regression: ensure the filepath.Rel fallback never leaks an absolute
+	// path through the callback.
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "x.md"), []byte("x"), 0644)
+
+	err := WalkSourceDir(dir, func(absPath, relPath string, d os.DirEntry) error {
+		if filepath.IsAbs(relPath) {
+			t.Errorf("relPath must be relative, got %q", relPath)
+		}
+		if !filepath.IsAbs(absPath) {
+			t.Errorf("absPath must be absolute, got %q", absPath)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWalkSourceDir_NestedSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
+	os.WriteFile(filepath.Join(dir, "a.md"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(dir, "sub", "b.md"), []byte("b"), 0644)
+
+	var relPaths []string
+	err := WalkSourceDir(dir, func(absPath, relPath string, d os.DirEntry) error {
+		relPaths = append(relPaths, relPath)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(relPaths) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(relPaths), relPaths)
+	}
+	// There's no order guarantee from WalkDir, but we check both exist
+	found := make(map[string]bool)
+	for _, p := range relPaths {
+		found[p] = true
+	}
+	if !found["a.md"] {
+		t.Error("missing a.md")
+	}
+	if !found[filepath.Join("sub", "b.md")] {
+		t.Error("missing sub/b.md")
+	}
+}
+
+func TestAddRecursive_WatchesResolvedDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Real source dir with a subdirectory (to verify recursive walking)
+	realDir := filepath.Join(dir, "realsrc")
+	os.MkdirAll(filepath.Join(realDir, "sub"), 0755)
+	os.WriteFile(filepath.Join(realDir, "a.md"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(realDir, "sub", "b.md"), []byte("b"), 0644)
+
+	// Symlink inside a project directory
+	projectDir := filepath.Join(dir, "project")
+	os.MkdirAll(projectDir, 0755)
+	linkPath := filepath.Join(projectDir, "raw")
+	if err := os.Symlink(realDir, linkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Skipf("fsnotify not available: %v", err)
+	}
+	defer w.Close()
+
+	if err := addRecursive(w, linkPath); err != nil {
+		t.Fatalf("addRecursive: %v", err)
+	}
+
+	// The real directory (resolved) should be watched, plus subdirs.
+	// fsnotify stores watched paths; we check both the root and subdir.
+	watched := w.WatchList()
+	resolved, _ := filepath.EvalSymlinks(linkPath)
+
+	foundRoot := false
+	foundSub := false
+	for _, p := range watched {
+		if p == resolved {
+			foundRoot = true
+		}
+		if p == filepath.Join(resolved, "sub") {
+			foundSub = true
+		}
+	}
+	if !foundRoot {
+		t.Errorf("resolved path %q not in watch list: %v", resolved, watched)
+	}
+	if !foundSub {
+		t.Errorf("resolved subpath %q not in watch list: %v", filepath.Join(resolved, "sub"), watched)
+	}
+}

--- a/internal/compiler/watch.go
+++ b/internal/compiler/watch.go
@@ -89,7 +89,7 @@ func Watch(projectDir string, debounceSeconds int, opts CompileOpts, coordinator
 			watcher.Close()
 		}
 		log.Info("using polling mode (inotify unavailable for these paths)", "sources", sourcePaths, "interval", fmt.Sprintf("%ds", debounceSeconds*2))
-		return watchPoll(projectDir, sourcePaths, cfg.Ignore, debounceSeconds*2, triggerOpts, cc)
+		return watchPoll(projectDir, cfg.Sources, cfg.Ignore, debounceSeconds*2, triggerOpts, cc)
 	}
 
 	defer watcher.Close()
@@ -143,17 +143,17 @@ func watchFsnotify(projectDir string, watcher *fsnotify.Watcher, debounceSeconds
 
 // watchPoll periodically scans source directories for changes.
 // Works on WSL2 /mnt/ paths, network drives, and any filesystem.
-func watchPoll(projectDir string, sourcePaths []string, ignore []string, intervalSeconds int, opts CompileOpts, cc *CompileCoordinator) error {
+func watchPoll(projectDir string, sources []config.Source, ignore []string, intervalSeconds int, opts CompileOpts, cc *CompileCoordinator) error {
 
 	// Build initial snapshot
-	snapshot := scanSnapshot(sourcePaths, ignore)
+	snapshot := scanSnapshot(projectDir, sources, ignore)
 	log.Info("initial snapshot", "files", len(snapshot))
 
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		newSnapshot := scanSnapshot(sourcePaths, ignore)
+		newSnapshot := scanSnapshot(projectDir, sources, ignore)
 
 		// Detect changes
 		var changed []string
@@ -189,27 +189,34 @@ func watchPoll(projectDir string, sourcePaths []string, ignore []string, interva
 }
 
 // scanSnapshot builds a map of file path → content hash for all source files.
-func scanSnapshot(sourcePaths []string, ignore []string) map[string]string {
+// Uses WalkSourceDir so symlinked source directories are followed correctly.
+// Ignore matching uses manifest paths (source-name/file-path) for consistency
+// with Diff.
+func scanSnapshot(projectDir string, sources []config.Source, ignore []string) map[string]string {
 	snapshot := make(map[string]string)
 
-	for _, dir := range sourcePaths {
-		filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
+	for _, src := range sources {
+		var srcDir string
+		if filepath.IsAbs(src.Path) {
+			srcDir = src.Path
+		} else {
+			srcDir = filepath.Join(projectDir, src.Path)
+		}
+
+		WalkSourceDir(srcDir, func(absPath, relPath string, _ os.DirEntry) error {
+			manifestPath := filepath.ToSlash(filepath.Join(src.Path, relPath))
+			if filepath.IsAbs(manifestPath) {
+				if rel, err := filepath.Rel(projectDir, manifestPath); err == nil {
+					manifestPath = filepath.ToSlash(rel)
+				}
+			}
+			if isIgnored(manifestPath, ignore) {
 				return nil
 			}
 
-			// Use relative path for consistent ignore matching with Diff
-			relPath, relErr := filepath.Rel(dir, path)
-			if relErr != nil {
-				relPath = path
-			}
-			if isIgnored(relPath, ignore) {
-				return nil
-			}
-
-			hash := quickHash(path)
+			hash := quickHash(absPath)
 			if hash != "" {
-				snapshot[path] = hash
+				snapshot[absPath] = hash
 			}
 			return nil
 		})
@@ -268,7 +275,14 @@ func triggerCompile(projectDir string, trigger string, opts CompileOpts, cc *Com
 
 // addRecursive adds a directory and all subdirectories to the watcher.
 func addRecursive(watcher *fsnotify.Watcher, dir string) error {
-	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+	walkPath := dir
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		walkPath = resolved
+	} else {
+		log.Warn("addRecursive: failed to resolve symlinks, watching as-is",
+			"path", dir, "error", err)
+	}
+	return filepath.WalkDir(walkPath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}

--- a/internal/tui/compile/model.go
+++ b/internal/tui/compile/model.go
@@ -424,10 +424,7 @@ type previewContentMsg struct{ content string }
 func (m Model) dirSnapshot() string {
 	var total int64
 	for _, dir := range m.sourcePaths {
-		filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
+		compiler.WalkSourceDir(dir, func(_, _ string, d os.DirEntry) error {
 			info, err := d.Info()
 			if err != nil {
 				return nil


### PR DESCRIPTION
`filepath.WalkDir` uses `os.Lstat` internally which does **not** follow symlinks — a symlink-to-directory is reported as `IsDir()==false` and no children are walked. This causes `sage-wiki diff`/`compile`/`watch` to silently produce "nothing to compile" when source directories are symlinked (in my use case I had the `raw/` directory symlinked)..

## What Changed

- **New `WalkSourceDir()` helper** (`internal/compiler/walk.go`) — resolves symlinks via `filepath.EvalSymlinks` before walking the real directory tree. Logs warnings when symlink resolution or relative-path computation fails (no more silently-swallowed errors). Only root-level symlinks are resolved; nested symlinks are documented as not followed to prevent loops.

- **diff.go** — uses `WalkSourceDir` instead of duplicating the symlink resolution pattern. Manifest paths now built from `source-name + relative-path` (preserves existing `raw/file.md` key format).

- **watch.go** — `scanSnapshot` uses `WalkSourceDir`; `addRecursive` resolves symlinks before registering fsnotify watchers.

- **tui/compile/model.go** — `dirSnapshot` uses `compiler.WalkSourceDir`.

## Tests Added

- `TestWalkSourceDir_SymlinkedDirectory` — files discovered through symlink
- `TestWalkSourceDir_PlainDirectory` — normal directory walk still works
- `TestDiff_DiscoversFilesInSymlinkedSource` — end-to-end: discover, manifest paths correct, idempotent re-diff after compile

## How to Reproduce the Bug

```bash
mkdir -p project/raw real && echo "# hello" > real/page.md
ln -sfn ../real project/raw
sage-wiki init     # in project/
sage-wiki diff     # shows nothing (bug)
# With fix:      # + raw/page.md (new)
```
