### PR TITLE
Fix document-budget timeout attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- **Deterministic document-budget timeout attribution.** Summarization and
+  triple extraction now identify `compile_doc_timeout` from the exact child
+  context deadline instead of comparing a separately started elapsed-time
+  counter. Parent cancellation and provider timeouts remain distinct, and typed
+  timeout diagnostics no longer report consumed time below the configured
+  limit.
+
 - **Project prompt overrides apply to every compilation surface (#143).**
   Overrides in a workspace's `prompts/` directory now take effect for
   standard `sage-wiki compile`, serve background worker cycles, and MCP/REST

--- a/internal/compiler/docbudget.go
+++ b/internal/compiler/docbudget.go
@@ -11,6 +11,8 @@ import (
 	"github.com/xoai/sage-wiki/pkg/events"
 )
 
+var errDocBudgetDeadline = errors.New("compiler: document budget deadline")
+
 // DocBudget tracks one document's compile_doc_timeout stopwatch
 // (SPEC-08 D6). The budget is consumed ONLY while the doc's own LLM units
 // run — queueing time and cross-document phases (concept extraction,
@@ -62,12 +64,27 @@ func (b *DocBudget) UnitContext(parent context.Context) (context.Context, contex
 		parent = context.Background()
 	}
 	rem := b.Remaining()
-	if rem <= 0 {
-		ctx, cancel := context.WithCancel(parent)
-		cancel()
-		return ctx, func() {}
+	return context.WithTimeoutCause(parent, rem, errDocBudgetDeadline)
+}
+
+// finishUnit records elapsed unit time and reports whether the exact context
+// deadline created by UnitContext caused unitErr. The cause, rather than a
+// second elapsed-time sample, distinguishes document budget expiry from parent
+// cancellation and nested provider timeouts.
+func (b *DocBudget) finishUnit(unitCtx context.Context, elapsed time.Duration, unitErr error) bool {
+	budgetOwned := unitCtx != nil &&
+		errors.Is(context.Cause(unitCtx), errDocBudgetDeadline) &&
+		(errors.Is(unitErr, context.DeadlineExceeded) || errors.Is(unitErr, context.Canceled))
+
+	b.mu.Lock()
+	if elapsed >= 0 {
+		b.used += elapsed
 	}
-	return context.WithTimeout(parent, rem)
+	if budgetOwned && b.used < b.limit {
+		b.used = b.limit
+	}
+	b.mu.Unlock()
+	return budgetOwned
 }
 
 // Limit returns the configured budget size (for typed-error reporting).

--- a/internal/compiler/docbudget_test.go
+++ b/internal/compiler/docbudget_test.go
@@ -79,6 +79,9 @@ func TestDocBudgetExpiredUnitContext(t *testing.T) {
 	default:
 		t.Fatal("exhausted budget must produce an already-done context")
 	}
+	if !errors.Is(context.Cause(ctx), errDocBudgetDeadline) {
+		t.Fatalf("context cause = %v, want errDocBudgetDeadline", context.Cause(ctx))
+	}
 }
 
 func TestDocBudgetsRegistryPerDoc(t *testing.T) {
@@ -126,6 +129,44 @@ type budgetSink struct {
 	events []events.Event
 }
 
+type contextBlockingTransport struct {
+	started chan struct{}
+	once    sync.Once
+	calls   atomic.Int32
+}
+
+func newContextBlockingTransport() *contextBlockingTransport {
+	return &contextBlockingTransport{started: make(chan struct{})}
+}
+
+func (t *contextBlockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	t.once.Do(func() { close(t.started) })
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func (t *contextBlockingTransport) waitForRequest(tb testing.TB) {
+	tb.Helper()
+	select {
+	case <-t.started:
+	case <-time.After(5 * time.Second):
+		tb.Fatal("LLM request did not reach the blocking transport")
+	}
+}
+
+func blockingLLMClient(t *testing.T, callTimeout time.Duration) (*llm.Client, *contextBlockingTransport) {
+	t.Helper()
+	c, err := llm.NewClient("openai", "fake-key", "http://llm.invalid", -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := newContextBlockingTransport()
+	c.SetTransport(transport)
+	c.SetCallTimeout(callTimeout)
+	return c, transport
+}
+
 func (s *budgetSink) Emit(ev events.Event) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -142,6 +183,86 @@ func (s *budgetSink) byType(ty events.Type) []events.Event {
 		}
 	}
 	return out
+}
+
+func TestDocBudgetFinishUnitAttributesExactDeadlineSource(t *testing.T) {
+	t.Run("budget deadline", func(t *testing.T) {
+		b := NewDocBudget(time.Hour)
+		unitCtx, cancel := context.WithTimeoutCause(context.Background(), 0, errDocBudgetDeadline)
+		defer cancel()
+		<-unitCtx.Done()
+
+		if !b.finishUnit(unitCtx, 0, unitCtx.Err()) {
+			t.Fatal("budget-owned child deadline was not attributed to the document budget")
+		}
+		if !errors.Is(context.Cause(unitCtx), errDocBudgetDeadline) {
+			t.Fatalf("context cause = %v, want errDocBudgetDeadline", context.Cause(unitCtx))
+		}
+		var le *limits.LimitError
+		err := docTimeoutError(b)
+		if !errors.As(err, &le) {
+			t.Fatalf("docTimeoutError = %v, want LimitError", err)
+		}
+		if le.Got < le.Limit {
+			t.Fatalf("timeout accounting Got=%d, Limit=%d; want Got >= Limit", le.Got, le.Limit)
+		}
+	})
+
+	t.Run("parent cancellation", func(t *testing.T) {
+		b := NewDocBudget(time.Hour)
+		parent, cancelParent := context.WithCancel(context.Background())
+		unitCtx, cancelUnit := b.UnitContext(parent)
+		defer cancelUnit()
+		cancelParent()
+		<-unitCtx.Done()
+
+		if b.finishUnit(unitCtx, time.Millisecond, unitCtx.Err()) {
+			t.Fatal("parent cancellation was attributed to the document budget")
+		}
+		if !errors.Is(context.Cause(unitCtx), context.Canceled) {
+			t.Fatalf("context cause = %v, want context.Canceled", context.Cause(unitCtx))
+		}
+	})
+
+	t.Run("shorter parent deadline", func(t *testing.T) {
+		b := NewDocBudget(time.Hour)
+		parent, cancelParent := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancelParent()
+		unitCtx, cancelUnit := b.UnitContext(parent)
+		defer cancelUnit()
+		<-unitCtx.Done()
+
+		if b.finishUnit(unitCtx, time.Millisecond, unitCtx.Err()) {
+			t.Fatal("shorter parent deadline was attributed to the document budget")
+		}
+		if !errors.Is(context.Cause(unitCtx), context.DeadlineExceeded) {
+			t.Fatalf("context cause = %v, want context.DeadlineExceeded", context.Cause(unitCtx))
+		}
+	})
+
+	t.Run("provider timeout while unit remains live", func(t *testing.T) {
+		b := NewDocBudget(time.Hour)
+		unitCtx, cancelUnit := b.UnitContext(context.Background())
+		defer cancelUnit()
+
+		if b.finishUnit(unitCtx, time.Millisecond, context.DeadlineExceeded) {
+			t.Fatal("provider timeout was attributed to the document budget")
+		}
+		if unitCtx.Err() != nil {
+			t.Fatalf("unit context unexpectedly terminated: %v", unitCtx.Err())
+		}
+	})
+
+	t.Run("explicit cleanup cancellation", func(t *testing.T) {
+		b := NewDocBudget(time.Hour)
+		unitCtx, cancelUnit := b.UnitContext(context.Background())
+		cancelUnit()
+		<-unitCtx.Done()
+
+		if b.finishUnit(unitCtx, time.Millisecond, unitCtx.Err()) {
+			t.Fatal("cleanup cancellation was attributed to the document budget")
+		}
+	})
 }
 
 func TestEmitDocTimeoutEventPair(t *testing.T) {
@@ -200,15 +321,9 @@ func budgetWorkspace(t *testing.T, names ...string) (projectDir, outputDir strin
 }
 
 func TestSummarizeDocBudgetExpiryTyped(t *testing.T) {
-	// Server slower than the budget: the unit must expire with the typed
-	// per-doc timeout error (retryable — not marked compiled).
-	srv := slowLLMServer(t, []time.Duration{200 * time.Millisecond}, strings.Repeat("summary ", 30))
-	c, err := llm.NewClient("openai", "fake-key", srv.URL, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	restore := llm.SetBackoffDelayForTest(func(int) time.Duration { return time.Millisecond })
-	defer restore()
+	// Context completion itself releases the transport; no server sleep decides
+	// whether the document budget owns the timeout.
+	c, transport := blockingLLMClient(t, time.Hour)
 
 	projectDir, outputDir, sources := budgetWorkspace(t, "a.md")
 	results := Summarize(SummarizeOpts{
@@ -221,8 +336,11 @@ func TestSummarizeDocBudgetExpiryTyped(t *testing.T) {
 		MaxTokens:   256,
 		MaxParallel: 1,
 		UserTZ:      time.UTC,
-		Budgets:     NewDocBudgets(30 * time.Millisecond),
+		Budgets:     NewDocBudgets(10 * time.Millisecond),
 	})
+	if got := transport.calls.Load(); got != 1 {
+		t.Fatalf("LLM calls = %d, want 1", got)
+	}
 	if len(results) != 1 {
 		t.Fatalf("results = %d, want 1", len(results))
 	}
@@ -232,6 +350,9 @@ func TestSummarizeDocBudgetExpiryTyped(t *testing.T) {
 	var le *limits.LimitError
 	if !errors.As(results[0].Error, &le) || le.Which != "compile_doc_timeout" {
 		t.Errorf("error is not a compile_doc_timeout LimitError: %v", results[0].Error)
+	}
+	if le.Got < le.Limit {
+		t.Errorf("timeout accounting Got=%d, Limit=%d; want Got >= Limit", le.Got, le.Limit)
 	}
 }
 
@@ -277,15 +398,7 @@ func TestSummarizeQueueTimeNotConsumed(t *testing.T) {
 // inflate the wrong counter). Only a deadline that ALSO exhausted the
 // per-doc budget is a compile_doc_timeout.
 func TestSummarizeProviderTimeoutNotMisattributed(t *testing.T) {
-	// Server slower than the provider callTimeout but well under the budget.
-	srv := slowLLMServer(t, []time.Duration{200 * time.Millisecond}, strings.Repeat("summary ", 30))
-	c, err := llm.NewClient("openai", "fake-key", srv.URL, -1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.SetCallTimeout(50 * time.Millisecond) // provider_timeout analog
-	restore := llm.SetBackoffDelayForTest(func(int) time.Duration { return time.Millisecond })
-	defer restore()
+	c, transport := blockingLLMClient(t, time.Millisecond)
 
 	projectDir, outputDir, sources := budgetWorkspace(t, "a.md")
 	results := Summarize(SummarizeOpts{
@@ -298,8 +411,11 @@ func TestSummarizeProviderTimeoutNotMisattributed(t *testing.T) {
 		MaxTokens:   256,
 		MaxParallel: 1,
 		UserTZ:      time.UTC,
-		Budgets:     NewDocBudgets(2000 * time.Millisecond), // budget >> callTimeout
+		Budgets:     NewDocBudgets(time.Hour),
 	})
+	if got := transport.calls.Load(); got != 1 {
+		t.Fatalf("LLM calls = %d, want 1", got)
+	}
 	if len(results) != 1 {
 		t.Fatalf("results = %d, want 1", len(results))
 	}
@@ -309,5 +425,40 @@ func TestSummarizeProviderTimeoutNotMisattributed(t *testing.T) {
 	// The provider timeout must NOT be classified as compile_doc_timeout.
 	if errors.Is(results[0].Error, limits.ErrTimeout) {
 		t.Errorf("provider timeout misattributed as compile_doc_timeout (budget was not exhausted): %v", results[0].Error)
+	}
+}
+
+func TestSummarizeParentCancelWithBudgetPreserved(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c, transport := blockingLLMClient(t, time.Hour)
+	projectDir, outputDir, sources := budgetWorkspace(t, "a.md")
+
+	resultCh := make(chan []SummaryResult, 1)
+	go func() {
+		resultCh <- Summarize(SummarizeOpts{
+			Ctx:         ctx,
+			ProjectDir:  projectDir,
+			OutputDir:   outputDir,
+			Sources:     sources,
+			Client:      c,
+			Model:       "gpt-4o-mini",
+			MaxTokens:   256,
+			MaxParallel: 1,
+			UserTZ:      time.UTC,
+			Budgets:     NewDocBudgets(time.Hour),
+		})
+	}()
+
+	transport.waitForRequest(t)
+	cancel()
+	results := <-resultCh
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if !errors.Is(results[0].Error, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", results[0].Error)
+	}
+	if errors.Is(results[0].Error, limits.ErrTimeout) {
+		t.Fatalf("parent cancellation was misattributed as compile_doc_timeout: %v", results[0].Error)
 	}
 }

--- a/internal/compiler/extract_triples.go
+++ b/internal/compiler/extract_triples.go
@@ -765,8 +765,9 @@ func ExtractTriplesPass(
 
 			start := time.Now()
 			graph, err := ExtractTriples(unitCtx, doc, tcfg, model, validTypes, validPredicates, client, pr, cfg.Compiler.CompileTemperature())
+			budgetTimedOut := false
 			if budget != nil {
-				budget.Consume(time.Since(start))
+				budgetTimedOut = budget.finishUnit(unitCtx, time.Since(start), err)
 				cancelUnit()
 			}
 			if err != nil {
@@ -776,11 +777,12 @@ func ExtractTriplesPass(
 				// expiry is a typed timeout failure (SPEC-08 AC11).
 				mu.Lock()
 				switch {
+				case budgetTimedOut:
+					timeoutErr := docTimeoutError(budget)
+					timeouts = append(timeouts, tripleTimeout{SourcePath: s.SourcePath, Err: timeoutErr})
+					log.Warn("triples: per-doc timeout", "source", s.SourcePath, "error", timeoutErr)
 				case ctx.Err() != nil:
 					cancelled = true
-				case budget != nil && budget.Expired():
-					timeouts = append(timeouts, tripleTimeout{SourcePath: s.SourcePath, Err: docTimeoutError(budget)})
-					log.Warn("triples: per-doc timeout", "source", s.SourcePath, "error", docTimeoutError(budget))
 				default:
 					failures++
 					log.Warn("triples: extraction failed", "source", s.SourcePath, "error", err)

--- a/internal/compiler/summarize.go
+++ b/internal/compiler/summarize.go
@@ -3,7 +3,6 @@ package compiler
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -137,17 +136,9 @@ func Summarize(opts SummarizeOpts) []SummaryResult {
 			start := time.Now()
 			result := summarizeOne(unitCtx, opts.ProjectDir, opts.OutputDir, info, opts.Client, opts.Model, opts.MaxTokens, opts.UserTZ, opts.Language, opts.SummaryNaming, opts.SourceRoots, opts.Prompts, opts.Temperature, opts.ExtractOpts...)
 			if budget != nil {
-				budget.Consume(time.Since(start))
+				budgetTimedOut := budget.finishUnit(unitCtx, time.Since(start), result.Error)
 				cancelUnit()
-				// A unit that failed because ITS budget deadline fired is a
-				// typed per-doc timeout — not a generic failure, not a run-level
-				// cancellation. Require BOTH a deadline-class error AND an
-				// exhausted budget: a provider_timeout (DeadlineExceeded with
-				// budget remaining) is its own condition, not a compile_doc
-				// timeout, and must not emit a self-contradictory
-				// limit_exceeded{Limit=doc_budget > Got=provider_timeout}.
-				parentCancelled := opts.Ctx != nil && opts.Ctx.Err() != nil
-				if result.Error != nil && errors.Is(result.Error, context.DeadlineExceeded) && budget.Expired() && !parentCancelled {
+				if budgetTimedOut {
 					result.Error = docTimeoutError(budget)
 				}
 			}

--- a/internal/compiler/triples_pass_test.go
+++ b/internal/compiler/triples_pass_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/xoai/sage-wiki/internal/config"
 	"github.com/xoai/sage-wiki/internal/limits"
-	"github.com/xoai/sage-wiki/internal/llm"
 	"github.com/xoai/sage-wiki/internal/log"
 	"github.com/xoai/sage-wiki/internal/ontology"
 	"github.com/xoai/sage-wiki/internal/storage"
@@ -366,17 +365,12 @@ func TestExtractTriplesPassFansOutConcurrently(t *testing.T) {
 // Cancellation MID-FLIGHT: the pre-check catches a ctx cancelled before the
 // call, but the branch that classifies an in-flight provider error as
 // cancellation rather than a per-document failure is only reachable this way.
-func TestExtractTriplesPassClassifiesMidFlightCancel(t *testing.T) {
+func TestExtractTriplesPassParentCancelWithBudgetPreserved(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cancel()
-		time.Sleep(50 * time.Millisecond)
-		json.NewEncoder(w).Encode(map[string]any{
-			"choices": []map[string]any{{"message": map[string]string{"content": sampleGraph}}},
-			"model":   "m", "usage": map[string]int{"total_tokens": 1},
-		})
-	}))
-	defer srv.Close()
+	client := triplesClient(t, "http://llm.invalid")
+	transport := newContextBlockingTransport()
+	client.SetTransport(transport)
+	client.SetCallTimeout(time.Hour)
 
 	var buf strings.Builder
 	var mu sync.Mutex
@@ -384,9 +378,20 @@ func TestExtractTriplesPassClassifiesMidFlightCancel(t *testing.T) {
 		&lockedWriter{mu: &mu, w: &buf}, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	defer restore()
 
-	ExtractTriplesPass(ctx, passStore(t),
-		[]SummaryResult{{SourcePath: "raw/a.md", Summary: "Backpressure extends flow control."}}, nil,
-		enabledCfg(), triplesClient(t, srv.URL), false, t.TempDir(), nil, nil, nil, nil, nil)
+	done := make(chan []tripleTimeout, 1)
+	go func() {
+		_, _, timeouts := ExtractTriplesPass(ctx, passStore(t),
+			[]SummaryResult{{SourcePath: "raw/a.md", Summary: "Backpressure extends flow control."}}, nil,
+			enabledCfg(), client, false, t.TempDir(), nil, nil, nil, NewDocBudgets(time.Hour), nil)
+		done <- timeouts
+	}()
+
+	transport.waitForRequest(t)
+	cancel()
+	timeouts := <-done
+	if len(timeouts) != 0 {
+		t.Fatalf("timeouts = %+v, want none for parent cancellation", timeouts)
+	}
 
 	mu.Lock()
 	out := buf.String()
@@ -533,22 +538,43 @@ func TestExtractTriplesPassBudgetExpiryRecorded(t *testing.T) {
 // as a generic provider failure. The deadline surfaces as
 // context.DeadlineExceeded through the client.
 func TestExtractTriplesPassBudgetExpiryMidCall(t *testing.T) {
-	// Server slower than the budget: the unit's deadline fires mid-call.
-	srv := slowLLMServer(t, []time.Duration{200 * time.Millisecond}, sampleGraph)
-	defer srv.Close()
+	client := triplesClient(t, "http://llm.invalid")
+	transport := newContextBlockingTransport()
+	client.SetTransport(transport)
+	client.SetCallTimeout(time.Hour)
 	ont := passStore(t)
-	restore := llm.SetBackoffDelayForTest(func(int) time.Duration { return time.Millisecond })
-	defer restore()
 
-	budgets := NewDocBudgets(40 * time.Millisecond)
+	budgets := NewDocBudgets(10 * time.Millisecond)
 	_, _, timeouts := ExtractTriplesPass(context.Background(), ont,
 		[]SummaryResult{{SourcePath: "raw/a.md", Summary: "Backpressure extends flow control."}}, nil,
-		enabledCfg(), triplesClient(t, srv.URL), false, t.TempDir(), nil, nil, nil, budgets, nil)
+		enabledCfg(), client, false, t.TempDir(), nil, nil, nil, budgets, nil)
 
 	if len(timeouts) != 1 {
 		t.Fatalf("timeouts = %+v, want one mid-call timeout entry", timeouts)
 	}
 	if !errors.Is(timeouts[0].Err, limits.ErrTimeout) {
 		t.Errorf("mid-call err = %v, want errors.Is ErrTimeout (not a generic failure)", timeouts[0].Err)
+	}
+	var le *limits.LimitError
+	if !errors.As(timeouts[0].Err, &le) || le.Got < le.Limit {
+		t.Errorf("mid-call timeout = %v, want LimitError with Got >= Limit", timeouts[0].Err)
+	}
+}
+
+func TestExtractTriplesPassProviderTimeoutNotMisattributed(t *testing.T) {
+	client := triplesClient(t, "http://llm.invalid")
+	transport := newContextBlockingTransport()
+	client.SetTransport(transport)
+	client.SetCallTimeout(time.Millisecond)
+
+	_, _, timeouts := ExtractTriplesPass(context.Background(), passStore(t),
+		[]SummaryResult{{SourcePath: "raw/a.md", Summary: "Backpressure extends flow control."}}, nil,
+		enabledCfg(), client, false, t.TempDir(), nil, nil, nil, NewDocBudgets(time.Hour), nil)
+
+	if got := transport.calls.Load(); got != 1 {
+		t.Fatalf("LLM calls = %d, want 1", got)
+	}
+	if len(timeouts) != 0 {
+		t.Fatalf("provider timeout was misattributed as compile_doc_timeout: %+v", timeouts)
 	}
 }


### PR DESCRIPTION
## Summary
- attribute compile document timeouts from the exact child context cause
- preserve parent cancellation and provider-timeout classification
- clamp typed timeout accounting so consumed time cannot be below the limit
- replace scheduler-sensitive timeout tests with context-synchronized witnesses

## Verification
- focused semantic tests: 100 repetitions
- focused race tests: 20 repetitions
- compiler and LLM race suites
- full `go test ./...`
- `go vet ./...`
- determinism self-test and normal check
- `make ci`

## Golden changes
None.