### PR TITLE
fix(prompts): localize article headings + title under `language` (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Fuller localization of generated articles (#110).** When `language` is set,
+  the generated article's H1 title and section headings (Definition, How it
+  works, …) are now written in that language too, not just the body. Code,
+  identifiers, proper nouns, and `[[wikilink]]` targets are kept in their
+  original form so cross-references still resolve. The language directive is now
+  a single shared instruction used by both the article writer and the summary
+  synthesis step.
+
 ## 0.1.10 — 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ sources:
 
 output: wiki # compiled output directory (_wiki for vault overlay)
 
+# Output language for generated articles (default: English). When set, the
+# article body, H1 title, and section headings are all written in this
+# language; code, identifiers, proper nouns, and [[wikilink]] targets are kept
+# in their original form. Use the language's own name, e.g. 简体中文, 日本語.
+# language: 简体中文
+
 # Folders to never read or send to APIs (vault overlay mode)
 # ignore:
 #   - Daily Notes

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -504,12 +504,7 @@ func synthesizeHierarchical(summaries []string, sourcePath string, client *llm.C
 				"Combine these %d section summaries into a single coherent summary of the source document %q.\n\n%s",
 				len(group), sourcePath, strings.Join(group, "\n\n---\n\n"),
 			)
-			if language != "" {
-				synthesisPrompt += fmt.Sprintf(
-					"\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.",
-					language,
-				)
-			}
+			synthesisPrompt += prompts.LanguageInstruction(language)
 
 			resp, err := client.ChatCompletion([]llm.Message{
 				{Role: "system", Content: "You are synthesizing partial summaries into a final summary."},

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -108,9 +108,27 @@ func Render(name string, data any, language string) (string, error) {
 	}
 	result := buf.String()
 	if language != "" && !isJSONTemplate(result) {
-		result += fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s. Keep technical terms, code, and proper nouns in their original form.", language)
+		result += LanguageInstruction(language)
 	}
 	return result, nil
+}
+
+// LanguageInstruction returns the directive appended to a prompt to produce
+// output in the given language, or "" when language is empty. It is the single
+// source of truth for localization wording, shared by Render and the summary
+// synthesis path (summarize.go) so the two cannot drift.
+//
+// The wording explicitly covers the title and section headings (issue #110 —
+// the body was localized but headings/title stayed English), and protects
+// [[wikilink]] targets: a target is a concept-file identifier, and translating
+// it would make the post-compile strip pass delete the cross-reference. This is
+// a PURE string builder — it does no JSON gating; callers (Render) gate on
+// isJSONTemplate themselves.
+func LanguageInstruction(language string) string {
+	if language == "" {
+		return ""
+	}
+	return fmt.Sprintf("\n\nIMPORTANT: Write your entire response in %s — including any title and all section headings. Keep the following in their original form: code, identifiers, file paths, URLs, established proper nouns (product, library, and API names), and the exact text inside every [[...]] wikilink (a wikilink target is a file identifier — never translate it).", language)
 }
 
 // ScaffoldDefaults copies all embedded default templates to a directory

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -42,8 +42,13 @@ func TestRenderSummarize(t *testing.T) {
 	if !strings.Contains(result, "2000") {
 		t.Error("expected max tokens in output")
 	}
-	if !strings.Contains(result, "## Key claims") {
+	if !strings.Contains(result, "Key claims") {
 		t.Error("expected Key claims section")
+	}
+	// Headings are described (not hardcoded as literal English `##`) so they
+	// localize under a language config (issue #110).
+	if !strings.Contains(result, "each as a `##` heading") {
+		t.Error("expected the section-heading instruction")
 	}
 }
 
@@ -65,6 +70,31 @@ func TestRenderWriteArticle(t *testing.T) {
 	}
 	if !strings.Contains(result, "[[multi-head-attention]]") {
 		t.Error("expected wikilinks in See also")
+	}
+}
+
+// TestRenderWriteArticle_LocalizesStructure is the reproducing test for issue
+// #110: under a language config, the rendered write prompt must direct the model
+// to localize the title and section headings (not just the body), and must
+// protect [[wikilink]] targets from translation (translating them would make the
+// strip pass delete the cross-references). Against the pre-fix generic append
+// (which only says "write in X, keep proper nouns original") both assertions
+// fail → RED.
+func TestRenderWriteArticle_LocalizesStructure(t *testing.T) {
+	result, err := Render("write_article", WriteArticleData{
+		ConceptName:     "Self-Attention",
+		ConceptID:       "self-attention",
+		RelatedConcepts: []string{"multi-head-attention"},
+		MaxTokens:       4000,
+	}, "Chinese")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(result, "section headings") {
+		t.Error("language instruction should tell the model to localize section headings")
+	}
+	if !strings.Contains(result, "never translate") {
+		t.Error("language instruction should protect [[wikilink]] targets from translation")
 	}
 }
 
@@ -119,6 +149,27 @@ func TestRenderLanguageSkippedForCapture(t *testing.T) {
 	}
 	if strings.Contains(result, "Write your entire response in") {
 		t.Error("language instruction should be skipped for JSON-output templates")
+	}
+}
+
+// TestLanguageInstruction guards the shared localization directive (issue #110):
+// empty language is a no-op (default output byte-identical), and a non-empty
+// language directs localizing the title + section headings while protecting
+// [[wikilink]] targets from translation. These are change-detectors on the
+// instruction wording, not proofs the model obeys.
+func TestLanguageInstruction(t *testing.T) {
+	if got := LanguageInstruction(""); got != "" {
+		t.Errorf("empty language should be a no-op, got %q", got)
+	}
+	instr := LanguageInstruction("Chinese")
+	// Contiguous phrase kept so the Render language tests stay green.
+	if !strings.Contains(instr, "Write your entire response in Chinese") {
+		t.Error("must keep the contiguous 'Write your entire response in <lang>' phrase")
+	}
+	for _, want := range []string{"title", "section headings", "never translate"} {
+		if !strings.Contains(instr, want) {
+			t.Errorf("instruction missing %q coverage: %q", want, instr)
+		}
 	}
 }
 

--- a/internal/prompts/templates/summarize_article.txt
+++ b/internal/prompts/templates/summarize_article.txt
@@ -3,20 +3,12 @@ You are a research assistant creating a structured summary of a source document.
 Source file: {{.SourcePath}}
 Source type: {{.SourceType}}
 
-Summarize the document with the following structure:
+Summarize the document with the following sections, in order, each as a `##` heading — write each heading's text in the response language:
 
-## Key claims
-List the main arguments, findings, or assertions.
-
-## Methodology
-Describe the approach, methods, or techniques used (if applicable).
-
-## Results
-Summarize key results, outcomes, or conclusions.
-
-## Concepts
-List key concepts, terms, and ideas introduced or discussed.
-Format as a comma-separated list for easy extraction.
+1. Key claims — the main arguments, findings, or assertions.
+2. Methodology — the approach, methods, or techniques used (if applicable).
+3. Results — key results, outcomes, or conclusions.
+4. Concepts — key concepts, terms, and ideas introduced or discussed, formatted as a comma-separated list for easy extraction.
 
 Keep the summary under {{.MaxTokens}} tokens. Focus on factual content.
 Use precise language. Do not add opinions or commentary.

--- a/internal/prompts/templates/summarize_paper.txt
+++ b/internal/prompts/templates/summarize_paper.txt
@@ -3,22 +3,12 @@ You are a research assistant creating a structured summary of an academic paper.
 Source file: {{.SourcePath}}
 Source type: paper
 
-Summarize the paper with the following structure:
+Summarize the paper with the following sections, in order, each as a `##` heading — write each heading's text in the response language:
 
-## Key claims
-List the main contributions and findings.
-
-## Methodology
-Describe the experimental setup, datasets, and evaluation metrics.
-
-## Results
-Summarize quantitative results with specific numbers where available.
-
-## Limitations
-Note any limitations or caveats mentioned by the authors.
-
-## Concepts
-List key technical concepts introduced or used.
-Format as a comma-separated list.
+1. Key claims — the main contributions and findings.
+2. Methodology — the experimental setup, datasets, and evaluation metrics.
+3. Results — quantitative results with specific numbers where available.
+4. Limitations — any limitations or caveats mentioned by the authors.
+5. Concepts — key technical concepts introduced or used, formatted as a comma-separated list.
 
 Keep the summary under {{.MaxTokens}} tokens. Preserve technical precision.

--- a/internal/prompts/templates/write_article.txt
+++ b/internal/prompts/templates/write_article.txt
@@ -19,22 +19,17 @@ Related concepts: {{.RelatedList}}
 {{.Learnings}}
 {{end}}
 
-Write a structured wiki article with:
+Write a comprehensive wiki article about this concept.
 
-## Definition
-Clear, precise definition of the concept.
+Begin with a single `#` H1 title: a natural, readable rendering of the concept in the article's language. Keep genuine proper nouns and product, library, or API names in their original form.
 
-## How it works
-Technical explanation with appropriate depth.
+Then write the following sections, in order, each as a `##` heading — write each heading's text in the article's language:
 
-## Variants
-Known variants, implementations, or alternatives.
-
-## Trade-offs
-Key trade-offs, limitations, or considerations.
-
-## See also
-List related concepts as [[wikilinks]]:
+1. Definition — a clear, precise definition of the concept.
+2. How it works — technical explanation with appropriate depth.
+3. Variants — known variants, implementations, or alternatives.
+4. Trade-offs — key trade-offs, limitations, or considerations.
+5. See also — related concepts as [[wikilinks]]. Keep each wikilink target exactly as written (it is a file identifier); do not translate text inside [[ ]]:
 {{range .RelatedConcepts}}- [[{{.}}]]
 {{end}}
 


### PR DESCRIPTION
Fixes #110.

## Problem
With a `language` config set (e.g. `language: 简体中文`), generated concept articles had localized **body** text but English **section headings** (Definition, How it works, …) and an English **H1 title** — partial localization.

Cause: `write_article.txt` hardcoded the English `##` heading skeleton as the literal structure the LLM echoes verbatim, and the only localization was a generic appended instruction (in `Render`) that never told the model to translate the structure or title. The H1 came from the model spontaneously echoing the English `Concept:` line (no code emits it).

## Fix
- **One shared `prompts.LanguageInstruction`** used by both `Render` and the summary-synthesis path (previously two byte-identical hardcoded copies).
- **Strengthened wording** covers the title and all section headings, and **explicitly protects `[[wikilink]]` targets from translation** — a target is a concept-file identifier, and translating it would make `StripBrokenWikilinks` delete the cross-reference. (No `[[target|display]]` form: the strip pass doesn't split on `|`, so piped links would be stripped anyway.)
- **Reworded `write_article.txt`, `summarize_article.txt`, `summarize_paper.txt`** to describe their sections instead of hardcoding literal English `##` headings, add a localized-H1 instruction, and keep wikilink targets original.
- `LanguageInstruction("")` returns `""` → default (no-language) output is **byte-identical**.

## Regression safety
Nothing keys on the English heading names — the quality scorer's Format dimension and the linter thin-section check match the generic `## ` prefix; `extractRelations` is heading-agnostic. So localized headings (`## 定义`) score/lint/relate identically.

## Docs
Documented the previously-undocumented top-level `language:` config in README; CHANGELOG updated.

## Honest caveat
This is a **prompt-tuning** fix. The tests assert the rendered instruction/template now direct localization and protect the link graph — they **cannot prove the model obeys** (mock LLM returns fixed text). Real confirmation is a manual `language: 简体中文` compile. Heading localization is high-confidence; H1-title localization is best-effort (genuine proper-noun titles stay original; page identity still keys on the English `concept:` slug).

## Test plan
- `TestRenderWriteArticle_LocalizesStructure` — rendered write prompt localizes headings + protects `[[wikilink]]` targets; **fails pre-fix, passes after**.
- `TestLanguageInstruction`; `TestRenderSummarize` updated; existing `TestRenderLanguage*` / `TestRenderWriteArticle` stay green.
- `go test ./...` 32/32; vet clean.