### PR TITLE
fix(compiler): seed writer with co-occurring concept slugs (#106)

### DIFF
--- a/internal/compiler/concepts.go
+++ b/internal/compiler/concepts.go
@@ -20,6 +20,22 @@ type ExtractedConcept struct {
 	Type    string   `json:"type"` // concept, technique, claim
 }
 
+// manifestConceptRefs converts the manifest's concept map into a slice of
+// ExtractedConcept carrying just the fields needed for co-occurrence discovery
+// (Name — the map key — and Sources). The manifest is the authoritative FULL
+// concept set at write time (it includes concepts from prior compiles, not
+// just the current batch), so the write pass sources related-concept
+// candidates from here to cover incremental compiles as well as full ones.
+// Aliases are not stored in the manifest; callers that need them use the
+// in-batch concept slice. Issue #106.
+func manifestConceptRefs(m map[string]manifest.Concept) []ExtractedConcept {
+	refs := make([]ExtractedConcept, 0, len(m))
+	for name, c := range m {
+		refs = append(refs, ExtractedConcept{Name: name, Sources: c.Sources})
+	}
+	return refs
+}
+
 // ExtractConcepts runs Pass 2: concept extraction from summaries.
 // It takes new/updated summaries and the existing concept list,
 // asks the LLM to identify and deduplicate concepts.

--- a/internal/compiler/fullpipeline.go
+++ b/internal/compiler/fullpipeline.go
@@ -314,6 +314,7 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 		Language:           cfg.Language,
 		Backpressure:       opts.Backpressure,
 		AntiPatternPhrases: cfg.Compiler.AntiPatternPhrasesOrDefault(),
+		AllConcepts:        manifestConceptRefs(mf.Concepts),
 	}, concepts)
 
 	// Quality scoring config (issue #97): weights + warning threshold.

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -917,6 +917,7 @@ func resumeBatch(
 					ChunkSize:          cfg.Search.ChunkSizeOrDefault(),
 					Language:           cfg.Language,
 					AntiPatternPhrases: cfg.Compiler.AntiPatternPhrasesOrDefault(),
+					AllConcepts:        manifestConceptRefs(mf.Concepts),
 				}, concepts)
 
 				for _, ar := range articles {

--- a/internal/compiler/pipeline_test.go
+++ b/internal/compiler/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/xoai/sage-wiki/internal/manifest"
@@ -148,6 +149,113 @@ compiler:
 	changelogPath := filepath.Join(dir, "wiki", "CHANGELOG.md")
 	if _, err := os.Stat(changelogPath); os.IsNotExist(err) {
 		t.Error("CHANGELOG.md should exist")
+	}
+}
+
+// TestCompile_SeedsRelatedConceptsIntoWritePrompt is the reproducing test for
+// issue #106: findRelatedConcepts() was a `return nil` stub, so the write
+// prompt's "See also" [[wikilinks]] block was always empty and the writer
+// never received a list of real concept slugs to link. It runs a full compile
+// with two concepts that share a source (so they co-occur) and asserts each
+// concept's write prompt is seeded with the OTHER concept's slug as a real
+// [[wikilink]]. Pre-fix (stub) the prompts contain no seeded links → RED.
+//
+// The Pass-3 handler captures prompts from concurrent goroutines, so the
+// capture slice is mutex-guarded (write pass fires max_parallel concurrent
+// LLM calls; each httptest request is served on its own goroutine).
+func TestCompile_SeedsRelatedConceptsIntoWritePrompt(t *testing.T) {
+	var mu sync.Mutex
+	var writePrompts []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+
+		messages, _ := body["messages"].([]any)
+		lastMsg := ""
+		if len(messages) > 0 {
+			if m, ok := messages[len(messages)-1].(map[string]any); ok {
+				lastMsg, _ = m["content"].(string)
+			}
+		}
+
+		var content string
+		switch {
+		case strings.Contains(lastMsg, "concept extraction system"):
+			// Pass 2: two concepts sharing one source → they co-occur.
+			content = `[{"name":"self-attention","aliases":[],"sources":["raw/article1.md"],"type":"concept"},` +
+				`{"name":"flash-attention","aliases":[],"sources":["raw/article1.md"],"type":"concept"}]`
+		case strings.Contains(lastMsg, "wiki author writing a comprehensive article"):
+			// Pass 3: capture the rendered write prompt, return a valid article.
+			mu.Lock()
+			writePrompts = append(writePrompts, lastMsg)
+			mu.Unlock()
+			content = "# Article\n\n## Definition\n\nA mechanism used in transformer models.\n\n## See also\n"
+		default:
+			// Pass 1: summarization (≥100 chars to pass quality validation).
+			content = "## Key claims\n\nThis document discusses self-attention and flash attention, two related " +
+				"mechanisms in transformer models, and the trade-offs between them.\n\n## Concepts\n\nself-attention, flash-attention"
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": content}},
+			},
+			"model": "gpt-4o-mini",
+			"usage": map[string]int{"total_tokens": 100},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
+
+	cfgContent := `
+version: 1
+project: test
+sources:
+  - path: raw
+    type: auto
+    watch: true
+output: wiki
+api:
+  provider: openai
+  api_key: sk-test
+  base_url: ` + server.URL + `
+models:
+  summarize: gpt-4o-mini
+compiler:
+  max_parallel: 2
+  auto_commit: false
+  summary_max_tokens: 500
+  default_tier: 3
+`
+	os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfgContent), 0644)
+	os.WriteFile(filepath.Join(dir, "raw", "article1.md"),
+		[]byte("# Self-Attention and Flash Attention\n\nSelf-attention computes contextual "+
+			"representations; flash attention optimizes its memory access pattern."), 0644)
+
+	result, err := Compile(dir, CompileOpts{})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if result.ConceptsExtracted != 2 {
+		t.Fatalf("expected 2 concepts extracted, got %d", result.ConceptsExtracted)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(writePrompts) != 2 {
+		t.Fatalf("expected 2 write prompts captured, got %d", len(writePrompts))
+	}
+	joined := strings.Join(writePrompts, "\n----\n")
+	// Each concept's See-also should list the OTHER co-occurring concept, so
+	// both slugs appear across the two captured prompts.
+	if !strings.Contains(joined, "[[self-attention]]") {
+		t.Errorf("write prompts missing seeded [[self-attention]] link — See-also was not populated from co-occurrence")
+	}
+	if !strings.Contains(joined, "[[flash-attention]]") {
+		t.Errorf("write prompts missing seeded [[flash-attention]] link — See-also was not populated from co-occurrence")
 	}
 }
 

--- a/internal/compiler/reextract.go
+++ b/internal/compiler/reextract.go
@@ -137,6 +137,7 @@ func ReExtract(projectDir string) (*CompileResult, error) {
 			ChunkSize:          cfg.Search.ChunkSizeOrDefault(),
 			Language:           cfg.Language,
 			AntiPatternPhrases: cfg.Compiler.AntiPatternPhrasesOrDefault(),
+			AllConcepts:        manifestConceptRefs(mf.Concepts),
 		}, concepts)
 
 		for _, ar := range articles {

--- a/internal/compiler/write.go
+++ b/internal/compiler/write.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -57,6 +58,11 @@ type ArticleWriteOpts struct {
 	Language           string
 	Backpressure       *BackpressureController // optional; if nil, uses fixed semaphore
 	AntiPatternPhrases []string                // sentences containing these are stripped (issue #95); nil/empty → no strip
+	// AllConcepts is the FULL manifest concept set (Name + Sources), used to
+	// seed each article's "See also" [[wikilinks]] from co-occurring concepts
+	// and to canonicalize display-form links to concepts outside the current
+	// batch. Nil → no related-concept seeding (backward compatible). Issue #106.
+	AllConcepts []ExtractedConcept
 }
 
 // WriteArticles runs Pass 3: write concept articles with ontology edges.
@@ -72,8 +78,17 @@ func WriteArticles(opts ArticleWriteOpts, concepts []ExtractedConcept) []Article
 	total := len(concepts)
 
 	// Build the alias→concept-id map once for wikilink sanitization (issue #95).
-	// The concept slice is the authoritative alias source at compile time.
-	aliasMap := buildAliasMap(concepts)
+	// The in-batch concept slice is the authoritative alias source; AllConcepts
+	// (the full manifest set) additionally lets display-form links to concepts
+	// outside this batch canonicalize instead of being stripped (issue #106).
+	aliasMap := buildAliasMap(concepts, opts.AllConcepts)
+
+	// Build the co-occurrence index once (source-sharing concepts), then look
+	// it up per article to seed the "See also" [[wikilinks]]. Read-only after
+	// construction, so it is safe to share across the write goroutines below.
+	// Sourced from the full manifest set so incremental compiles link to
+	// pre-existing concepts too (issue #106).
+	relatedIndex := buildRelatedConceptsIndex(opts.AllConcepts, maxRelatedConcepts)
 
 	// Use BackpressureController if available, otherwise fixed semaphore
 	var sem chan struct{}
@@ -96,7 +111,7 @@ func WriteArticles(opts ArticleWriteOpts, concepts []ExtractedConcept) []Article
 			defer wg.Done()
 			defer release()
 
-			result := writeOneArticle(opts, c, aliasMap)
+			result := writeOneArticle(opts, c, aliasMap, relatedIndex[c.Name])
 			results[idx] = result
 
 			n := int(done.Add(1))
@@ -120,7 +135,7 @@ func WriteArticles(opts ArticleWriteOpts, concepts []ExtractedConcept) []Article
 	return results
 }
 
-func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept, aliasMap map[string]string) ArticleResult {
+func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept, aliasMap map[string]string, relatedNames []string) ArticleResult {
 	result := ArticleResult{ConceptName: concept.Name}
 
 	// Check for existing article
@@ -134,8 +149,8 @@ func writeOneArticle(opts ArticleWriteOpts, concept ExtractedConcept, aliasMap m
 	// Build source context from relevant sections (document splitting)
 	sourceContext := buildSourceContext(opts.ProjectDir, concept, opts.SplitThreshold)
 
-	// Build prompt
-	relatedNames := findRelatedConcepts(concept)
+	// Build prompt. relatedNames are real, co-occurring concept slugs (issue
+	// #106) that resolve to existing article files and survive the strip pass.
 	prompt, err := prompts.Render("write_article", prompts.WriteArticleData{
 		ConceptName:     formatConceptName(concept.Name),
 		ConceptID:       concept.Name,
@@ -574,11 +589,15 @@ func sanitizeWikilinks(content string, aliasMap map[string]string) string {
 	})
 }
 
-// buildAliasMap builds an alias→concept-id lookup from the in-memory concept
-// slice (the authoritative alias source at compile time — the ontology store
-// holds no aliases). Display-form names are added after aliases so a canonical
-// display name cannot be clobbered by a colliding alias. Issue #95.
-func buildAliasMap(concepts []ExtractedConcept) map[string]string {
+// buildAliasMap builds an alias→concept-id lookup for wikilink sanitization.
+// Aliases come only from the in-batch concept slice (the authoritative alias
+// source at compile time — the ontology store and manifest hold no aliases).
+// Canonical ids and display forms are added for every concept in allConcepts
+// (the full manifest set, a superset of the batch) so display-form links to
+// concepts OUTSIDE the current batch also canonicalize and survive the strip
+// pass rather than being dropped (issue #106). When allConcepts is nil it
+// falls back to the batch, preserving the original issue-#95 behavior.
+func buildAliasMap(concepts []ExtractedConcept, allConcepts []ExtractedConcept) map[string]string {
 	m := make(map[string]string)
 	for _, c := range concepts {
 		for _, a := range c.Aliases {
@@ -590,7 +609,11 @@ func buildAliasMap(concepts []ExtractedConcept) map[string]string {
 	// Add canonical ids and display forms AFTER aliases so a real concept's
 	// own id/name always wins over a colliding alias from another concept
 	// (e.g. concept B named "attention" must beat concept A's alias "attention").
-	for _, c := range concepts {
+	canonicalSet := allConcepts
+	if len(canonicalSet) == 0 {
+		canonicalSet = concepts
+	}
+	for _, c := range canonicalSet {
 		m[c.Name] = c.Name
 		m[formatConceptName(c.Name)] = c.Name
 	}
@@ -621,10 +644,87 @@ func formatConceptName(name string) string {
 	return strings.Join(words, " ")
 }
 
-func findRelatedConcepts(concept ExtractedConcept) []string {
-	// Related concepts are discovered during extraction as co-occurrences
-	// For now, return empty — the ontology will be populated as articles are written
-	return nil
+// maxRelatedConcepts caps how many "See also" links each article is seeded
+// with. The cap is by design: a source cited by many concepts would otherwise
+// flood every article with links. Ranking by shared-source count keeps the
+// strongest co-occurrences; a richer signal (vector similarity) is a follow-up.
+const maxRelatedConcepts = 8
+
+// buildRelatedConceptsIndex builds, for every concept, the list of other
+// concepts it co-occurs with — i.e. concepts that cite at least one common
+// source document. Co-occurrence is the mechanism the original stub intended
+// ("discovered during extraction as co-occurrences"); it needs no embeddings,
+// works on a cold compile, and yields real slugs that resolve to article files
+// and survive the strip pass (issue #106).
+//
+// Results per concept are ranked by shared-source count (desc), tie-broken by
+// name (asc) for determinism despite Go map iteration order, then truncated to
+// cap. Returns conceptName → []relatedSlug. A nil/empty input yields an empty
+// map (so behavior matches the old stub when AllConcepts is unset).
+//
+// Cost is ~O(sources × concepts-per-source); a pathological source cited by
+// every concept is O(N²). The cap bounds output size, not build cost — fine
+// for typical wikis.
+func buildRelatedConceptsIndex(all []ExtractedConcept, limit int) map[string][]string {
+	index := make(map[string][]string, len(all))
+	if len(all) == 0 {
+		return index
+	}
+
+	// source → set of concept names citing it. Sets dedupe repeated sources
+	// within a concept's list (the manifest stores Sources verbatim) so a
+	// duplicate cannot inflate co-occurrence counts.
+	bySource := make(map[string]map[string]bool)
+	for _, c := range all {
+		seen := make(map[string]bool, len(c.Sources))
+		for _, s := range c.Sources {
+			if s == "" || seen[s] {
+				continue
+			}
+			seen[s] = true
+			if bySource[s] == nil {
+				bySource[s] = make(map[string]bool)
+			}
+			bySource[s][c.Name] = true
+		}
+	}
+
+	for _, c := range all {
+		// Count shared sources with each co-occurring concept (exclude self).
+		shared := make(map[string]int)
+		seen := make(map[string]bool, len(c.Sources))
+		for _, s := range c.Sources {
+			if s == "" || seen[s] {
+				continue
+			}
+			seen[s] = true
+			for other := range bySource[s] {
+				if other != c.Name {
+					shared[other]++
+				}
+			}
+		}
+		if len(shared) == 0 {
+			continue
+		}
+
+		related := make([]string, 0, len(shared))
+		for name := range shared {
+			related = append(related, name)
+		}
+		sort.Slice(related, func(i, j int) bool {
+			if shared[related[i]] != shared[related[j]] {
+				return shared[related[i]] > shared[related[j]] // more shared sources first
+			}
+			return related[i] < related[j] // deterministic tie-break
+		})
+		if len(related) > limit {
+			related = related[:limit]
+		}
+		index[c.Name] = related
+	}
+
+	return index
 }
 
 // extractRelations parses article text for relationship patterns and creates ontology edges.

--- a/internal/compiler/write_test.go
+++ b/internal/compiler/write_test.go
@@ -2,10 +2,13 @@ package compiler
 
 import (
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/xoai/sage-wiki/internal/manifest"
 	"github.com/xoai/sage-wiki/internal/ontology"
 	"github.com/xoai/sage-wiki/internal/storage"
 )
@@ -415,7 +418,7 @@ func TestBuildAliasMap(t *testing.T) {
 		{Name: "attention", Aliases: []string{"自注意力", "self-attention"}},
 		{Name: "flash-attention", Aliases: []string{"闪光注意力"}},
 	}
-	m := buildAliasMap(concepts)
+	m := buildAliasMap(concepts, nil)
 	if m["自注意力"] != "attention" {
 		t.Errorf("alias not mapped: %v", m["自注意力"])
 	}
@@ -448,7 +451,7 @@ func TestBuildAliasMap_CanonicalWinsOverAliasCollision(t *testing.T) {
 		{Name: "transformer", Aliases: []string{"attention"}}, // aliases the OTHER concept's id
 		{Name: "attention", Aliases: []string{"self-attention"}},
 	}
-	m := buildAliasMap(concepts)
+	m := buildAliasMap(concepts, nil)
 	if m["attention"] != "attention" {
 		t.Errorf("canonical id must win over colliding alias: m[attention]=%q, want \"attention\"", m["attention"])
 	}
@@ -466,5 +469,154 @@ func TestStripAntiPatternSentences_UnclosedFence(t *testing.T) {
 	got := stripAntiPatternSentences(in, phrases)
 	if !strings.Contains(got, "this article will survive") {
 		t.Errorf("content after unclosed fence should be left intact: %q", got)
+	}
+}
+
+// TestBuildRelatedConceptsIndex covers co-occurrence discovery (issue #106):
+// concepts sharing a source are related; self is excluded; isolated concepts
+// have no relations; duplicate sources do not double-count; ranking is by
+// shared-source count with a deterministic tie-break.
+func TestBuildRelatedConceptsIndex(t *testing.T) {
+	concepts := []ExtractedConcept{
+		{Name: "a", Sources: []string{"s1", "s2"}},
+		{Name: "b", Sources: []string{"s1"}},        // shares s1 with a
+		{Name: "c", Sources: []string{"s2"}},        // shares s2 with a
+		{Name: "d", Sources: []string{"s9"}},        // isolated
+		{Name: "e", Sources: []string{"s1", "s1"}},  // duplicate source; shares s1 with a
+	}
+	idx := buildRelatedConceptsIndex(concepts, maxRelatedConcepts)
+
+	// a shares s1 with b,e and s2 with c → all three, self excluded, d excluded.
+	gotA := append([]string(nil), idx["a"]...)
+	sort.Strings(gotA)
+	if !reflect.DeepEqual(gotA, []string{"b", "c", "e"}) {
+		t.Errorf("a related = %v, want [b c e]", idx["a"])
+	}
+	for _, name := range idx["a"] {
+		if name == "a" {
+			t.Error("a must not be related to itself")
+		}
+		if name == "d" {
+			t.Error("d is isolated and must not co-occur")
+		}
+	}
+
+	// d is isolated → no relations.
+	if len(idx["d"]) != 0 {
+		t.Errorf("d related = %v, want empty", idx["d"])
+	}
+
+	// Dedup: e lists s1 twice but must appear once under s1, and a↔e share
+	// exactly one source (s1), so e's only relation is a (b also shares s1).
+	gotE := append([]string(nil), idx["e"]...)
+	sort.Strings(gotE)
+	if !reflect.DeepEqual(gotE, []string{"a", "b"}) {
+		t.Errorf("e related = %v, want [a b] (duplicate s1 not double-counted)", idx["e"])
+	}
+
+	// nil input → empty map (matches the old stub when AllConcepts is unset).
+	if got := buildRelatedConceptsIndex(nil, maxRelatedConcepts); len(got) != 0 {
+		t.Errorf("nil input should yield empty index, got %v", got)
+	}
+}
+
+// TestBuildRelatedConceptsIndex_RankingCapDeterminism verifies shared-source
+// ranking, the cap, and that output is stable regardless of input order.
+func TestBuildRelatedConceptsIndex_RankingCapDeterminism(t *testing.T) {
+	// "hub" shares 2 sources with "strong" and 1 source each with many others.
+	concepts := []ExtractedConcept{
+		{Name: "hub", Sources: []string{"s1", "s2", "s3"}},
+		{Name: "strong", Sources: []string{"s1", "s2"}}, // 2 shared → ranks first
+		{Name: "w1", Sources: []string{"s3"}},
+		{Name: "w2", Sources: []string{"s3"}},
+	}
+	idx := buildRelatedConceptsIndex(concepts, maxRelatedConcepts)
+	if len(idx["hub"]) == 0 || idx["hub"][0] != "strong" {
+		t.Errorf("hub related = %v, want 'strong' ranked first (2 shared sources)", idx["hub"])
+	}
+
+	// Cap under ALL-EQUAL counts: one source cited by many concepts, so every
+	// co-occurrence has shared-source count 1 and ranking is pure tie-break.
+	// The surviving `maxRelatedConcepts` must be the alphabetically-first names
+	// (not an arbitrary subset), in sorted order.
+	var many []ExtractedConcept
+	many = append(many, ExtractedConcept{Name: "center", Sources: []string{"s"}})
+	for i := 0; i < maxRelatedConcepts+5; i++ {
+		many = append(many, ExtractedConcept{Name: "n" + string(rune('a'+i)), Sources: []string{"s"}})
+	}
+	wantCap := make([]string, maxRelatedConcepts)
+	for i := 0; i < maxRelatedConcepts; i++ {
+		wantCap[i] = "n" + string(rune('a'+i)) // na, nb, ... (first N by name)
+	}
+	capped := buildRelatedConceptsIndex(many, maxRelatedConcepts)
+	if !reflect.DeepEqual(capped["center"], wantCap) {
+		t.Errorf("center related = %v, want first-%d-by-name %v", capped["center"], maxRelatedConcepts, wantCap)
+	}
+
+	// Determinism under all-equal counts: reversing the many-input (which
+	// changes Go map iteration order) must yield byte-identical ordered output
+	// — this is the case where only the tie-break enforces a stable order.
+	manyReversed := make([]ExtractedConcept, len(many))
+	for i := range many {
+		manyReversed[i] = many[len(many)-1-i]
+	}
+	cappedRev := buildRelatedConceptsIndex(manyReversed, maxRelatedConcepts)
+	if !reflect.DeepEqual(capped["center"], cappedRev["center"]) {
+		t.Errorf("non-deterministic under equal counts: %v vs %v", capped["center"], cappedRev["center"])
+	}
+
+	// Determinism with mixed counts: reversed input yields identical output.
+	reversed := make([]ExtractedConcept, len(concepts))
+	for i := range concepts {
+		reversed[i] = concepts[len(concepts)-1-i]
+	}
+	idx2 := buildRelatedConceptsIndex(reversed, maxRelatedConcepts)
+	if !reflect.DeepEqual(idx["hub"], idx2["hub"]) {
+		t.Errorf("non-deterministic ordering: %v vs %v", idx["hub"], idx2["hub"])
+	}
+}
+
+// TestManifestConceptRefs round-trips a manifest concept map into the
+// []ExtractedConcept{Name, Sources} shape the write pass consumes (issue #106).
+func TestManifestConceptRefs(t *testing.T) {
+	m := map[string]manifest.Concept{
+		"alpha": {ArticlePath: "wiki/concepts/alpha.md", Sources: []string{"s1", "s2"}},
+		"beta":  {ArticlePath: "wiki/concepts/beta.md", Sources: []string{"s2"}},
+	}
+	refs := manifestConceptRefs(m)
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 refs, got %d", len(refs))
+	}
+	byName := map[string][]string{}
+	for _, r := range refs {
+		byName[r.Name] = r.Sources
+	}
+	if !reflect.DeepEqual(byName["alpha"], []string{"s1", "s2"}) {
+		t.Errorf("alpha sources = %v, want [s1 s2]", byName["alpha"])
+	}
+	if !reflect.DeepEqual(byName["beta"], []string{"s2"}) {
+		t.Errorf("beta sources = %v, want [s2]", byName["beta"])
+	}
+}
+
+// TestBuildAliasMap_AllConceptsCanonicalizesOutOfBatch verifies the issue-#106
+// extension: display-form links to concepts OUTSIDE the current batch still
+// canonicalize when allConcepts (the full manifest set) is supplied.
+func TestBuildAliasMap_AllConceptsCanonicalizesOutOfBatch(t *testing.T) {
+	batch := []ExtractedConcept{
+		{Name: "attention", Aliases: []string{"self-attention"}},
+	}
+	all := []ExtractedConcept{
+		{Name: "attention"},
+		{Name: "flash-attention"}, // NOT in the current batch
+	}
+	m := buildAliasMap(batch, all)
+	// In-batch alias still resolves.
+	if m["self-attention"] != "attention" {
+		t.Errorf("in-batch alias lost: %q", m["self-attention"])
+	}
+	// Display form of an out-of-batch concept canonicalizes to its slug.
+	if m["Flash Attention"] != "flash-attention" {
+		t.Errorf("out-of-batch display form not canonicalized: %q", m["Flash Attention"])
 	}
 }


### PR DESCRIPTION
Fixes #106.

## Problem
`findRelatedConcepts()` was a `return nil` stub, so the `write_article` prompt's "See also" `[[wikilinks]]` block was always empty. The writer, told to cross-reference, invented links from source text that rarely matched real concept slugs — and the post-compile `strip_broken_links` sweep deleted them, leaving ~85% of concept articles orphaned.

## Fix
Replace the stub with `buildRelatedConceptsIndex`: concepts that cite a common source document are related (the co-occurrence mechanism the stub's own comment always intended). Chosen over write-time vector similarity because `concept:` vectors are upserted *after* each article is written and the write pass is concurrent — so a vector search returns empty on a cold compile. Co-occurrence needs no embeddings and works on the first full compile.

- Set-based, so duplicate sources can't inflate counts; ranked by shared-source count with a deterministic tie-break; capped at `maxRelatedConcepts=8`.
- Sourced from the **full manifest** (`manifestConceptRefs(mf.Concepts)` via a new `AllConcepts` field), wired at all three `WriteArticles` call sites — so incremental compiles link too, not just full ones. Returned values are real slugs that resolve to on-disk files and survive the strip pass.
- Extends `buildAliasMap` so display-form links to concepts outside the current batch (`[[Flash Attention]]` → `[[flash-attention]]`) canonicalize instead of being stripped.
- Backward compatible: nil `AllConcepts` ⇒ empty index ⇒ prior stub behavior.

## Out of scope (follow-ups)
- Vector-similarity ranking (issue #106 fix #1 "nicer signal") — needs a pre-write embedding pass.
- Post-write backlink pass (#3) and `ConnectionsPass.Fix()` auto-injection (#4) — both run post-compile when all data exists.

## Test plan
- `TestCompile_SeedsRelatedConceptsIntoWritePrompt` — full compile against a mock LLM with two concepts sharing a source; asserts the captured write prompt's See-also is seeded with the co-occurring `[[slug]]`. **Fails against the stub, passes after.**
- `TestBuildRelatedConceptsIndex` (+ ranking/cap/determinism/dedup), `TestManifestConceptRefs`, `TestBuildAliasMap_AllConceptsCanonicalizesOutOfBatch`.
- `go test ./...` → 32/32; compiler `-race -count=5` clean; build + vet clean.