### PR TITLE
fix(compiler): opt-in relative summary filenames (#107)

### DIFF
--- a/internal/compiler/fullpipeline.go
+++ b/internal/compiler/fullpipeline.go
@@ -17,6 +17,46 @@ import (
 	"github.com/xoai/sage-wiki/internal/vectors"
 )
 
+// sourceRootPaths extracts the configured source root paths (sources[].path),
+// used to strip the root prefix under relative summary naming (issue #107).
+func sourceRootPaths(sources []config.Source) []string {
+	roots := make([]string, 0, len(sources))
+	for _, s := range sources {
+		roots = append(roots, s.Path)
+	}
+	return roots
+}
+
+// sourceInfoPaths extracts the discovered file paths from a SourceInfo slice.
+func sourceInfoPaths(sources []SourceInfo) []string {
+	paths := make([]string, 0, len(sources))
+	for _, s := range sources {
+		paths = append(paths, s.Path)
+	}
+	return paths
+}
+
+// warnSummaryNameCollisions logs a warning when, under the given naming mode,
+// two distinct source paths map to the same summary filename (issue #107).
+// Best-effort: it needs the whole source set, so it runs at set-level sites
+// (the full/on-demand pipeline and batch submission), not per file. Under the
+// default "full" mode collisions cannot occur, so this is a no-op there.
+func warnSummaryNameCollisions(paths, roots []string, mode string) {
+	if mode != "relative" {
+		return
+	}
+	seen := make(map[string]string, len(paths))
+	for _, p := range paths {
+		name := SummaryFilenameMode(p, resolveSourceRoot(p, roots), mode)
+		if prev, ok := seen[name]; ok && prev != p {
+			log.Warn("summary_naming: relative filename collision — one summary overwrites another",
+				"filename", name, "source_a", prev, "source_b", p)
+			continue
+		}
+		seen[name] = p
+	}
+}
+
 // FullPipelineOpts bundles all parameters needed for the full compilation
 // pipeline (Pass 1 → Pass 2 → Pass 3).
 type FullPipelineOpts struct {
@@ -93,19 +133,25 @@ func runFullPipeline(sources []SourceInfo, opts FullPipelineOpts) *FullPipelineR
 		}
 	}
 
+	summaryNaming := cfg.Compiler.SummaryNamingOrDefault()
+	sourceRoots := sourceRootPaths(cfg.Sources)
+	warnSummaryNameCollisions(sourceInfoPaths(sources), sourceRoots, summaryNaming)
+
 	summaries := Summarize(SummarizeOpts{
-		Ctx:          opts.Ctx,
-		ProjectDir:   opts.ProjectDir,
-		OutputDir:    cfg.Output,
-		Sources:      sources,
-		Client:       client,
-		Model:        model,
-		MaxTokens:    maxTokens,
-		MaxParallel:  cfg.Compiler.MaxParallel,
-		UserTZ:       cfg.Compiler.UserTimeLocation(),
-		Language:     cfg.Language,
-		Backpressure: opts.Backpressure,
-		ExtractOpts:  sumExOpts,
+		Ctx:           opts.Ctx,
+		ProjectDir:    opts.ProjectDir,
+		OutputDir:     cfg.Output,
+		Sources:       sources,
+		Client:        client,
+		Model:         model,
+		MaxTokens:     maxTokens,
+		MaxParallel:   cfg.Compiler.MaxParallel,
+		UserTZ:        cfg.Compiler.UserTimeLocation(),
+		Language:      cfg.Language,
+		Backpressure:  opts.Backpressure,
+		ExtractOpts:   sumExOpts,
+		SummaryNaming: summaryNaming,
+		SourceRoots:   sourceRoots,
 	})
 
 	for _, sr := range summaries {

--- a/internal/compiler/pipeline.go
+++ b/internal/compiler/pipeline.go
@@ -736,6 +736,11 @@ func resumeBatch(
 		pendingSet[p] = true
 	}
 
+	// Summary naming (issue #107): resolve roots once and warn on collisions
+	// over the full pending set, matching the standard/on-demand path.
+	batchRoots := sourceRootPaths(cfg.Sources)
+	warnSummaryNameCollisions(state.Pending, batchRoots, cfg.Compiler.SummaryNamingOrDefault())
+
 	// Process batch results as summaries
 	progress.StartPhase("Processing batch results", len(batchResults))
 	var successfulSummaries []SummaryResult
@@ -785,11 +790,13 @@ func resumeBatch(
 			continue
 		}
 
-		// Write summary file
+		// Write summary file (issue #107: honor the configured naming scheme via
+		// the same helper as the standard path, so batch/standard never diverge).
 		summaryText := br.Response.Content
 		summaryDir := filepath.Join(projectDir, cfg.Output, "summaries")
 		os.MkdirAll(summaryDir, 0755)
-		summaryPath := filepath.Join(cfg.Output, "summaries", SummaryFilename(path))
+		summaryName := SummaryFilenameMode(path, resolveSourceRoot(path, batchRoots), cfg.Compiler.SummaryNamingOrDefault())
+		summaryPath := filepath.Join(cfg.Output, "summaries", summaryName)
 		absOutputPath := filepath.Join(projectDir, summaryPath)
 
 		frontmatter := fmt.Sprintf("---\nsource: %s\ncompiled_at: %s\nbatch: true\n---\n\n", path, timeNow(cfg.Compiler.UserTimeLocation()))

--- a/internal/compiler/pipeline_test.go
+++ b/internal/compiler/pipeline_test.go
@@ -259,6 +259,92 @@ compiler:
 	}
 }
 
+// TestCompile_RelativeSummaryNaming is the reproducing/wiring test for issue
+// #107: with compiler.summary_naming=relative, a nested source at
+// docs/Report/Report.md must produce the summary file Report.md — the source
+// root prefix (docs-) stripped and the duplicated marker-pdf stem (Report-
+// Report) collapsed. Against the default (full) scheme the file would be
+// docs-Report-Report.md. Pre-fix (no relative mode) → RED. It exercises the
+// standard-path flag wiring end to end: config → SummarizeOpts → summarizeOne →
+// SummaryFilenameMode → on-disk filename.
+func TestCompile_RelativeSummaryNaming(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		messages, _ := body["messages"].([]any)
+		lastMsg := ""
+		if len(messages) > 0 {
+			if m, ok := messages[len(messages)-1].(map[string]any); ok {
+				lastMsg, _ = m["content"].(string)
+			}
+		}
+
+		var content string
+		switch {
+		case strings.Contains(lastMsg, "concept extraction system"):
+			content = `[{"name":"report","aliases":[],"sources":["docs/Report/Report.md"],"type":"concept"}]`
+		case strings.Contains(lastMsg, "wiki author writing a comprehensive article"):
+			content = "# Article\n\n## Definition\n\nA report concept."
+		default:
+			content = "## Key claims\n\nThis document is a financial report covering the main findings, figures, and conclusions of the review.\n\n## Concepts\n\nreport"
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"content": content}}},
+			"model":   "gpt-4o-mini",
+			"usage":   map[string]int{"total_tokens": 100},
+		})
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	wiki.InitGreenfield(dir, "test", "gemini-2.5-flash")
+
+	cfgContent := `
+version: 1
+project: test
+sources:
+  - path: docs
+    type: auto
+    watch: true
+output: wiki
+api:
+  provider: openai
+  api_key: sk-test
+  base_url: ` + server.URL + `
+models:
+  summarize: gpt-4o-mini
+compiler:
+  max_parallel: 2
+  auto_commit: false
+  summary_max_tokens: 500
+  default_tier: 3
+  summary_naming: relative
+`
+	os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfgContent), 0644)
+	// marker-pdf-style nested layout: one subdir per PDF, subdir name == stem.
+	os.MkdirAll(filepath.Join(dir, "docs", "Report"), 0755)
+	os.WriteFile(filepath.Join(dir, "docs", "Report", "Report.md"),
+		[]byte("# Report\n\nA financial report with figures and conclusions."), 0644)
+
+	if _, err := Compile(dir, CompileOpts{}); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	summariesDir := filepath.Join(dir, "wiki", "summaries")
+	if _, err := os.Stat(filepath.Join(summariesDir, "Report.md")); err != nil {
+		entries, _ := os.ReadDir(summariesDir)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected relative summary name Report.md, not found. summaries dir: %v", names)
+	}
+	// The full-scheme name must NOT be produced under relative mode.
+	if _, err := os.Stat(filepath.Join(summariesDir, "docs-Report-Report.md")); err == nil {
+		t.Errorf("full-scheme name docs-Report-Report.md should not exist under summary_naming: relative")
+	}
+}
+
 // TestCompile_EmptyArticleNotWritten is the reproducing test for the
 // silent-hollow-write bug: when the article-writing LLM call returns empty
 // content (e.g. a reasoning model exhausting its token budget), the compiler

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -41,6 +41,10 @@ type SummarizeOpts struct {
 	Language     string
 	Backpressure *BackpressureController // optional; if nil, uses fixed semaphore
 	ExtractOpts  []extract.ExtractOpts   // optional; passed to extract.Extract
+	// Summary filename scheme + configured source roots for "relative" naming
+	// (issue #107). SummaryNaming "" behaves as "full".
+	SummaryNaming string
+	SourceRoots   []string
 }
 
 // Summarize processes sources through Pass 1, producing summaries.
@@ -95,7 +99,7 @@ func Summarize(opts SummarizeOpts) []SummaryResult {
 			defer wg.Done()
 			defer release()
 
-			result := summarizeOne(opts.ProjectDir, opts.OutputDir, info, opts.Client, opts.Model, opts.MaxTokens, opts.UserTZ, opts.Language, opts.ExtractOpts...)
+			result := summarizeOne(opts.ProjectDir, opts.OutputDir, info, opts.Client, opts.Model, opts.MaxTokens, opts.UserTZ, opts.Language, opts.SummaryNaming, opts.SourceRoots, opts.ExtractOpts...)
 			results[idx] = result
 
 			n := int(done.Add(1))
@@ -135,15 +139,27 @@ func summarizeOne(
 	maxTokens int,
 	userTZ *time.Location,
 	language string,
+	summaryNaming string,
+	sourceRoots []string,
 	extractOpts ...extract.ExtractOpts,
 ) SummaryResult {
 	result := SummaryResult{SourcePath: info.Path}
+
+	// Resolve the summary filename under the configured naming scheme (issue
+	// #107). The SAME name is used for the reuse-lookup below and every write,
+	// so a scheme change consistently reuses/writes one filename per source.
+	// Root resolution is only needed for "relative"; skip it under the default.
+	root := ""
+	if summaryNaming == "relative" {
+		root = resolveSourceRoot(info.Path, sourceRoots)
+	}
+	summaryName := SummaryFilenameMode(info.Path, root, summaryNaming)
 
 	// Skip LLM call if a valid summary file already exists on disk with a matching
 	// source hash. Restores resume-from-checkpoint behavior when compile-state.json is
 	// missing (e.g. a prior failed run cleared it). The source_hash field in the
 	// frontmatter guards against serving stale summaries for modified sources.
-	summaryPath := filepath.Join(outputDir, "summaries", SummaryFilename(info.Path))
+	summaryPath := filepath.Join(outputDir, "summaries", summaryName)
 	absSummary := filepath.Join(projectDir, summaryPath)
 	if existing, err := os.ReadFile(absSummary); err == nil {
 		body := string(existing)
@@ -191,7 +207,7 @@ func summarizeOne(
 			return result
 		}
 		summaryText = text
-		return writeSummaryFile(projectDir, outputDir, info, content, summaryText, result, userTZ)
+		return writeSummaryFile(projectDir, outputDir, info, summaryName, content, summaryText, result, userTZ)
 	}
 
 	// Chunk if needed
@@ -251,7 +267,7 @@ func summarizeOne(
 		return result
 	}
 
-	return writeSummaryFile(projectDir, outputDir, info, content, summaryText, result, userTZ)
+	return writeSummaryFile(projectDir, outputDir, info, summaryName, content, summaryText, result, userTZ)
 }
 
 // emptyContentError returns a non-nil error when an LLM response carries no
@@ -279,11 +295,11 @@ func validateSummary(text string) error {
 	return nil
 }
 
-func writeSummaryFile(projectDir, outputDir string, info SourceInfo, content *extract.SourceContent, summaryText string, result SummaryResult, loc *time.Location) SummaryResult {
+func writeSummaryFile(projectDir, outputDir string, info SourceInfo, summaryName string, content *extract.SourceContent, summaryText string, result SummaryResult, loc *time.Location) SummaryResult {
 	summaryDir := filepath.Join(projectDir, outputDir, "summaries")
 	os.MkdirAll(summaryDir, 0755)
 
-	summaryPath := filepath.Join(outputDir, "summaries", SummaryFilename(info.Path))
+	summaryPath := filepath.Join(outputDir, "summaries", summaryName)
 	absOutputPath := filepath.Join(projectDir, summaryPath)
 
 	frontmatter := fmt.Sprintf(`---

--- a/internal/compiler/summarize_test.go
+++ b/internal/compiler/summarize_test.go
@@ -62,7 +62,7 @@ func TestSummarizeOneReusesExistingSummaryOnHashMatch(t *testing.T) {
 	buildSummaryFile(t, filepath.Join(projectDir, outputDir), "sources-doc", sourceHash, longBody)
 
 	info := SourceInfo{Path: "sources/doc.md", Hash: sourceHash, Type: "article"}
-	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "", "", nil)
 
 	if result.Error != nil {
 		t.Fatalf("expected no error, got: %v", result.Error)
@@ -84,7 +84,7 @@ func TestSummarizeOneSkipsReusedWhenHashMismatch(t *testing.T) {
 
 	// Hash differs → must not reuse; extraction of missing source returns an error
 	info := SourceInfo{Path: "sources/doc.md", Hash: "sha256:new", Type: "article"}
-	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "", "", nil)
 
 	if result.Error == nil {
 		t.Fatal("expected an error (extract should fail on missing source), got nil")
@@ -103,7 +103,7 @@ func TestSummarizeOneSkipsReusedWhenSummaryTooShort(t *testing.T) {
 
 	// Body below 100 chars → must not reuse
 	info := SourceInfo{Path: "sources/doc.md", Hash: sourceHash, Type: "article"}
-	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "", "", nil)
 
 	if result.Error == nil {
 		t.Fatal("expected an error (extract should fail on missing source), got nil")
@@ -119,7 +119,7 @@ func TestSummarizeOneSkipsReusedWhenNoSummaryFile(t *testing.T) {
 
 	// No summary file exists → must not reuse
 	info := SourceInfo{Path: "sources/doc.md", Hash: "sha256:abc123", Type: "article"}
-	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "")
+	result := summarizeOne(projectDir, outputDir, info, nil, "", 0, nil, "", "", nil)
 
 	if result.Error == nil {
 		t.Fatal("expected an error (extract should fail on missing source), got nil")

--- a/internal/compiler/summary_path.go
+++ b/internal/compiler/summary_path.go
@@ -63,3 +63,104 @@ func SummaryFilename(sourcePath string) string {
 
 	return joined + ".md"
 }
+
+// SummaryFilenameMode converts a source path to a summary filename under the
+// configured naming scheme (issue #107).
+//
+// mode "full" (the default) delegates to SummaryFilename — byte-identical to
+// historical behavior. mode "relative" strips the configured sourceRoot prefix
+// and collapses a duplicated trailing path segment, producing cleaner names for
+// nested source trees:
+//
+//	full:      "wiki/pdf2md/Final FS Letter/Final FS Letter.md"
+//	             → "wiki-pdf2md-Final FS Letter-Final FS Letter.md"
+//	relative:  same path, root "wiki/pdf2md"
+//	             → "Final FS Letter.md"
+//
+// relative mode trades some cross-path collision safety for readability: two
+// source roots sharing a relative subpath, or a top-level "foo.md" alongside
+// "foo/foo.md", can collide. "full" remains the collision-safe default.
+func SummaryFilenameMode(sourcePath, sourceRoot, mode string) string {
+	if mode != "relative" {
+		return SummaryFilename(sourcePath)
+	}
+
+	p := filepath.ToSlash(filepath.Clean(sourcePath))
+	parts := strings.Split(p, "/")
+
+	// Strip the source-root prefix so the summary name is relative to the
+	// source the file was discovered under.
+	if sourceRoot != "" {
+		rootParts := strings.Split(filepath.ToSlash(filepath.Clean(sourceRoot)), "/")
+		if hasSegmentPrefix(parts, rootParts) {
+			parts = parts[len(rootParts):]
+		}
+	}
+
+	cleaned := parts[:0]
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			continue
+		}
+		cleaned = append(cleaned, part)
+	}
+	if len(cleaned) == 0 {
+		return "summary.md"
+	}
+
+	// Trim a trailing .md from the LAST segment BEFORE the duplicate compare —
+	// the raw last segment "Final FS Letter.md" only equals the parent dir
+	// "Final FS Letter" once the extension is removed.
+	last := cleaned[len(cleaned)-1]
+	if strings.EqualFold(filepath.Ext(last), ".md") {
+		cleaned[len(cleaned)-1] = strings.TrimSuffix(last, filepath.Ext(last))
+	}
+
+	// Collapse a duplicated TRAILING segment (marker-pdf's one-subdir-per-PDF
+	// convention: <X>/<X>). Only the trailing pair, to bound the collision
+	// blast radius of the collapse.
+	if n := len(cleaned); n >= 2 && cleaned[n-1] == cleaned[n-2] {
+		cleaned = cleaned[:n-1]
+	}
+
+	joined := strings.Join(cleaned, "-")
+	joined = strings.ReplaceAll(joined, ".", "-")
+	return joined + ".md"
+}
+
+// hasSegmentPrefix reports whether path segments begin with the given prefix
+// segments (exact, case-sensitive match per segment).
+func hasSegmentPrefix(parts, prefix []string) bool {
+	if len(prefix) > len(parts) {
+		return false
+	}
+	for i, seg := range prefix {
+		if parts[i] != seg {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveSourceRoot returns the configured source root (from roots) that most
+// specifically prefixes path — the longest segment-prefix match — or "" if none
+// applies. Both sides are slash/clean-normalized so comparison is stable; roots
+// are matched by whole path segments, not raw string prefixes, so "docs" does
+// not match "docsite/...". Issue #107.
+func resolveSourceRoot(path string, roots []string) string {
+	p := strings.Split(filepath.ToSlash(filepath.Clean(path)), "/")
+	best := ""
+	bestLen := -1
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		rNorm := filepath.ToSlash(filepath.Clean(root))
+		rParts := strings.Split(rNorm, "/")
+		if hasSegmentPrefix(p, rParts) && len(rParts) > bestLen {
+			best = rNorm
+			bestLen = len(rParts)
+		}
+	}
+	return best
+}

--- a/internal/compiler/summary_path_test.go
+++ b/internal/compiler/summary_path_test.go
@@ -90,3 +90,67 @@ func TestSummaryFilename_NoCollisions(t *testing.T) {
 		seen[fn] = p
 	}
 }
+
+// TestSummaryFilenameMode_FullDelegates locks the issue-#107 default: "full"
+// (and the empty/unset mode) must be byte-identical to SummaryFilename for
+// every input, regardless of the source root passed — the default naming does
+// not change existing behavior.
+func TestSummaryFilenameMode_FullDelegates(t *testing.T) {
+	inputs := []string{
+		"manifest.md", "raw/paper.md", "docs/projects/claw/manifest.md",
+		"../../ezra/docs/manifest.md", "raw/data.txt", "", "wiki/pdf2md/X/X.md",
+	}
+	for _, in := range inputs {
+		want := SummaryFilename(in)
+		if got := SummaryFilenameMode(in, "wiki/pdf2md", "full"); got != want {
+			t.Errorf("full mode diverged for %q: %q != %q", in, got, want)
+		}
+		if got := SummaryFilenameMode(in, "wiki/pdf2md", ""); got != want {
+			t.Errorf("empty mode should behave as full for %q: %q != %q", in, got, want)
+		}
+	}
+}
+
+// TestSummaryFilenameMode_Relative covers issue #107 relative naming: source-
+// root prefix strip + trailing duplicate-segment collapse, with the edge cases
+// the fix-plan review flagged (trim-.md-before-compare, non-trailing dup kept,
+// empty-after-strip, absolute/normalized root, non-.md extension).
+func TestSummaryFilenameMode_Relative(t *testing.T) {
+	tests := []struct{ path, root, want string }{
+		{"wiki/pdf2md/Final FS Letter/Final FS Letter.md", "wiki/pdf2md", "Final FS Letter.md"}, // strip + collapse
+		{"docs/Report/Report.md", "docs", "Report.md"},                                         // strip + collapse
+		{"docs/Report/Summary.md", "docs", "Report-Summary.md"},                                 // strip, no dup
+		{"Report/Report.md", "", "Report.md"},                                                   // collapse, no root
+		{"a/a/b.md", "", "a-a-b.md"},                                                             // non-trailing dup preserved
+		{"other/Report/Report.md", "docs", "other-Report.md"},                                   // root not a prefix → no strip, still collapse
+		{"docs/Report.md", "docs", "Report.md"},                                                 // root == parent → stem only
+		{"docs", "docs", "summary.md"},                                                          // empty after strip
+		{"docs/Report/Report.md", "./docs/", "Report.md"},                                       // root normalized before match
+		{"docs/data/data.txt", "docs", "data-data-txt.md"},                                      // non-.md: no trim, no collapse
+	}
+	for _, tt := range tests {
+		if got := SummaryFilenameMode(tt.path, tt.root, "relative"); got != tt.want {
+			t.Errorf("SummaryFilenameMode(%q, %q, relative) = %q, want %q", tt.path, tt.root, got, tt.want)
+		}
+	}
+}
+
+func TestResolveSourceRoot(t *testing.T) {
+	sources := []string{"docs", "wiki/pdf2md", "wiki"}
+	tests := []struct{ path, want string }{
+		{"wiki/pdf2md/X/X.md", "wiki/pdf2md"}, // longest-prefix wins over "wiki"
+		{"wiki/other/a.md", "wiki"},
+		{"docs/a.md", "docs"},
+		{"unrelated/a.md", ""},        // no match
+		{"docsite/a.md", ""},          // segment match, not raw string prefix
+		{"./docs/a.md", "docs"},       // path normalized before match
+	}
+	for _, tt := range tests {
+		if got := resolveSourceRoot(tt.path, sources); got != tt.want {
+			t.Errorf("resolveSourceRoot(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+	if got := resolveSourceRoot("docs/a.md", nil); got != "" {
+		t.Errorf("nil roots should yield \"\", got %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,14 @@ type CompilerConfig struct {
 	// default list; explicit `[]` → disabled (no stripping).
 	AntiPatternPhrases []string `yaml:"anti_pattern_phrases,omitempty"`
 
+	// Summary filename scheme (issue #107). "full" (default) hyphen-joins every
+	// source-path segment (collision-safe, issue #51). "relative" strips the
+	// configured source-root prefix and collapses a duplicated trailing segment
+	// (e.g. marker-pdf's <X>/<X>.md → X.md), trading some cross-path collision
+	// safety for cleaner names. Changing this renames summaries going forward;
+	// enabling it requires a full recompile to rename existing files.
+	SummaryNaming string `yaml:"summary_naming,omitempty"`
+
 	resolvedTZ *time.Location `yaml:"-"` // cached by Validate(); not serialized
 }
 
@@ -147,6 +155,15 @@ func (c CompilerConfig) AntiPatternPhrasesOrDefault() []string {
 		return defaultAntiPatternPhrases
 	}
 	return c.AntiPatternPhrases
+}
+
+// SummaryNamingOrDefault returns the summary filename scheme, defaulting to
+// "full" when unset (issue #107). Validate() rejects any other value.
+func (c CompilerConfig) SummaryNamingOrDefault() string {
+	if c.SummaryNaming == "" {
+		return "full"
+	}
+	return c.SummaryNaming
 }
 
 // QualityConfig configures the zero-LLM 5-dimension article quality scorer
@@ -663,6 +680,12 @@ func (c *Config) Validate() error {
 		validModes := map[string]bool{"standard": true, "batch": true, "auto": true}
 		if !validModes[c.Compiler.Mode] {
 			return fmt.Errorf("config: invalid compiler.mode %q (valid: standard, batch, auto)", c.Compiler.Mode)
+		}
+	}
+	if c.Compiler.SummaryNaming != "" {
+		validNaming := map[string]bool{"full": true, "relative": true}
+		if !validNaming[c.Compiler.SummaryNaming] {
+			return fmt.Errorf("config: invalid summary_naming %q (valid: full, relative)", c.Compiler.SummaryNaming)
 		}
 	}
 	// Merge relation_types (preferred) and relations (deprecated) keys.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -190,6 +190,15 @@ func TestValidation(t *testing.T) {
 			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Compiler: CompilerConfig{Timezone: "Asia/Shanghai"}},
 		},
 		{
+			name:    "invalid summary_naming",
+			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Compiler: CompilerConfig{SummaryNaming: "relatve"}},
+			wantErr: "invalid summary_naming",
+		},
+		{
+			name: "valid summary_naming relative",
+			cfg:  Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Compiler: CompilerConfig{SummaryNaming: "relative"}},
+		},
+		{
 			name:    "invalid relation name uppercase",
 			cfg:     Config{Project: "test", Output: "wiki", Sources: []Source{{Path: "raw"}}, Ontology: OntologyConfig{Relations: []RelationConfig{{Name: "Extends"}}}},
 			wantErr: "invalid name",


### PR DESCRIPTION
Fixes #107.

## Problem
`SummaryFilename` hyphen-joins every source-path segment (deliberate #51 collision-avoidance), producing noisy summary filenames for nested source trees. marker-pdf output at `wiki/pdf2md/<X>/<X>.md` becomes `wiki-pdf2md-X-X.md` — a repeated `wiki-pdf2md-` prefix on every file plus a duplicated `X-X` stem.

## Fix
Add an opt-in `compiler.summary_naming: full | relative` flag.

- **Default `full`** delegates verbatim to `SummaryFilename` → existing wikis are **byte-identical** (no churn, no migration). Locked by a regression test over the full existing table.
- **`relative`** strips the configured source-root prefix (resolved from `cfg.Sources` by longest **segment**-prefix at name-computation time) and collapses a duplicated **trailing** segment → `wiki/pdf2md/X/X.md` → `X.md`.

One shared `SummaryFilenameMode` helper is used by every summary write (standard, on-demand, batch) **and** the reuse-lookup, so they cannot diverge — a divergence would miss the reuse-lookup and orphan the old file. `Config.Validate()` hard-errors on an unknown value; a best-effort collision warning runs over the full source set on both the standard and batch paths.

The root is resolved from config at name time (not stored on `SourceInfo`), which keeps the standard, on-demand, and batch paths consistent.

## Trade-offs / scope
- `relative` trades some collision safety for readability (two source roots sharing a subpath, or `foo.md` vs `foo/foo.md`, can collide) — `full` stays the safe default; a warning fires on collision.
- **No auto-migration this increment:** enabling `relative` renames summaries going forward; existing files are renamed on a full recompile. Auto-reconciliation (prune summaries whose frontmatter `source:` is stale) is a documented follow-up.
- `mcp/tools_write.go` (manual/BYOK write) intentionally stays `full` — documented follow-up.

## Test plan
- `TestCompile_RelativeSummaryNaming` — mock-LLM full compile asserts the on-disk summary is `Report.md` under `relative`; **fails against the old scheme, passes after**.
- `TestSummaryFilenameMode_FullDelegates` (byte-identical lock), `_Relative` (strip/collapse/edge table), `TestResolveSourceRoot`, config validation cases.
- Existing 21 `SummaryFilename` subtests unchanged. `go test ./...` 32/32; compiler `-race` clean; vet clean.