### PR TITLE
feat(pkg): add pkg/sagewiki for in-process Go embedding (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`pkg/sagewiki` — in-process Go embedding (#112).** A supported, non-internal
+  entry point for embedding sage-wiki in another Go program without spawning
+  `sage-wiki serve` as a subprocess. `NewServer(projectDir)` returns a handle
+  exposing `MCPServer()` and `Close()`; pair it with mcp-go's
+  `client.NewInProcessClient` to call the same wiki tools an editor integration
+  calls over stdio. `SetVersion` lets an embedder report its own version string
+  in the initialize response. The package is experimental while sage-wiki is
+  pre-1.0: the Go signatures are meant to stay put, but tool names, argument
+  schemas, and `config.yaml` layout can change in any release.
+
+### Fixed
+
+- **MCP server reports the real build version.** `initialize` returned a
+  hardcoded `0.1.0` in `serverInfo.version` regardless of the binary's actual
+  version; it now reports the `-ldflags`-injected build version (`dev` from a
+  plain `go build`), mirroring `internal/pack.Version`.
+
 ## 0.2.5 — 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -265,6 +265,49 @@ query, derived from your config. Targets: `claude-code`, `cursor`,
 `wiki_learn`, closing the read-capture-evolve loop. Workflows and tips:
 [Agent Memory Layer](docs/guides/agent-memory-layer.md).
 
+### Embedding in a Go program
+
+To call the same tools from your own Go process — no subprocess, no stdio or
+port to manage — use `pkg/sagewiki` with mcp-go's in-process transport:
+
+```go
+srv, err := sagewiki.NewServer("/path/to/wiki")  // project must already exist
+if err != nil {
+    return err
+}
+defer srv.Close()  // the caller owns the DB handle here
+
+cli, err := client.NewInProcessClient(srv.MCPServer())
+if err != nil {
+    return err
+}
+defer cli.Close()
+
+if err := cli.Start(ctx); err != nil {
+    return err
+}
+if _, err := cli.Initialize(ctx, mcp.InitializeRequest{}); err != nil {
+    return err
+}
+
+res, err := cli.CallTool(ctx, mcp.CallToolRequest{
+    Params: mcp.CallToolParams{
+        Name:      "wiki_search",
+        Arguments: map[string]any{"query": "attention", "limit": 5},
+    },
+})
+```
+
+The project must already exist and the caller owns the database handle, so
+`Close` is required — unlike `serve`, nothing else closes it. Logs go to the
+host's stderr, and `initialize` reports the sage-wiki build version (`dev` from
+a plain `go build`); call `sagewiki.SetVersion` at startup to report your own
+version string instead.
+
+The package is **experimental** while sage-wiki is pre-1.0: the Go signatures
+are meant to stay put, but tool names, argument schemas, and `config.yaml`
+layout can change in any release. Pin a version.
+
 ## Operations
 
 - **Storage** — SQLite by default (single file, zero config); PostgreSQL +

--- a/cmd/sage-wiki/main.go
+++ b/cmd/sage-wiki/main.go
@@ -223,6 +223,10 @@ func init() {
 
 	// Enables `sage-wiki --version` in addition to the `version` subcommand.
 	rootCmd.Version = version
+
+	// Report the real build version to MCP clients on initialize, instead of
+	// the constant the server package defaults to.
+	mcppkg.Version = version
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,6 +29,12 @@ import (
 	"github.com/xoai/sage-wiki/internal/wiki"
 )
 
+// Version is the version this server reports to MCP clients during
+// initialize, set at build time via ldflags (mirrors internal/pack.Version).
+// When unset — running from source, or embedded via pkg/sagewiki in a host
+// that does not set it — clients see "dev".
+var Version = "dev"
+
 // Server wraps an MCP server with wiki tools.
 type Server struct {
 	mcp         *server.MCPServer
@@ -83,7 +89,7 @@ func NewServer(projectDir string, coordinator ...*compiler.CompileCoordinator) (
 
 	mcpServer := server.NewMCPServer(
 		"sage-wiki",
-		"0.1.0",
+		Version,
 		server.WithToolCapabilities(true),
 	)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -121,7 +121,9 @@ func (s *Server) Close() error {
 	return s.closeDB()
 }
 
-// MCPServer returns the underlying MCP server for testing.
+// MCPServer returns the underlying MCP server, for tests and for wiring into
+// a transport — pkg/sagewiki re-exports this so embedders can hand it to
+// mcp-go's in-process client.
 func (s *Server) MCPServer() *server.MCPServer {
 	return s.mcp
 }

--- a/pkg/sagewiki/sagewiki.go
+++ b/pkg/sagewiki/sagewiki.go
@@ -1,0 +1,102 @@
+// Package sagewiki is the supported entry point for embedding sage-wiki in
+// another Go program, in-process, without spawning `sage-wiki serve` as a
+// subprocess (#112).
+//
+// It deliberately exposes one thing: the MCP server handle. Everything a
+// caller can do, it does by calling the same MCP tools an editor or agent
+// integration calls over stdio — the compiler, store, and config internals
+// stay unexported. Pair it with mcp-go's in-process transport:
+//
+//	srv, err := sagewiki.NewServer("/path/to/wiki-project")
+//	if err != nil {
+//		return err
+//	}
+//	defer srv.Close()
+//
+//	cli, err := client.NewInProcessClient(srv.MCPServer())
+//	if err != nil {
+//		return err
+//	}
+//	defer cli.Close()
+//
+//	if _, err := cli.Initialize(ctx, mcp.InitializeRequest{}); err != nil {
+//		return err
+//	}
+//	res, err := cli.CallTool(ctx, mcp.CallToolRequest{
+//		Params: mcp.CallToolParams{
+//			Name:      "wiki_search",
+//			Arguments: map[string]any{"query": "attention", "limit": 5},
+//		},
+//	})
+//
+// The project directory must already be initialized (`sage-wiki init`, or
+// the equivalent init tooling): NewServer opens an existing config.yaml and
+// .sage/wiki.db, it does not create them.
+//
+// # Experimental
+//
+// sage-wiki is pre-1.0 and this package is experimental. The Go signatures
+// here are small and meant to stay put, but what they give you access to —
+// MCP tool names, their argument schemas, config.yaml layout, and tool
+// behavior — can change in any release. Pin a version.
+//
+// # Logging
+//
+// sage-wiki logs to the host process's stderr (see internal/log). An
+// embedder cannot currently redirect that.
+//
+// # Version reporting
+//
+// The initialize response carries the sage-wiki build version, which is `dev`
+// unless the binary was built with the release ldflags — an embedded server
+// gets `dev` by default. Call SetVersion during startup to report your own
+// version string instead.
+package sagewiki
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/xoai/sage-wiki/internal/mcp"
+)
+
+// Server is a live sage-wiki MCP server bound to one project directory.
+type Server struct {
+	inner *mcp.Server
+}
+
+// NewServer opens the project at projectDir and returns a server with the
+// wiki tools registered — the same set `sage-wiki serve` exposes.
+//
+// The caller owns the returned Server and must Close it: unlike the serve
+// commands, nothing else closes the underlying database.
+func NewServer(projectDir string) (*Server, error) {
+	inner, err := mcp.NewServer(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{inner: inner}, nil
+}
+
+// MCPServer returns the underlying MCP server, for wiring into a transport
+// such as mcp-go's client.NewInProcessClient.
+//
+// The Server retains ownership: the handle stops working once Close runs.
+func (s *Server) MCPServer() *server.MCPServer {
+	return s.inner.MCPServer()
+}
+
+// Close releases the project's database handle. It is safe to call more
+// than once.
+func (s *Server) Close() error {
+	return s.inner.Close()
+}
+
+// SetVersion overrides the version string this server reports to clients in
+// the initialize response. Without it, clients see the sage-wiki build
+// version (`dev` from a plain `go build`) — an embedder that would rather
+// report its own version calls this first.
+//
+// It applies process-wide to servers created afterwards, so call it during
+// startup, before NewServer, and not concurrently with it.
+func SetVersion(version string) {
+	mcp.Version = version
+}

--- a/pkg/sagewiki/sagewiki_test.go
+++ b/pkg/sagewiki/sagewiki_test.go
@@ -1,0 +1,172 @@
+package sagewiki_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/xoai/sage-wiki/internal/wiki"
+	"github.com/xoai/sage-wiki/pkg/sagewiki"
+)
+
+// setupProject initializes a greenfield project the same way the CLI's
+// `sage-wiki init` does, since NewServer expects an existing project.
+func setupProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := wiki.InitGreenfield(dir, "test-project", "gemini-2.5-flash"); err != nil {
+		t.Fatalf("InitGreenfield: %v", err)
+	}
+	return dir
+}
+
+// TestInProcessEmbedding is the end-to-end case this package exists for:
+// construct a server, hand it to mcp-go's in-process transport, complete the
+// MCP handshake, and list the wiki tools — no subprocess, no stdio, no port.
+func TestInProcessEmbedding(t *testing.T) {
+	srv, err := sagewiki.NewServer(setupProject(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := client.NewInProcessClient(srv.MCPServer())
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	defer cli.Close()
+
+	ctx := context.Background()
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	initResult, err := cli.Initialize(ctx, mcp.InitializeRequest{})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := initResult.ServerInfo.Name; got != "sage-wiki" {
+		t.Errorf("ServerInfo.Name = %q, want %q", got, "sage-wiki")
+	}
+	// Version is ldflags-injected; from a plain `go test` it is the default.
+	if initResult.ServerInfo.Version == "" {
+		t.Error("ServerInfo.Version is empty")
+	}
+
+	tools, err := cli.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("no tools registered")
+	}
+
+	// Spot-check one read tool from each registration group rather than
+	// pinning the full set, which grows release to release.
+	want := []string{"wiki_search", "wiki_status", "wiki_compile"}
+	got := make(map[string]bool, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		got[tool.Name] = true
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("tool %q not registered", name)
+		}
+	}
+}
+
+// TestCallToolInProcess confirms a tool actually executes against the
+// project's database through the transport, not just that it is listed.
+func TestCallToolInProcess(t *testing.T) {
+	srv, err := sagewiki.NewServer(setupProject(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := client.NewInProcessClient(srv.MCPServer())
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	defer cli.Close()
+
+	ctx := context.Background()
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := cli.Initialize(ctx, mcp.InitializeRequest{}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	result, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{Name: "wiki_status"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(wiki_status): %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("wiki_status returned an error result: %+v", result.Content)
+	}
+	if len(result.Content) == 0 {
+		t.Error("wiki_status returned no content")
+	}
+}
+
+// TestNewServerRejectsUninitializedDir documents that NewServer opens an
+// existing project rather than creating one.
+func TestNewServerRejectsUninitializedDir(t *testing.T) {
+	srv, err := sagewiki.NewServer(t.TempDir())
+	if err == nil {
+		srv.Close()
+		t.Fatal("expected an error for a directory with no config.yaml")
+	}
+}
+
+// TestCloseIsIdempotent covers the documented promise that callers can Close
+// more than once (App.Close wraps a closeOnce handle).
+func TestCloseIsIdempotent(t *testing.T) {
+	srv, err := sagewiki.NewServer(setupProject(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := srv.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+// TestSetVersionIsReportedOnInitialize covers the documented escape hatch for
+// embedders that want their own version in the initialize response instead of
+// the sage-wiki build version.
+func TestSetVersionIsReportedOnInitialize(t *testing.T) {
+	const want = "host-app/9.9.9"
+	sagewiki.SetVersion(want)
+	t.Cleanup(func() { sagewiki.SetVersion("dev") })
+
+	srv, err := sagewiki.NewServer(setupProject(t))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	defer srv.Close()
+
+	cli, err := client.NewInProcessClient(srv.MCPServer())
+	if err != nil {
+		t.Fatalf("NewInProcessClient: %v", err)
+	}
+	defer cli.Close()
+
+	ctx := context.Background()
+	if err := cli.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	initResult, err := cli.Initialize(ctx, mcp.InitializeRequest{})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := initResult.ServerInfo.Version; got != want {
+		t.Errorf("ServerInfo.Version = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Implements the thin wrapper described in #112.

## What this adds

`pkg/sagewiki` — a non-internal entry point exposing only the MCP server handle:

- `NewServer(projectDir) (*Server, error)` — wraps `internal/mcp.NewServer`
- `(*Server).MCPServer() *server.MCPServer` — for `client.NewInProcessClient`
- `(*Server).Close() error` — the caller owns the DB handle

Deliberately **not** exposed: compiler, store, config. An embedder calls the same
MCP tools an editor integration calls over stdio, so there's no second API surface
to keep in sync with the tool schemas.

`internal/mcp` needed no refactor — `MCPServer()` and `Close()` already existed. The
only change there is the version fix below, plus widening `MCPServer()`'s "for
testing" doc comment now that it's a supported entry point.

## Addressing your three points

1. **API stability.** The package doc marks it experimental and says explicitly that
   while the Go signatures are meant to stay put, tool names, argument schemas, and
   `config.yaml` layout can change in any release. Same note in the README section
   and CHANGELOG entry.
2. **Version string.** Separate commit. `server.NewMCPServer` was passed a hardcoded
   `"0.1.0"`, so `serverInfo.version` on `initialize` was that constant regardless of
   the binary — an MCP client couldn't tell which sage-wiki it was talking to. Now a
   package-level `Version` var defaulting to `"dev"`, wired from main's
   ldflags-injected version. I followed `internal/pack.Version`, which already uses
   this exact pattern, rather than inventing a mechanism.
3. **What it should not expose.** Only the server handle, per above. I don't need
   deeper hooks — calling the MCP tools in-process is exactly the use case.

The two commits are independent; the version fix stands alone if you'd rather take
only that.

## Verification

- `go build ./...` and `go build -tags webui ./...`, `go vet ./...` — clean
- `CGO_ENABLED=1 go test -race ./pkg/... ./internal/mcp/... ./cmd/...` — pass
- `golangci-lint run --new-from-merge-base=main` — 0 issues
- Version fix confirmed over the real transport, not just unit tests:

  ```
  $ go build -ldflags "-X main.version=v9.9.9-test" -o sage-wiki ./cmd/sage-wiki
  $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | ./sage-wiki serve --project p
  {"result":{...,"serverInfo":{"name":"sage-wiki","version":"v9.9.9-test"}}}
  ```

`pkg/sagewiki/sagewiki_test.go` covers the embedding path end to end — construct,
hand to mcp-go's in-process transport, handshake, `ListTools`, `CallTool(wiki_status)`
— plus the uninitialized-dir error and `Close` idempotency. I noticed the existing
`pkg/` test bar was a single 8-line case, so I aimed a bit higher; trim if it's more
than you want.

## Notes

- Branched from the `v0.2.4` tag.
- While adapting my own project to this design I hit a few capability gaps in the MCP
  tool set (no `wiki_query`, `wiki_add_source` is path-only). Those are orthogonal to
  this PR and I've written them up separately in #112 — this PR doesn't depend on any
  of them.
- `sage-wiki init <dir>` silently exits 2 while printing success (`--project` works
  fine). Unrelated to this change and left alone; happy to file it separately.
