### PR TITLE
fix(ci): stabilize hosted race shards and protect latest-SHA verification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ## Checklist
 
 - [ ] `make ci` passes on this branch (build, vet, race tests, new-issue lint, translation drift)
+- [ ] Hosted `CI required` is green on the latest PR SHA (a green local `make ci` is mandatory but not a substitute; stale hosted results do not count)
 - [ ] If `README.md` changed: the six `docs/translations/README_*.md` translations are updated, or a commit carries `translations: lag-ok`
 - [ ] User-facing changes are documented (CHANGELOG `[Unreleased]`, README, affected guides — all README translations for user-visible behavior)
 - [ ] Tests added or updated for the change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,3 +478,33 @@ jobs:
           COMMIT_MSGS="$(git log --format=%B "$RANGE")"
           export BASE HEAD COMMIT_MSGS
           bash scripts/check-readme-translations.sh
+
+  # The ONE stable required result: `CI required` is the unique displayed
+  # check-run context this repo protects (R5-R6). Every non-advisory job is
+  # a dependency; vuln stays advisory (continue-on-error) and is deliberately
+  # excluded. `if: always()` + explicit result inspection means this job runs
+  # even when a dependency fails and turns red unless EVERY listed result is
+  # `success` — the aggregate behavior a required status check needs. No
+  # checkout, no permissions: this job only reads `needs`.
+  ci-required:
+    name: CI required
+    needs: [build, parity, go-test, fuzz-short, skill-drift, postgres, minio, lint, frontend, translations]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All required jobs succeeded
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.parity.result }}" != "success" ] || \
+             [ "${{ needs.go-test.result }}" != "success" ] || \
+             [ "${{ needs.fuzz-short.result }}" != "success" ] || \
+             [ "${{ needs.skill-drift.result }}" != "success" ] || \
+             [ "${{ needs.postgres.result }}" != "success" ] || \
+             [ "${{ needs.minio.result }}" != "success" ] || \
+             [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.frontend.result }}" != "success" ] || \
+             [ "${{ needs.translations.result }}" != "success" ]; then
+            echo "CI required: one or more dependencies did not succeed"
+            exit 1
+          fi
+          echo "CI required: all dependencies succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,12 +485,16 @@ jobs:
   # excluded. `if: always()` + explicit result inspection means this job runs
   # even when a dependency fails and turns red unless EVERY listed result is
   # `success` — the aggregate behavior a required status check needs. No
-  # checkout, no permissions: this job only reads `needs`.
+  # checkout, no permissions: this job only reads `needs`. Explicit empty
+  # job-level permissions drop the workflow-level `contents: read` here, so
+  # the aggregate gate stays least-privilege even if a future workflow edit
+  # broadens the top-level permissions block.
   ci-required:
     name: CI required
     needs: [build, parity, go-test, fuzz-short, skill-drift, postgres, minio, lint, frontend, translations]
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: All required jobs succeeded
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@
   standard `sage-wiki compile`, serve background worker cycles, and MCP/REST
   on-demand topic compilation.
 
+- **SQLite writer reservation at transaction begin.** A second handle on the
+  same SQLite path could enter a write transaction while another handle held
+  a deferred snapshot, commit, and force the paused handle's later snapshot
+  upgrade to fail with `SQLITE_BUSY_SNAPSHOT` mid-callback — the
+  cross-handle contention class behind hosted CI flakes. The writer DSN now
+  uses `_txlock=immediate`, so both `WriteTx` and `BeginWrite` take the
+  writer lock at BEGIN, where the existing busy-handler arbitration applies,
+  instead of at first write.
+
+- **Deterministic idle-close and worker-cycle tests.** The engine manager's
+  idle-close tests are driven by an injected synchronous controlled-time
+  evaluator instead of real-time sleeps, and the compile worker harness now
+  mirrors serve backend ownership (one handle, same backend, for every pass
+  store). Both suites reproduce the single-backend topology on purpose, so a
+  second SQLite handle can never hide the cross-handle race again.
+
+### Added
+
+- **Hosted CI aggregate check-run (`CI required`).** The main CI workflow
+  now emits a single stable check-run that explicitly inspects every
+  required job (build, parity, go-test, fuzz-short, skill-drift, postgres,
+  minio, lint, frontend, translations) and reports failure unless all
+  succeed — including on runs where a dependency failed. One stable status
+  for pre-main merges: `make ci` stays mandatory local evidence, but only a
+  green `CI required` on the latest PR SHA clears the hosted gate.
+
 ## [0.2.8] — 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@
   instead of at first write.
 
 - **Deterministic idle-close and worker-cycle tests.** The engine manager's
-  idle-close tests are driven by an injected synchronous controlled-time
-  evaluator instead of real-time sleeps, and the compile worker harness now
+  idle-close tests drive the idle evaluator directly with explicit
+  timestamps instead of real-time sleeps, and the compile worker harness now
   mirrors serve backend ownership (one handle, same backend, for every pass
-  store). Both suites reproduce the single-backend topology on purpose, so a
-  second SQLite handle can never hide the cross-handle race again.
+  store) — removing the stray second handle that distorted worker-cycle runs
+  with `BUSY_SNAPSHOT` flakes. The cross-handle production class stays
+  covered by the dedicated two-handle storage test.
 
 ### Added
 
@@ -32,8 +33,10 @@
   required job (build, parity, go-test, fuzz-short, skill-drift, postgres,
   minio, lint, frontend, translations) and reports failure unless all
   succeed — including on runs where a dependency failed. One stable status
-  for pre-main merges: `make ci` stays mandatory local evidence, but only a
-  green `CI required` on the latest PR SHA clears the hosted gate.
+  for pre-main merges: `make ci` stays mandatory local evidence, and a green
+  `CI required` on the latest PR SHA is the gate maintainers hold before
+  merging — a policy gate today, mechanical once branch protection requires
+  the check on `main`.
 
 ## [0.2.8] — 2026-08-05
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,14 @@ CI quality gate (build, vet, race tests, new-issue lint, translation drift).
 On `main` itself the *local* drift range is empty (CI's push path checks
 `before..after` and is not), so always check from your branch.
 
-**Local `make ci` is mandatory but not a substitute for hosted CI.** Merges
-to `main` gate on the hosted `CI required` check-run on the latest PR SHA: a
+**Local `make ci` is mandatory but not a substitute for hosted CI.** The
+hosted `CI required` check-run on the latest PR SHA is the merge gate: a
 green `make ci` mirrors the quality gate (build, vet, race tests, new-issue
 lint, translation drift) but does not replace a green hosted run, and a
-hosted result that predates your last push does not count. Treat a PR as
-CI-clear only when `CI required` reports success on the HEAD SHA.
+hosted result that predates your last push does not count. Today that gate
+is maintainer policy — a PR is not mergeable without `CI required` success
+on the HEAD SHA — and it becomes mechanical once branch protection requires
+the check on `main`.
 
 ## Repository layout
 
@@ -47,10 +49,10 @@ to document the debt.
 contributors at `action_required` — checks must have *run and passed*, not
 merely be absent. Click "Approve and run workflows" on fork PRs, and treat a
 PR showing zero checks as unverified regardless of local runs. When reworking
-CI workflow code, keep the required context valid: relax or remove the
-required `CI required` status check on `main` before reverting or renaming
-the workflow that emits that check-run — a required context that no workflow
-produces blocks every merge.
+CI workflow code, keep the required context valid: once branch protection
+requires `CI required` on `main`, relax or remove that required status check
+before reverting or renaming the workflow that emits the check-run — a
+required context that no workflow produces blocks every merge.
 
 ## Adding a file format parser
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,13 @@ CI quality gate (build, vet, race tests, new-issue lint, translation drift).
 On `main` itself the *local* drift range is empty (CI's push path checks
 `before..after` and is not), so always check from your branch.
 
+**Local `make ci` is mandatory but not a substitute for hosted CI.** Merges
+to `main` gate on the hosted `CI required` check-run on the latest PR SHA: a
+green `make ci` mirrors the quality gate (build, vet, race tests, new-issue
+lint, translation drift) but does not replace a green hosted run, and a
+hosted result that predates your last push does not count. Treat a PR as
+CI-clear only when `CI required` reports success on the HEAD SHA.
+
 ## Repository layout
 
 Selected entries (illustrative, not exhaustive):
@@ -39,7 +46,11 @@ to document the debt.
 **Maintainers merging external PRs:** GitHub holds CI for first-time
 contributors at `action_required` — checks must have *run and passed*, not
 merely be absent. Click "Approve and run workflows" on fork PRs, and treat a
-PR showing zero checks as unverified regardless of local runs.
+PR showing zero checks as unverified regardless of local runs. When reworking
+CI workflow code, keep the required context valid: relax or remove the
+required `CI required` status check on `main` before reverting or renaming
+the workflow that emits that check-run — a required context that no workflow
+produces blocks every merge.
 
 ## Adding a file format parser
 

--- a/internal/compiler/cli_queue_test.go
+++ b/internal/compiler/cli_queue_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xoai/sage-wiki/internal/ontology"
 	"github.com/xoai/sage-wiki/internal/storage"
 	"github.com/xoai/sage-wiki/internal/store"
+	"github.com/xoai/sage-wiki/internal/trust"
 	"github.com/xoai/sage-wiki/internal/vectors"
 )
 
@@ -142,9 +143,12 @@ func TestCompile_DryRunNoSideEffects(t *testing.T) {
 	}
 }
 
-// testBackend is the minimal store.Backend for Compile-level tests,
-// built exactly like setupStores' legacy sqlite path. Trust/OutputIndex/
-// Learnings are nil — the compile path never touches them.
+// testBackend is the minimal store.Backend for Compile- and worker-cycle
+// tests, built like setupStores' legacy sqlite path but over ONE
+// *storage.DB handle (R3: worker tests must mirror serve-mode ownership,
+// where Items and the pass stores share a backend). OutputIndex and
+// Learnings stay nil and BeginWrite stays an explicit unsupported stub —
+// neither the Compile path nor a worker cycle reaches those surfaces.
 type testBackend struct {
 	db      *storage.DB
 	items   store.CompileItemStore
@@ -152,6 +156,7 @@ type testBackend struct {
 	chunks  store.ChunkStore
 	vecs    store.VectorStore
 	ont     store.OntologyStore
+	trust   store.TrustStore
 }
 
 func newTestBackend(db *storage.DB) *testBackend {
@@ -164,6 +169,7 @@ func newTestBackend(db *storage.DB) *testBackend {
 		chunks:  memory.NewChunkStore(db),
 		vecs:    vectors.NewStore(db),
 		ont:     ontology.NewStore(db, ontology.ValidRelationNames(merged), ontology.ValidEntityTypeNames(mergedTypes)),
+		trust:   trust.NewStore(db),
 	}
 }
 
@@ -172,7 +178,7 @@ func (b *testBackend) Chunks() store.ChunkStore          { return b.chunks }
 func (b *testBackend) Vectors() store.VectorStore        { return b.vecs }
 func (b *testBackend) Ontology() store.OntologyStore     { return b.ont }
 func (b *testBackend) Communities() store.CommunityStore { return b.ont.(store.CommunityStore) }
-func (b *testBackend) Trust() store.TrustStore           { return nil }
+func (b *testBackend) Trust() store.TrustStore           { return b.trust }
 func (b *testBackend) CompileItems() store.CompileItemStore {
 	return b.items
 }

--- a/internal/compiler/worker_cycle_test.go
+++ b/internal/compiler/worker_cycle_test.go
@@ -147,7 +147,8 @@ func TestWorkerHarness_SingleBackendTopology(t *testing.T) {
 		t.Error("cycle itemStore is not the harness Items")
 	}
 	if cr.run.memStore != tb.Entries() || cr.run.chunkStore != tb.Chunks() ||
-		cr.run.vecStore != tb.Vectors() || cr.run.trustStore != tb.Trust() {
+		cr.run.vecStore != tb.Vectors() || cr.run.trustStore != tb.Trust() ||
+		cr.run.pipelineOntStore != tb.Ontology() {
 		t.Error("cycle pass stores are not the harness backend's own stores")
 	}
 	if cr.run.db != tb {

--- a/internal/compiler/worker_cycle_test.go
+++ b/internal/compiler/worker_cycle_test.go
@@ -16,11 +16,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/log"
 	"github.com/xoai/sage-wiki/internal/metrics"
 	"github.com/xoai/sage-wiki/internal/prompts"
 	"github.com/xoai/sage-wiki/internal/storage"
+	"github.com/xoai/sage-wiki/internal/store"
 	"github.com/xoai/sage-wiki/internal/wiki"
 	"github.com/xoai/sage-wiki/pkg/events"
 )
@@ -30,7 +30,8 @@ type workerHarness struct {
 	dir     string
 	project string
 	server  *httptest.Server
-	items   *CompileItemStore
+	backend store.Backend
+	items   store.CompileItemStore
 	worker  *Worker
 	embeds  atomic.Int32
 }
@@ -113,11 +114,46 @@ compiler:
 		t.Fatalf("open store: %v", err)
 	}
 	t.Cleanup(func() { db.Close() })
-	h.items = NewCompileItemStore(db, config.NowUTC)
+	// R3: one backend owns every store a worker cycle touches — serve-mode
+	// topology, where NewWorkerForServe sources Items from the same backend
+	// the pass stores come from (single handle, single writeMu).
+	h.backend = newTestBackend(db)
+	h.items = h.backend.CompileItems()
 	return h
 }
 
 var itoa = strconv.Itoa
+
+// TestWorkerHarness_SingleBackendTopology pins spec R3/AC3: a worker cycle
+// must run entirely on the harness backend — every pass store is the
+// backend's own instance and no second sqlite handle is opened. Pre-fix,
+// setupStores opened handle B for chunk/entry/vector stores and only
+// itemStore pointed at handle A, so the 5 ms heartbeat raced FTS writes
+// (BUSY/BUSY_SNAPSHOT, empty compile key).
+func TestWorkerHarness_SingleBackendTopology(t *testing.T) {
+	h := newWorkerHarness(t, 3, http.StatusOK)
+	h.newWorker(t, 50*time.Millisecond, 5*time.Millisecond, 3)
+
+	cr, err := h.worker.openCycleRun(context.Background())
+	if err != nil {
+		t.Fatalf("openCycleRun: %v", err)
+	}
+	defer cr.cleanup()
+	tb, ok := cr.run.db.(*testBackend)
+	if !ok {
+		t.Fatalf("cycle run db = %T, want the harness testBackend (no second handle)", cr.run.db)
+	}
+	if cr.run.itemStore != h.items {
+		t.Error("cycle itemStore is not the harness Items")
+	}
+	if cr.run.memStore != tb.Entries() || cr.run.chunkStore != tb.Chunks() ||
+		cr.run.vecStore != tb.Vectors() || cr.run.trustStore != tb.Trust() {
+		t.Error("cycle pass stores are not the harness backend's own stores")
+	}
+	if cr.run.db != tb {
+		t.Error("cycle run db is not the harness backend")
+	}
+}
 
 func (h *workerHarness) writeSource(t *testing.T, name, content string) {
 	t.Helper()
@@ -131,6 +167,7 @@ func (h *workerHarness) newWorker(t *testing.T, poll, heartbeat time.Duration, m
 	h.worker = NewWorker(WorkerDeps{
 		ProjectDir: h.dir,
 		Items:      h.items,
+		Backend:    h.backend,
 		Coord:      NewCompileCoordinator(),
 		Progress:   NewProgress(),
 		Config: workerSettings{
@@ -341,6 +378,7 @@ func TestWorker_TierClaimOrder(t *testing.T) {
 	h.worker = NewWorker(WorkerDeps{
 		ProjectDir: h.dir,
 		Items:      h.items,
+		Backend:    h.backend,
 		Coord:      NewCompileCoordinator(),
 		Progress:   progress,
 		Config: workerSettings{
@@ -393,6 +431,7 @@ func TestWorker_ClaimFencing(t *testing.T) {
 	w2 := NewWorker(WorkerDeps{
 		ProjectDir: h.dir,
 		Items:      h.items,
+		Backend:    h.backend,
 		Coord:      NewCompileCoordinator(),
 		Progress:   NewProgress(),
 		Config:     h.worker.deps.Config,
@@ -425,6 +464,7 @@ func TestWorker_EmitsQueueEvents(t *testing.T) {
 	h.worker = NewWorker(WorkerDeps{
 		ProjectDir: h.dir,
 		Items:      h.items,
+		Backend:    h.backend,
 		Coord:      NewCompileCoordinator(),
 		Progress:   progress,
 		Config: workerSettings{

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -30,8 +30,14 @@ func Open(path string) (*DB, error) {
 		}
 	}
 
-	// Write connection
-	writeDB, err := sql.Open("sqlite", path)
+	// Write connection. _txlock=immediate reserves SQLite's sole writer at
+	// BEGIN (spec R1): a deferred begin only takes a read snapshot, so a
+	// second handle's transaction can enter, write, and commit first, and the
+	// paused handle's later snapshot upgrade fails BUSY_SNAPSHOT — exactly
+	// the cross-handle contention class seen in hosted CI. Waiting at begin
+	// is safer than failing mid-callback: transaction callbacks are never
+	// replayed.
+	writeDB, err := sql.Open("sqlite", path+"?_txlock=immediate")
 	if err != nil {
 		return nil, fmt.Errorf("storage.Open: %w", err)
 	}

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -2,9 +2,11 @@ package storage
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestOpenAndMigrate(t *testing.T) {
@@ -105,6 +107,147 @@ func TestWriteTxSerialization(t *testing.T) {
 	db.ReadDB().QueryRow("SELECT val FROM test_counter").Scan(&val)
 	if val != 10 {
 		t.Errorf("expected counter 10, got %d", val)
+	}
+}
+
+// TestWriteTxSerializesAcrossHandles proves cross-handle writer reservation
+// (spec R2): two storage.Open handles on one SQLite path must serialize write
+// transactions such that handle B's transaction body does not enter until
+// handle A's write transaction commits. A writeMu on one handle cannot
+// serialize another handle (see stored learning 0ac16bd512a342fca11b3c2b38ce64e7),
+// so SQLite's own writer reservation is the mechanism under test.
+//
+// Phases are coordinated with channels. The generous timeout below is a
+// deadlock bound only: it stays below the 5s busy_timeout so that handle B's
+// blocked BEGIN (immediate mode) can still succeed after A commits, and it
+// proves nothing about scheduling — immediate mode keeps B out of its body by
+// lock, not by timing.
+func TestWriteTxSerializesAcrossHandles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	dbA, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open handle A: %v", err)
+	}
+	defer dbA.Close()
+	dbB, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open handle B: %v", err)
+	}
+	defer dbB.Close()
+
+	for _, stmt := range []string{
+		"CREATE TABLE IF NOT EXISTS test_counter (val INTEGER NOT NULL)",
+		"DELETE FROM test_counter",
+		"INSERT INTO test_counter (val) VALUES (0)",
+	} {
+		if _, err := dbA.WriteDB().Exec(stmt); err != nil {
+			t.Fatalf("setup %q: %v", stmt, err)
+		}
+	}
+
+	order := make(chan string, 8)   // buffered phase log; drained after joins
+	aRead := make(chan struct{})    // A's callback established its snapshot
+	bAttempt := make(chan struct{}) // B goroutine is about to call WriteTx
+	bDone := make(chan struct{})    // B's WriteTx returned
+	resumeA := make(chan struct{})  // A may proceed to write and commit
+	aDone := make(chan struct{})    // A's WriteTx returned
+
+	var aErr, bErr error
+
+	go func() {
+		aErr = dbA.WriteTx(func(tx *sql.Tx) error {
+			var v int
+			if err := tx.QueryRow("SELECT val FROM test_counter").Scan(&v); err != nil {
+				return err
+			}
+			order <- "A:read"
+			close(aRead)
+			<-resumeA
+			order <- "A:write"
+			if _, err := tx.Exec("UPDATE test_counter SET val = val + 1"); err != nil {
+				return fmt.Errorf("A snapshot upgrade: %w", err)
+			}
+			return nil
+		})
+		order <- "A:done"
+		close(aDone)
+	}()
+
+	// B must not attempt its transaction until A has begun and read; otherwise
+	// B can win the SQLite write lock first and the choreography flips.
+	<-aRead
+	go func() {
+		close(bAttempt)
+		bErr = dbB.WriteTx(func(tx *sql.Tx) error {
+			order <- "B:enter"
+			if _, err := tx.Exec("UPDATE test_counter SET val = val + 1"); err != nil {
+				return fmt.Errorf("B write: %w", err)
+			}
+			order <- "B:write"
+			return nil
+		})
+		order <- "B:done"
+		close(bDone)
+	}()
+	<-bAttempt
+
+	// While A pauses before its write, B attempts WriteTx. Immediate mode
+	// blocks B inside BEGIN until A commits; deferred mode lets B enter and
+	// commit right away. The wait is a deadlock bound only — generous for
+	// scheduling, yet below the 5s busy_timeout so B's blocked BEGIN succeeds
+	// after A commits.
+	select {
+	case <-bDone:
+		t.Logf("transaction phase: B entered and committed while A was paused (deferred)")
+	case <-time.After(2 * time.Second):
+		t.Logf("transaction phase: B remained blocked in BEGIN while A was paused (immediate)")
+	}
+
+	close(resumeA)
+	<-aDone
+	<-bDone
+
+	if aErr != nil {
+		t.Errorf("handle A WriteTx: %v", aErr)
+	}
+	if bErr != nil {
+		t.Errorf("handle B WriteTx: %v", bErr)
+	}
+
+	entries := make([]string, 0, 8)
+drain:
+	for {
+		select {
+		case e := <-order:
+			entries = append(entries, e)
+		default:
+			break drain
+		}
+	}
+	t.Logf("observed transaction order: %v", entries)
+
+	// B's callback entry must be ordered after A's commit.
+	bEnteredAt, aDoneAt := -1, -1
+	for i, e := range entries {
+		switch e {
+		case "B:enter":
+			bEnteredAt = i
+		case "A:done":
+			aDoneAt = i
+		}
+	}
+	if bEnteredAt >= 0 && aDoneAt >= 0 && bEnteredAt < aDoneAt {
+		t.Errorf("handle B entered its transaction body before handle A committed (order: %v)", entries)
+	}
+
+	var val int
+	if err := dbA.ReadDB().QueryRow("SELECT val FROM test_counter").Scan(&val); err != nil {
+		t.Fatalf("read final counter: %v", err)
+	}
+	if val != 2 {
+		t.Errorf("expected final counter 2, got %d (order: %v)", val, entries)
 	}
 }
 

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -137,14 +137,22 @@ func TestWriteTxSerializesAcrossHandles(t *testing.T) {
 	}
 	defer dbB.Close()
 
-	for _, stmt := range []string{
-		"CREATE TABLE IF NOT EXISTS test_counter (val INTEGER NOT NULL)",
-		"DELETE FROM test_counter",
-		"INSERT INTO test_counter (val) VALUES (0)",
-	} {
-		if _, err := dbA.WriteDB().Exec(stmt); err != nil {
-			t.Fatalf("setup %q: %v", stmt, err)
+	// Setup runs through WriteTx so the write connection is only ever touched
+	// while its lock is held (WriteDB's documented contract), matching the
+	// other tests in this package.
+	if err := dbA.WriteTx(func(tx *sql.Tx) error {
+		for _, stmt := range []string{
+			"CREATE TABLE IF NOT EXISTS test_counter (val INTEGER NOT NULL)",
+			"DELETE FROM test_counter",
+			"INSERT INTO test_counter (val) VALUES (0)",
+		} {
+			if _, err := tx.Exec(stmt); err != nil {
+				return fmt.Errorf("%q: %w", stmt, err)
+			}
 		}
+		return nil
+	}); err != nil {
+		t.Fatalf("setup: %v", err)
 	}
 
 	order := make(chan string, 8)   // buffered phase log; drained after joins
@@ -155,6 +163,7 @@ func TestWriteTxSerializesAcrossHandles(t *testing.T) {
 	aDone := make(chan struct{})    // A's WriteTx returned
 
 	var aErr, bErr error
+	var bEntryVal int // value B's callback reads at entry; synced via close(bDone)
 
 	go func() {
 		aErr = dbA.WriteTx(func(tx *sql.Tx) error {
@@ -181,6 +190,11 @@ func TestWriteTxSerializesAcrossHandles(t *testing.T) {
 	go func() {
 		close(bAttempt)
 		bErr = dbB.WriteTx(func(tx *sql.Tx) error {
+			var v int
+			if err := tx.QueryRow("SELECT val FROM test_counter").Scan(&v); err != nil {
+				return err
+			}
+			bEntryVal = v
 			order <- "B:enter"
 			if _, err := tx.Exec("UPDATE test_counter SET val = val + 1"); err != nil {
 				return fmt.Errorf("B write: %w", err)
@@ -228,18 +242,39 @@ drain:
 	}
 	t.Logf("observed transaction order: %v", entries)
 
-	// B's callback entry must be ordered after A's commit.
-	bEnteredAt, aDoneAt := -1, -1
+	// Ordering anchors — both airtight, neither has a false-red window:
+	//
+	// 1. Data anchor: B's entry read must observe A's committed increment
+	//    (bEntryVal == 1). WAL snapshots contain only committed data, and B's
+	//    BEGIN (immediate mode) can succeed only after A's commit releases the
+	//    writer lock, so B's entry read observes the increment if and only if
+	//    A committed before B entered. The observation is the database state
+	//    read inside B's own transaction — not a goroutine log line — so there
+	//    is no post-commit logging gap to race with.
+	//
+	// 2. Log anchor: "B:enter" must follow "A:write" in the phase log.
+	//    "A:write" is logged inside A's callback immediately after the UPDATE,
+	//    while A still holds the writer lock (commit has not happened yet);
+	//    "B:enter" is logged only after B's BEGIN succeeds, which requires the
+	//    lock to be free. The write lock therefore orders the two log sends
+	//    with no scheduler involvement. ("A:done" is deliberately NOT used as
+	//    an anchor: it is logged after WriteTx returns, and Commit may release
+	//    the writer lock before the goroutine schedules that send, letting B
+	//    enter and log first — a false-red window.)
+	if bEntryVal != 1 {
+		t.Errorf("handle B entered its transaction before handle A's increment committed (B entry read %d): %v", bEntryVal, entries)
+	}
+	bEnteredAt, aWriteAt := -1, -1
 	for i, e := range entries {
 		switch e {
 		case "B:enter":
 			bEnteredAt = i
-		case "A:done":
-			aDoneAt = i
+		case "A:write":
+			aWriteAt = i
 		}
 	}
-	if bEnteredAt >= 0 && aDoneAt >= 0 && bEnteredAt < aDoneAt {
-		t.Errorf("handle B entered its transaction body before handle A committed (order: %v)", entries)
+	if bEnteredAt >= 0 && aWriteAt >= 0 && bEnteredAt < aWriteAt {
+		t.Errorf("handle B entered its transaction body before handle A's write (order: %v)", entries)
 	}
 
 	var val int

--- a/pkg/engine/manager.go
+++ b/pkg/engine/manager.go
@@ -359,28 +359,35 @@ func (m *Manager) idleLoop(ctx context.Context, d time.Duration) {
 		case <-m.idleStop:
 			return
 		case now := <-t.C:
-			// Detach under the lock, close outside it (F-043): the close
-			// drains in-flight readers and must not stall the Manager.
-			var evicted []struct {
+			m.evaluateIdle(now, d)
+		}
+	}
+}
+
+// evaluateIdle detaches every handle idle longer than d at now and closes
+// the detached handles. Detach happens under the lock, close outside it
+// (F-043): the close drains in-flight readers and must not stall the
+// Manager. Synchronous so tests drive it with explicit timestamps instead
+// of waiting on the background ticker.
+func (m *Manager) evaluateIdle(now time.Time, d time.Duration) {
+	var evicted []struct {
+		name string
+		h    *managerHandle
+	}
+	m.mu.Lock()
+	for name, h := range m.handles {
+		if now.Sub(h.lastUse) > d {
+			delete(m.handles, name)
+			evicted = append(evicted, struct {
 				name string
 				h    *managerHandle
-			}
-			m.mu.Lock()
-			for name, h := range m.handles {
-				if now.Sub(h.lastUse) > d {
-					delete(m.handles, name)
-					evicted = append(evicted, struct {
-						name string
-						h    *managerHandle
-					}{name, h})
-				}
-			}
-			m.mu.Unlock()
-			for _, e := range evicted {
-				if err := m.closeHandle(e.name, e.h); err != nil {
-					log.Warn("engine: idle close failed", "name", e.name, "error", err)
-				}
-			}
+			}{name, h})
+		}
+	}
+	m.mu.Unlock()
+	for _, e := range evicted {
+		if err := m.closeHandle(e.name, e.h); err != nil {
+			log.Warn("engine: idle close failed", "name", e.name, "error", err)
 		}
 	}
 }

--- a/pkg/engine/manager_lru_test.go
+++ b/pkg/engine/manager_lru_test.go
@@ -157,7 +157,10 @@ func TestManager_IdleClose(t *testing.T) {
 	root := t.TempDir()
 	initWorkspaceIn(t, root, "one")
 
-	m, err := OpenManager(context.Background(), root, WithIdleClose(60*time.Millisecond))
+	// No WithIdleClose: the synchronous evaluator is driven with explicit
+	// timestamps, never by the background ticker (AC4 — no scheduler-
+	// sensitive polling, no Sleep(interval) < idle).
+	m, err := OpenManager(context.Background(), root)
 	if err != nil {
 		t.Fatalf("OpenManager: %v", err)
 	}
@@ -169,12 +172,25 @@ func TestManager_IdleClose(t *testing.T) {
 	if got := m.openCount(); got != 1 {
 		t.Fatalf("openCount = %d, want 1", got)
 	}
-	deadline := time.Now().Add(3 * time.Second)
-	for m.openCount() != 0 && time.Now().Before(deadline) {
-		time.Sleep(20 * time.Millisecond)
+
+	// Controlled recency: pin lastUse to a known instant, then evaluate at
+	// exact timestamps. Monotonic time makes the arithmetic exact.
+	const d = 60 * time.Millisecond
+	m.mu.Lock()
+	base := time.Now()
+	m.handles["one"].lastUse = base
+	m.mu.Unlock()
+
+	// now.Sub(lastUse) == d: strict > d boundary — survives.
+	m.evaluateIdle(base.Add(d), d)
+	if got := m.openCount(); got != 1 {
+		t.Fatalf("openCount at exactly d = %d, want 1 (survives at the boundary)", got)
 	}
+
+	// now.Sub(lastUse) == d + 1ns: evicted.
+	m.evaluateIdle(base.Add(d+time.Nanosecond), d)
 	if got := m.openCount(); got != 0 {
-		t.Errorf("openCount after idle window = %d, want 0", got)
+		t.Errorf("openCount at d+1ns = %d, want 0 (evicted past the boundary)", got)
 	}
 }
 
@@ -183,11 +199,14 @@ func TestManager_IdleClose(t *testing.T) {
 // re-calling Workspace — so recency must be refreshable independently.
 // Touch refreshes lastUse; a workspace touched past its idle window stays
 // open (without Touch, idle-close evicts a workspace under active traffic).
+// Controlled timestamps prove Touch changes the eviction decision: the
+// stale recency would be evicted at d+1ns, the refreshed one survives at
+// exactly d (AC4 — no wall-clock timing margins).
 func TestManager_TouchKeepsIdleWorkspaceOpen(t *testing.T) {
 	root := t.TempDir()
 	initWorkspaceIn(t, root, "one")
 
-	m, err := OpenManager(context.Background(), root, WithIdleClose(60*time.Millisecond))
+	m, err := OpenManager(context.Background(), root)
 	if err != nil {
 		t.Fatalf("OpenManager: %v", err)
 	}
@@ -196,14 +215,43 @@ func TestManager_TouchKeepsIdleWorkspaceOpen(t *testing.T) {
 	if _, err := m.Workspace(context.Background(), "one"); err != nil {
 		t.Fatal(err)
 	}
-	// Touch repeatedly past the idle window — the workspace must survive.
-	deadline := time.Now().Add(600 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		m.Touch("one")
-		time.Sleep(20 * time.Millisecond)
-	}
 	if got := m.openCount(); got != 1 {
-		t.Errorf("openCount after touched idle window = %d, want 1 (Touch must refresh recency)", got)
+		t.Fatalf("openCount = %d, want 1", got)
+	}
+
+	const d = 60 * time.Millisecond
+	m.mu.Lock()
+	h := m.handles["one"]
+	stale := h.lastUse.Add(-time.Hour) // clearly past d before any refresh
+	h.lastUse = stale
+	m.mu.Unlock()
+
+	// Touch must refresh recency (monotonic clock: strictly after stale).
+	m.Touch("one")
+	m.mu.Lock()
+	refreshed := h.lastUse
+	m.mu.Unlock()
+	if !refreshed.After(stale) {
+		t.Fatalf("Touch did not refresh lastUse: stale=%v refreshed=%v", stale, refreshed)
+	}
+
+	// The stale timestamp would have been evicted at d+1ns; the refreshed
+	// handle survives there — Touch changed the eviction decision.
+	m.evaluateIdle(stale.Add(d+time.Nanosecond), d)
+	if got := m.openCount(); got != 1 {
+		t.Fatalf("openCount after Touch at stale+d+1ns = %d, want 1 (Touch must refresh recency)", got)
+	}
+
+	// Survives at exactly d past the refreshed recency...
+	m.evaluateIdle(refreshed.Add(d), d)
+	if got := m.openCount(); got != 1 {
+		t.Fatalf("openCount at exactly d after Touch = %d, want 1", got)
+	}
+
+	// ...and is evicted at d+1ns.
+	m.evaluateIdle(refreshed.Add(d+time.Nanosecond), d)
+	if got := m.openCount(); got != 0 {
+		t.Errorf("openCount at d+1ns after Touch = %d, want 0", got)
 	}
 }
 

--- a/pkg/engine/manager_lru_test.go
+++ b/pkg/engine/manager_lru_test.go
@@ -255,6 +255,58 @@ func TestManager_TouchKeepsIdleWorkspaceOpen(t *testing.T) {
 	}
 }
 
+// TestManager_IdleCloseWiring exercises the production wiring the
+// synchronous evaluateIdle tests deliberately bypass: WithIdleClose must
+// spawn idleLoop, whose ticker must delegate to evaluateIdle, and Close
+// must stop that goroutine via the idleStop/idleDone channels. Eviction is
+// asserted with an EVENTUAL check — polling openCount under a generous
+// integration bound (~100x the worst-case d+tick lag) — never with a
+// Sleep(short) < idle precision contract.
+func TestManager_IdleCloseWiring(t *testing.T) {
+	root := t.TempDir()
+	initWorkspaceIn(t, root, "one")
+
+	const d = 30 * time.Millisecond // tick = d/2 = 15ms
+	m, err := OpenManager(context.Background(), root, WithIdleClose(d))
+	if err != nil {
+		t.Fatalf("OpenManager: %v", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	if _, err := m.Workspace(context.Background(), "one"); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.openCount(); got != 1 {
+		t.Fatalf("openCount = %d, want 1", got)
+	}
+
+	// The idle handle must be evicted by the BACKGROUND goroutine: lastUse
+	// is refreshed only by Workspace/cached, so without ticker → evaluateIdle
+	// delegation nothing will ever close it. The bound is deliberately
+	// generous — eventual wiring proof, not scheduler-bound precision.
+	deadline := time.Now().Add(5 * time.Second)
+	for m.openCount() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("idleLoop never evicted the idle workspace — WithIdleClose wiring broken")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Close must signal idleStop and wait on idleDone; a goroutine that
+	// stopped delegating (or never started) would deadlock the wait. Bound
+	// the wait so a regression fails instead of hanging the suite.
+	closed := make(chan struct{})
+	go func() {
+		_ = m.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return — idleStop/idleDone coordination broken")
+	}
+}
+
 func TestManager_MaxOpenZeroUnlimited(t *testing.T) {
 	root := t.TempDir()
 	names := []string{"u1", "u2", "u3", "u4"}


### PR DESCRIPTION
## Summary

- reserve SQLite's writer at transaction begin with `_txlock=immediate`, backed by a deterministic two-handle `BUSY_SNAPSHOT` regression witness
- align worker-cycle tests with serve-mode backend ownership and replace scheduler-dependent manager idle tests with controlled-time evaluation plus ticker wiring coverage
- add one stable `CI required` aggregate check and document local-plus-hosted latest-SHA verification

## Root Cause

GitHub Actions run 31564759759 failed compiler race shards on Ubuntu/macOS through cross-handle SQLite writer contention and failed the macOS rest shard through a 60 ms scheduler assumption. Unprotected `main` let the merged SHA receive its first hosted test only after push.

## Verification

- `GOTOOLCHAIN=go1.26.5 GOMAXPROCS=2 CGO_ENABLED=1 go test -race -run '^TestWorkerCycle_StoresCompileKeys$' -count=500 ./internal/compiler` (`ok`, 251.750s)
- `GOTOOLCHAIN=go1.26.5 make ci` (full build, webui build, vet, `go test -race ./...`, new-issue lint: `0 issues`)
- deterministic checker self-test and normal check: both green, run sequentially
- `actionlint .github/workflows/ci.yml`, `gofmt -l`, and `git diff --check`: clean
- independent per-task reviews and whole-branch re-review: approved, no critical or important findings

## Protection Sequence

After this PR's latest applicable SHA reports a successful `CI required` check from GitHub Actions, `main` will be configured to require that exact context with strict/up-to-date checks and administrator enforcement. This PR will not be merged until the protection API readback and hosted checks are green.

## Checklist

- [x] `make ci` passes on this branch
- [ ] Hosted `CI required` is green on the latest PR SHA
- [x] User-facing/process changes documented under CHANGELOG `[Unreleased]` and contributor guidance
- [x] Tests added or updated
