### PR TITLE
fix: gofmt walk.go; detect symlinked /mnt/ paths for WSL2 polling

### DIFF
--- a/internal/compiler/watch.go
+++ b/internal/compiler/watch.go
@@ -75,9 +75,21 @@ func Watch(projectDir string, debounceSeconds int, opts CompileOpts, coordinator
 	// On WSL2 with /mnt/ paths, fsnotify silently fails to deliver events
 	usePolling := fsErr != nil
 	if !usePolling {
-		// Detect if we're on a path where inotify won't work
-		for _, sp := range sourcePaths {
-			if strings.HasPrefix(sp, "/mnt/") {
+		// Detect if we're on a path where inotify won't work.
+		// Resolve symlinks so a symlinked source like raw -> /mnt/c/docs
+		// is recognized as a /mnt/ path (the unresolved project-dir
+		// relative path wouldn't start with /mnt/).
+		for _, src := range cfg.Sources {
+			var checkDir string
+			if filepath.IsAbs(src.Path) {
+				checkDir = src.Path
+			} else {
+				checkDir = filepath.Join(projectDir, src.Path)
+			}
+			if resolved, err := filepath.EvalSymlinks(checkDir); err == nil {
+				checkDir = resolved
+			}
+			if strings.HasPrefix(checkDir, "/mnt/") {
 				usePolling = true
 				break
 			}


### PR DESCRIPTION
Two follow-up items from #103:

### 1. gofmt walk.go
Blank comment line before parameter list, tab-indented absPath/relPath items so `gofmt -l` CI checks pass.

### 2. WSL2 /mnt/ detection through symlinks
A symlinked source like `raw -> /mnt/c/docs` previously slipped past the `/mnt/` prefix check in `Watch()` because the unresolved project-relative path doesn't start with `/mnt/`. fsnotify would be selected and `addRecursive` would register an inotify watch on the resolved `/mnt/` target where WSL2 delivers no events, causing watch mode to silently stop recompiling.

Now resolves symlinks via `filepath.EvalSymlinks` before checking the `/mnt/` prefix.