### PR TITLE
feat(ci): shadow DAG, scheduled diagnostics, and qualification observer

### DIFF
--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -1,0 +1,231 @@
+name: CI Diagnostics
+
+# Scheduled broad diagnostics (20260812-ci-quality-system Task 11).
+#
+# Every job here carries explicit NON-BLOCKING ownership (standards.yaml
+# owner: scheduled-diagnostics / pr-advisory): this workflow has no aggregate,
+# is not referenced by ci.yml's `CI required`, and nothing in it can block a
+# merge. Its purpose is evidence — full-OS coverage, parity repetition,
+# performance trend, mutable vulnerability intelligence, and broad
+# client/example health — with fail-closed validation so a broken diagnostic
+# is red, never silently green.
+
+on:
+  schedule:
+    - cron: '47 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  diagnostics-validation:
+    name: Diagnostics responsibility validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Self-tests first: a broken checker must be visible before the live
+      # validation below could produce a false green.
+      - name: Checker self-tests
+        run: |
+          bash scripts/ci/check-format.sh --self-test
+          bash scripts/ci/check-modules.sh --self-test
+          bash scripts/ci/run-go-tests.sh --self-test
+          bash scripts/ci/classify-client-paths.sh --self-test
+
+      - name: Validate manifests against this diagnostics workflow
+        run: |
+          go run ./tools/civalidate \
+            --standards ci/standards.yaml \
+            --packages ci/package-ownership.yaml \
+            --platforms ci/platform-contracts.yaml \
+            --services ci/service-contracts.yaml \
+            --fuzz-targets ci/fuzz-targets.yaml \
+            --workflow .github/workflows/ci-diagnostics.yml \
+            --makefile Makefile
+
+  full-suite-windows:
+    name: Scheduled full Windows suite
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Full OS coverage beyond the PR shards: every package, no race
+      # (Windows has no guaranteed C compiler), matching ci.yml's Windows leg.
+      - name: Test (full suite)
+        run: CGO_ENABLED=0 go test -timeout 15m ./...
+
+  full-suite-macos:
+    name: Scheduled full macOS suite
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test (full suite)
+        run: CGO_ENABLED=0 go test -timeout 15m ./...
+
+  parity-repetition:
+    name: Scheduled parity repetition
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Repeat the golden-corpus replay to surface low-probability flakes the
+      # single PR pass can miss; a flake here is diagnostic evidence, not a
+      # merge verdict.
+      - name: Parity suite (10x)
+        run: CGO_ENABLED=0 go test -count=10 ./internal/parity/
+
+  performance-warmcheck:
+    name: Scheduled performance warmcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # SPEC-06 warm-latency gate: warm mmap search must stay within 2x of the
+      # memory backend on the same fixture. Fails loud (never a silent pass).
+      - name: Warmcheck
+        run: bash scripts/spec06/warmcheck.sh
+
+  vuln-scan:
+    name: Scheduled vulnerability scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Record tool identity so a trend is attributable; a scan FAILURE is a
+      # red diagnostic, never "no findings" (fail-closed, no continue-on-error).
+      - name: Install govulncheck and record version
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck --version
+          go version
+
+      - name: govulncheck
+        run: govulncheck ./...
+
+  clients-broad:
+    name: Scheduled broad client diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - client: python
+            python: '3.12'
+          - client: typescript
+            node: '20'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        if: matrix.client == 'python'
+        with:
+          python-version: ${{ matrix.python }}
+
+      - uses: actions/setup-node@v4
+        if: matrix.client == 'typescript'
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Python unit
+        if: matrix.client == 'python'
+        run: |
+          pip install -e "clients/python[dev]"
+          cd clients/python && python -m pytest -q -m "not contract"
+
+      - name: TypeScript unit + typecheck
+        if: matrix.client == 'typescript'
+        run: |
+          cd clients/typescript && npm ci
+          npm run typecheck
+          npm test
+
+  examples-broad:
+    name: Scheduled broad example diagnostics
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: cd examples/langgraph && pip install -r requirements.txt
+      - run: cd clients/typescript && npm ci && npm run build
+      - run: cd examples/vercel-ai-sdk && npm ci
+
+      - name: Start fixture server
+        run: bash scripts/p4-fixture-server.sh | sed 's/^export //' >> "$GITHUB_ENV"
+
+      - name: LangGraph example
+        run: |
+          cd examples/langgraph
+          python main.py | tee /tmp/langgraph.out
+          python main.py recursion | tee /tmp/langgraph-recursion.out
+          grep -q "PASS: retrieved >= 1 result" /tmp/langgraph.out
+          grep -q "PASS: retrieved >= 1 result" /tmp/langgraph-recursion.out
+          grep -q "uncompiled_sources=1 > 0" /tmp/langgraph-recursion.out
+
+      - name: Vercel AI SDK example
+        run: |
+          cd examples/vercel-ai-sdk
+          npm start | tee /tmp/vercel.out
+          grep -q "PASS: retrieved >= 1 result" /tmp/vercel.out
+
+      - name: Stop fixture server
+        if: always()
+        run: bash scripts/p4-fixture-server.sh --stop

--- a/.github/workflows/ci-observe.yml
+++ b/.github/workflows/ci-observe.yml
@@ -1,0 +1,131 @@
+name: CI Observe
+
+# Read-only qualification observer (20260812-ci-quality-system Task 12).
+#
+# Collects metrics from completed CI and CI Shadow workflow runs, evaluates
+# qualification thresholds (>= 20 matched pairs over >= 7 days, zero
+# unexplained identical-tree divergence, p95 within bound), and persists the
+# verdict to ci/qualification.json. This workflow is advisory: it has no
+# aggregate, is not referenced by CI required, and cannot alter any result.
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  observe:
+    name: Collect qualification metrics
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Fetch recent completed runs into fixtures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/observe
+          repo="$GITHUB_REPOSITORY"
+
+          fetch_runs() { # workflow_name output_prefix
+            local wf="$1" prefix="$2"
+            gh api "repos/$repo/actions/workflows" --paginate \
+              -q ".workflows[] | select(.name==\"$wf\") | .id" 2>/dev/null | while read -r wf_id; do
+              gh api "repos/$repo/actions/workflows/$wf_id/runs?status=completed&per_page=30" \
+                -q '.workflow_runs[] | select(.head_repository.full_name=="'"${repo%/*}'/${repo#*/}"' or .head_repository.full_name=="'"$repo"'") | .id' 2>/dev/null
+            done > "/tmp/${prefix}_runs.txt"
+          }
+
+          fetch_runs "CI" ci
+          fetch_runs "CI Shadow" shadow
+
+          python3 - <<'PYEOF'
+          import json, os, subprocess, sys
+
+          repo = os.environ["GITHUB_REPOSITORY"]
+
+          def gh(path):
+              r = subprocess.run(["gh", "api", path, "-q", "."], capture_output=True, text=True)
+              if r.returncode != 0:
+                  return None
+              try:
+                  return json.loads(r.stdout)
+              except:
+                  return None
+
+          def collect(prefix, wf_name):
+              runs = []
+              ids_file = f"/tmp/{prefix}_runs.txt"
+              if not os.path.exists(ids_file):
+                  return runs
+              with open(ids_file) as f:
+                  run_ids = [int(l.strip()) for l in f if l.strip()][:30]
+              for rid in run_ids:
+                  run = gh(f"repos/{repo}/actions/runs/{rid}")
+                  if not run:
+                      continue
+                  jobs_resp = gh(f"repos/{repo}/actions/runs/{rid}/jobs")
+                  jobs = []
+                  if jobs_resp and "jobs" in jobs_resp:
+                      for j in jobs_resp["jobs"]:
+                          jobs.append({
+                              "name": j.get("name",""),
+                              "status": j.get("status",""),
+                              "started_at": j.get("started_at",""),
+                              "completed_at": j.get("completed_at",""),
+                              "conclusion": j.get("conclusion",""),
+                              "runner_os": next((l for l in j.get("labels",[]) if any(o in l for o in ("ubuntu","windows","macos"))), ""),
+                          })
+                  obs = {
+                      "workflow": wf_name,
+                      "run_id": rid,
+                      "event": run.get("event",""),
+                      "attempt": run.get("run_attempt", 1),
+                      "head_sha": run.get("head_sha",""),
+                      "head_branch": run.get("head_branch",""),
+                      "checkout_sha": run.get("head_sha",""),
+                      "created_at": run.get("created_at",""),
+                      "status": run.get("status",""),
+                      "conclusion": run.get("conclusion",""),
+                      "jobs": jobs,
+                  }
+                  runs.append(obs)
+              return runs
+
+          all_runs = collect("ci", "CI") + collect("shadow", "CI Shadow")
+          if all_runs:
+              with open("/tmp/observe/runs.json", "w") as f:
+                  json.dump(all_runs, f, indent=2)
+              print(f"collected {len(all_runs)} run observations")
+          else:
+              print("no runs collected", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+
+      - name: Evaluate qualification
+        run: |
+          go run ./tools/ciobserve \
+            --fixtures /tmp/observe \
+            --output /tmp/qualification.json \
+            --minimum-runs 20 \
+            --minimum-days 7 \
+            --max-p95-seconds 480
+
+      - name: Show qualification verdict
+        run: cat /tmp/qualification.json

--- a/.github/workflows/ci-shadow.yml
+++ b/.github/workflows/ci-shadow.yml
@@ -1,0 +1,347 @@
+# CI Shadow — advisory candidate DAG (20260812-ci-quality-system Task 10).
+#
+# Every job here is a CANDIDATE witness earning qualification under the
+# shadow protocol (>= 20 relevant executions over >= 7 days, zero unexplained
+# divergence, explicit promotion approval — ADR-042). None of these jobs is
+# in the required `CI required` aggregate in ci.yml, and this workflow has no
+# aggregate of its own: nothing in this file can block a merge.
+#
+# Package lists, service selectors, and pins are manifest-driven: civalidate
+# prints them from ci/package-ownership.yaml, ci/platform-contracts.yaml, and
+# ci/service-contracts.yaml, and the shadow-validation job re-checks this
+# workflow against those manifests on every run.
+
+name: CI Shadow
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Nightly: scheduled diagnostics (fuzz exploration) run here; PR/push
+    # events run only the merge-candidate jobs below.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  shadow-validation:
+    name: Shadow responsibility validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      # Self-tests first: a broken checker must be visible before the live
+      # validation below could produce a false green.
+      - name: Checker self-tests
+        run: |
+          bash scripts/ci/check-format.sh --self-test
+          bash scripts/ci/check-modules.sh --self-test
+          bash scripts/ci/run-go-tests.sh --self-test
+
+      - name: Validate manifests against this shadow workflow
+        run: |
+          go run ./tools/civalidate \
+            --standards ci/standards.yaml \
+            --packages ci/package-ownership.yaml \
+            --platforms ci/platform-contracts.yaml \
+            --services ci/service-contracts.yaml \
+            --workflow .github/workflows/ci-shadow.yml \
+            --makefile Makefile
+
+  # Candidate Linux race shards — rebalanced from measured package timings.
+  # Package lists come from the ownership manifest, so a shard edit drifts
+  # the manifest and the shadow-validation job, never just this job.
+  linux-race-parity:
+    name: Shadow Linux race shard parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve shard packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-shard linux-race-parity)" >> "$GITHUB_OUTPUT"
+      - name: Test (race)
+        run: bash scripts/ci/run-go-tests.sh --standard go-correctness-race --raw "$RUNNER_TEMP/linux-race-parity.json" -- go test -race -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  linux-race-compiler:
+    name: Shadow Linux race shard compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve shard packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-shard linux-race-compiler)" >> "$GITHUB_OUTPUT"
+      - name: Test (race)
+        run: bash scripts/ci/run-go-tests.sh --standard go-correctness-race --raw "$RUNNER_TEMP/linux-race-compiler.json" -- go test -race -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  linux-race-core:
+    name: Shadow Linux race shard core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve shard packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-shard linux-race-core)" >> "$GITHUB_OUTPUT"
+      - name: Test (race)
+        run: bash scripts/ci/run-go-tests.sh --standard go-correctness-race --raw "$RUNNER_TEMP/linux-race-core.json" -- go test -race -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  linux-race-platform:
+    name: Shadow Linux race shard platform
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve shard packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-shard linux-race-platform)" >> "$GITHUB_OUTPUT"
+      - name: Test (race)
+        run: bash scripts/ci/run-go-tests.sh --standard go-correctness-race --raw "$RUNNER_TEMP/linux-race-platform.json" -- go test -race -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  linux-race-rest:
+    name: Shadow Linux race shard rest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve shard packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-shard linux-race-rest)" >> "$GITHUB_OUTPUT"
+      - name: Test (race)
+        run: bash scripts/ci/run-go-tests.sh --standard go-correctness-race --raw "$RUNNER_TEMP/linux-race-rest.json" -- go test -race -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  # Focused OS contracts: only the packages with a named invariant for this
+  # GOOS, from ci/platform-contracts.yaml. Full OS suites stay required in
+  # ci.yml until these focused lists qualify.
+  platform-windows:
+    name: Shadow focused Windows contracts
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve contract packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-platform-packages windows)" >> "$GITHUB_OUTPUT"
+      - name: Test focused contracts
+        run: CGO_ENABLED=0 go test -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  platform-macos:
+    name: Shadow focused macOS contracts
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - id: pkgs
+        name: Resolve contract packages from the manifest
+        run: echo "packages=$(go run ./tools/civalidate --print-platform-packages darwin)" >> "$GITHUB_OUTPUT"
+      - name: Test focused contracts
+        run: CGO_ENABLED=0 go test -timeout 15m ${{ steps.pkgs.outputs.packages }}
+
+  # PostgreSQL contract — pinned image digest, selected env-gated tests only.
+  postgres-contract:
+    name: Shadow PostgreSQL contract
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16@sha256:a36250871de0833b8757561c72f2477ef1ddd1101afa4e617fb552e0de514c6b
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sage_wiki_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - name: Enable pgvector in the test database
+        env:
+          PGPASSWORD: postgres
+        run: |
+          for i in $(seq 1 15); do
+            pg_isready -h localhost -U postgres && break
+            sleep 2
+          done
+          psql -h localhost -U postgres -d sage_wiki_test \
+            -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+          psql -h localhost -U postgres -d sage_wiki_test \
+            -c "SELECT extname FROM pg_extension WHERE extname='vector';" | grep -q vector
+
+      - id: args
+        name: Resolve selected tests from the manifest
+        run: echo "args=$(go run ./tools/civalidate --print-service-run postgres)" >> "$GITHUB_OUTPUT"
+
+      # Args pass through an env var: ${{ }} is textual substitution, and the
+      # -run regex contains parentheses that would be bash syntax errors if
+      # substituted directly into the script.
+      - name: Test selected contract tests
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/sage_wiki_test?sslmode=disable
+          SELECTED_ARGS: ${{ steps.args.outputs.args }}
+        run: CGO_ENABLED=0 go test $SELECTED_ARGS
+
+  # MinIO contract — pinned image digest AND pinned mc client checksum
+  # (verified before use), selected env-gated tests only.
+  minio-contract:
+    name: Shadow MinIO contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      # Background docker container (not a service container) so the server
+      # command is explicit — the image's default CMD no longer starts it.
+      - name: Start MinIO
+        run: >
+          docker run -d --name minio
+          -p 9000:9000
+          -e MINIO_ROOT_USER=minioadmin
+          -e MINIO_ROOT_PASSWORD=minioadmin
+          minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
+          server /data --console-address ":9001"
+
+      - name: Wait for MinIO
+        run: |
+          for i in $(seq 1 20); do
+            if curl -fsS http://localhost:9000/minio/health/live 2>/dev/null; then
+              echo "MinIO ready"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "MinIO failed to start" && docker logs minio && exit 1
+
+      - name: Create test buckets (pinned mc)
+        run: |
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/mc
+          echo "01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891  /tmp/mc" | sha256sum -c -
+          chmod +x /tmp/mc
+          /tmp/mc alias set local http://localhost:9000 minioadmin minioadmin
+          /tmp/mc mb --ignore-existing local/sage-it-roundtrip
+          /tmp/mc mb --ignore-existing local/sage-it-corrupt
+          /tmp/mc mb --ignore-existing local/sage-it-crypt
+
+      - id: args
+        name: Resolve selected tests from the manifest
+        run: echo "args=$(go run ./tools/civalidate --print-service-run minio)" >> "$GITHUB_OUTPUT"
+
+      # Env-var indirection: see postgres-contract for why ${{ }} must not
+      # substitute the -run regex directly into the script.
+      - name: Test selected contract tests
+        env:
+          SAGE_TEST_MINIO: "1"
+          SAGE_TEST_MINIO_ENDPOINT: http://localhost:9000
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+          SAGE_MIRROR_CRASH_LOOPS: "100"
+          SELECTED_ARGS: ${{ steps.args.outputs.args }}
+        run: CGO_ENABLED=0 go test -timeout 10m $SELECTED_ARGS
+
+  # Fuzz exploration, parallelized: one advisory matrix leg per target.
+  # Random exploration is a SCHEDULED diagnostic (spec §3), not a merge
+  # candidate — so it runs only on the nightly schedule / manual dispatch.
+  # Task 11 adds the target-inventory contract; a future milestone may
+  # compare this parallel shape against the sequential fuzz-short job.
+  fuzz-targets:
+    name: Shadow fuzz ${{ matrix.target }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: fm-extract
+            fuzz: FuzzFrontmatter
+            package: ./internal/extract/
+            crashers: internal/extract/testdata/fuzz/
+          - target: fm-web
+            fuzz: FuzzFrontmatter
+            package: ./internal/web/
+            crashers: internal/web/testdata/fuzz/
+          - target: fm-ontology
+            fuzz: FuzzFrontmatter
+            package: ./internal/ontology/
+            crashers: internal/ontology/testdata/fuzz/
+          - target: fm-wiki
+            fuzz: FuzzFrontmatter
+            package: ./internal/wiki/
+            crashers: internal/wiki/testdata/fuzz/
+          - target: fm-compiler
+            fuzz: FuzzFrontmatter
+            package: ./internal/compiler/
+            crashers: internal/compiler/testdata/fuzz/
+          - target: wikilink
+            fuzz: FuzzWikilink
+            package: ./internal/compiler/
+            crashers: internal/compiler/testdata/fuzz/
+          - target: alias
+            fuzz: FuzzAliasNormalize
+            package: ./internal/compiler/
+            crashers: internal/compiler/testdata/fuzz/
+          - target: canonical
+            fuzz: FuzzCanonical
+            package: ./internal/compiler/
+            crashers: internal/compiler/testdata/fuzz/
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - name: Fuzz (30s)
+        run: go test -run=NONE -fuzz=${{ matrix.fuzz }} -fuzztime=30s ${{ matrix.package }}
+      - name: Upload crashers
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-shadow-crashers-${{ matrix.target }}
+          path: ${{ matrix.crashers }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/clients.yml
+++ b/.github/workflows/clients.yml
@@ -8,14 +8,28 @@ name: Clients
 on:
   push:
     branches: [main]
-    paths: ["clients/**", "examples/**", "scripts/p4-fixture-server.sh", "internal/**", "cmd/**", ".github/workflows/clients.yml"]
+    paths: ["clients/**", "examples/**", "scripts/p4-fixture-server.sh", "scripts/ci/classify-client-paths.sh", "internal/**", "cmd/**", "api/openapi.yaml", ".github/workflows/clients.yml"]
   pull_request:
-    paths: ["clients/**", "examples/**", "scripts/p4-fixture-server.sh", "internal/**", "cmd/**", ".github/workflows/clients.yml"]
+    paths: ["clients/**", "examples/**", "scripts/p4-fixture-server.sh", "scripts/ci/classify-client-paths.sh", "internal/**", "cmd/**", "api/openapi.yaml", ".github/workflows/clients.yml"]
 
 permissions:
   contents: read
 
 jobs:
+  # Contract test for the client path classifier (20260812-ci-quality-system
+  # Task 11): the classifier decides which changes are client-relevant, and a
+  # weakened classifier would silently skip client contract tests on exactly
+  # the changes that break clients. This self-test must pass before the
+  # classifier is trusted with relevant-change execution; it runs on every
+  # triggered build so a regression is immediately red.
+  path-classifier-self-test:
+    name: Client path classifier self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Classifier self-test
+        run: bash scripts/ci/classify-client-paths.sh --self-test
+
   python-unit:
     name: Python unit (${{ matrix.python }})
     runs-on: ubuntu-latest
@@ -38,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           cache: true
       - uses: actions/setup-python@v5
         with:
@@ -74,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           cache: true
       - uses: actions/setup-node@v4
         with:
@@ -95,7 +109,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           cache: true
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,15 @@
 name: fuzz
 
+# Nightly scheduled fuzz exploration (20260812-ci-quality-system Task 11).
+# Random exploration is a scheduled diagnostic, never merge authority: this
+# workflow has no aggregate and is not referenced by ci.yml's `CI required`.
+#
+# The target matrix is manifest-driven: ci/fuzz-targets.yaml is the single
+# source of truth, validated fail-closed against the source tree (a new
+# source target without inventory, a stale entry, or an empty scheduled
+# suite turns the inventory job red). Committed seed corpora run in ordinary
+# package tests — this workflow only runs time-bounded random exploration.
+
 'on':
   schedule:
     - cron: '17 3 * * *'
@@ -9,10 +19,11 @@ permissions:
   contents: read
 
 jobs:
-  fuzz:
-    name: Fuzz targets (nightly)
+  inventory:
+    name: Fuzz inventory validation
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    outputs:
+      targets: ${{ steps.list.outputs.targets }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,106 +31,49 @@ jobs:
         with:
           go-version-file: go.mod
 
-      # REQUIRED per-target invocations: Go's -fuzz errors when one
-      # invocation matches multiple targets. continue-on-error per step
-      # so one crasher never masks the other targets that night — but
-      # OUTCOME (not conclusion) is what the aggregation step reads: a
-      # failed target ends the job RED via the aggregation step below.
-      - id: docx
-        name: FuzzExtractDocx
-        run: go test -run=NONE -fuzz=FuzzExtractDocx -fuzztime=60s ./internal/extract/
-        continue-on-error: true
-      - id: xlsx
-        name: FuzzExtractXlsx
-        run: go test -run=NONE -fuzz=FuzzExtractXlsx -fuzztime=60s ./internal/extract/
-        continue-on-error: true
-      - id: pptx
-        name: FuzzExtractPptx
-        run: go test -run=NONE -fuzz=FuzzExtractPptx -fuzztime=60s ./internal/extract/
-        continue-on-error: true
-      - id: epub
-        name: FuzzExtractEpub
-        run: go test -run=NONE -fuzz=FuzzExtractEpub -fuzztime=60s ./internal/extract/
-        continue-on-error: true
-      - id: eml
-        name: FuzzExtractEmail
-        run: go test -run=NONE -fuzz=FuzzExtractEmail -fuzztime=60s ./internal/extract/
-        continue-on-error: true
-      - id: pdf
-        name: FuzzExtractPdfGo
-        run: go test -run=NONE -fuzz=FuzzExtractPdfGo -fuzztime=60s ./internal/extract/
-        continue-on-error: true
+      # Fail closed on any manifest drift before expanding the matrix.
+      - name: Validate responsibility manifests
+        run: |
+          go run ./tools/civalidate \
+            --standards ci/standards.yaml \
+            --packages ci/package-ownership.yaml \
+            --platforms ci/platform-contracts.yaml \
+            --services ci/service-contracts.yaml \
+            --fuzz-targets ci/fuzz-targets.yaml \
+            --workflow .github/workflows/fuzz.yml \
+            --makefile Makefile
 
-      # SPEC-08 hardening targets (30s each). FuzzFrontmatter runs once per
-      # owning package — the five pure-string frontmatter sites live in five
-      # packages (Go visibility forbids one cross-package target).
-      - id: fm-extract
-        name: FuzzFrontmatter (extract)
-        run: go test -run=NONE -fuzz=FuzzFrontmatter -fuzztime=30s ./internal/extract/
-        continue-on-error: true
-      - id: fm-web
-        name: FuzzFrontmatter (web)
-        run: go test -run=NONE -fuzz=FuzzFrontmatter -fuzztime=30s ./internal/web/
-        continue-on-error: true
-      - id: fm-ontology
-        name: FuzzFrontmatter (ontology)
-        run: go test -run=NONE -fuzz=FuzzFrontmatter -fuzztime=30s ./internal/ontology/
-        continue-on-error: true
-      - id: fm-wiki
-        name: FuzzFrontmatter (wiki)
-        run: go test -run=NONE -fuzz=FuzzFrontmatter -fuzztime=30s ./internal/wiki/
-        continue-on-error: true
-      - id: fm-compiler
-        name: FuzzFrontmatter (compiler)
-        run: go test -run=NONE -fuzz=FuzzFrontmatter -fuzztime=30s ./internal/compiler/
-        continue-on-error: true
-      - id: wikilink
-        name: FuzzWikilink
-        run: go test -run=NONE -fuzz=FuzzWikilink -fuzztime=30s ./internal/compiler/
-        continue-on-error: true
-      - id: alias
-        name: FuzzAliasNormalize
-        run: go test -run=NONE -fuzz=FuzzAliasNormalize -fuzztime=30s ./internal/compiler/
-        continue-on-error: true
-      - id: canonical
-        name: FuzzCanonical
-        run: go test -run=NONE -fuzz=FuzzCanonical -fuzztime=30s ./internal/compiler/
-        continue-on-error: true
+      - id: list
+        name: Expand the scheduled target matrix from the manifest
+        run: echo "targets=$(go run ./tools/civalidate --print-fuzz-targets-json scheduled)" >> "$GITHUB_OUTPUT"
 
-      - name: Upload crashers (when any target failed)
-        if: always() && (steps.docx.outcome == 'failure' || steps.xlsx.outcome == 'failure' || steps.pptx.outcome == 'failure' || steps.epub.outcome == 'failure' || steps.eml.outcome == 'failure' || steps.pdf.outcome == 'failure' || steps.fm-extract.outcome == 'failure' || steps.fm-web.outcome == 'failure' || steps.fm-ontology.outcome == 'failure' || steps.fm-wiki.outcome == 'failure' || steps.fm-compiler.outcome == 'failure' || steps.wikilink.outcome == 'failure' || steps.alias.outcome == 'failure' || steps.canonical.outcome == 'failure')
+  fuzz:
+    name: Fuzz ${{ matrix.target.target }} (${{ matrix.target.package }})
+    needs: inventory
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.inventory.outputs.targets) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # One target per invocation: Go's -fuzz errors when a pattern matches
+      # more than one target. A crasher turns this leg red visibly; legs are
+      # independent so one crasher never masks the other targets.
+      - name: Fuzz (time-bounded)
+        run: go test -run=NONE -fuzz=${{ matrix.target.target }} -fuzztime=${{ matrix.target.budget }} ./${{ matrix.target.package }}/
+
+      - name: Upload crashers
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-crashers
-          path: |
-            internal/extract/testdata/fuzz/
-            internal/web/testdata/fuzz/
-            internal/ontology/testdata/fuzz/
-            internal/wiki/testdata/fuzz/
-            internal/compiler/testdata/fuzz/
+          name: fuzz-crashers-${{ matrix.target.target }}
+          path: ${{ matrix.target.package }}/testdata/fuzz/
           if-no-files-found: ignore
           retention-days: 14
-
-      # Aggregation: continue-on-error keeps all targets running, but any
-      # failed OUTCOME must turn the job red — a crasher can never be
-      # mistaken for a pass.
-      - name: Fail if any target crashed
-        if: always()
-        run: |
-          if [ "${{ steps.docx.outcome }}" = "failure" ] || \
-             [ "${{ steps.xlsx.outcome }}" = "failure" ] || \
-             [ "${{ steps.pptx.outcome }}" = "failure" ] || \
-             [ "${{ steps.epub.outcome }}" = "failure" ] || \
-             [ "${{ steps.eml.outcome }}" = "failure" ] || \
-             [ "${{ steps.pdf.outcome }}" = "failure" ] || \
-             [ "${{ steps.fm-extract.outcome }}" = "failure" ] || \
-             [ "${{ steps.fm-web.outcome }}" = "failure" ] || \
-             [ "${{ steps.fm-ontology.outcome }}" = "failure" ] || \
-             [ "${{ steps.fm-wiki.outcome }}" = "failure" ] || \
-             [ "${{ steps.fm-compiler.outcome }}" = "failure" ] || \
-             [ "${{ steps.wikilink.outcome }}" = "failure" ] || \
-             [ "${{ steps.alias.outcome }}" = "failure" ] || \
-             [ "${{ steps.canonical.outcome }}" = "failure" ]; then
-            echo "fuzz findings — see the fuzz-crashers artifact"
-            exit 1
-          fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ sage/
 # Build
 /sage-wiki
 /civalidate
+/ciobserve
 /testsummary
 bin/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,10 +130,23 @@ malformed docx/xlsx/pptx/epub/eml/pdf inputs and checks the caps hold.
 
 ## Fuzzing
 
-Native Go fuzz targets guard the parsing and hardening surfaces. A PR-gated
-short pass runs every target for 30s (`fuzz-short` job in
-[.github/workflows/ci.yml](.github/workflows/ci.yml)); a nightly job runs the
-same targets longer ([.github/workflows/fuzz.yml](.github/workflows/fuzz.yml)).
+Native Go fuzz targets guard the parsing and hardening surfaces. Two tiers run
+in CI, both driven by the machine-readable inventory in
+[`ci/fuzz-targets.yaml`](ci/fuzz-targets.yaml) (validated fail-closed against
+the source tree — a new target without an inventory entry, or a stale entry,
+turns the nightly job red):
+
+- **PR-gated short pass** (`fuzz-short` job in
+  [.github/workflows/ci.yml](.github/workflows/ci.yml)): the 8 hardening
+  targets (`FuzzFrontmatter` ×5 packages, `FuzzWikilink`,
+  `FuzzAliasNormalize`, `FuzzCanonical`) for 30s each.
+- **Nightly exploration** ([.github/workflows/fuzz.yml](.github/workflows/fuzz.yml)):
+  every target in the inventory — the 8 hardening targets plus the 6 extractor
+  format targets (`FuzzExtract{Docx,Xlsx,Pptx,Epub,Email,PdfGo}`), which do
+  **not** run on PRs.
+
+Committed seed corpora run deterministically as ordinary package tests on
+every PR; only the time-bounded random exploration above is scheduled.
 
 Run a target locally (pick one target per invocation — Go's `-fuzz` errors if
 a pattern matches more than one):

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,44 @@ modules-check:
 
 # Responsibility manifests: parser/validation suite plus the live fail-closed
 # validator (exact package partition, aggregate membership, Make targets,
-# determinism roles, platform inventory).
+# determinism roles, platform inventory, shards, service contracts, fuzz
+# inventory). Every workflow is validated so a witness job reference can
+# never point at a job that does not exist: ci.yml (required aggregate),
+# ci-shadow.yml (advisory candidates), fuzz.yml (scheduled exploration),
+# and ci-diagnostics.yml (scheduled broad diagnostics).
 responsibility-check:
 	$(GO) test ./tools/civalidate -count=1
 	$(GO) run ./tools/civalidate \
 		--standards ci/standards.yaml \
 		--packages ci/package-ownership.yaml \
 		--platforms ci/platform-contracts.yaml \
+		--services ci/service-contracts.yaml \
+		--fuzz-targets ci/fuzz-targets.yaml \
 		--workflow .github/workflows/ci.yml \
+		--makefile Makefile
+	$(GO) run ./tools/civalidate \
+		--standards ci/standards.yaml \
+		--packages ci/package-ownership.yaml \
+		--platforms ci/platform-contracts.yaml \
+		--services ci/service-contracts.yaml \
+		--fuzz-targets ci/fuzz-targets.yaml \
+		--workflow .github/workflows/ci-shadow.yml \
+		--makefile Makefile
+	$(GO) run ./tools/civalidate \
+		--standards ci/standards.yaml \
+		--packages ci/package-ownership.yaml \
+		--platforms ci/platform-contracts.yaml \
+		--services ci/service-contracts.yaml \
+		--fuzz-targets ci/fuzz-targets.yaml \
+		--workflow .github/workflows/fuzz.yml \
+		--makefile Makefile
+	$(GO) run ./tools/civalidate \
+		--standards ci/standards.yaml \
+		--packages ci/package-ownership.yaml \
+		--platforms ci/platform-contracts.yaml \
+		--services ci/service-contracts.yaml \
+		--fuzz-targets ci/fuzz-targets.yaml \
+		--workflow .github/workflows/ci-diagnostics.yml \
 		--makefile Makefile
 
 # Determinism tripwire: contract self-test first, then the live scan.

--- a/ci/fuzz-targets.yaml
+++ b/ci/fuzz-targets.yaml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Fuzz target inventory (20260812-ci-quality-system Task 11).
+#
+# Every `func Fuzz*` in the repository must appear here, and every entry must
+# still exist in source — civalidate scans *_test.go and fails closed on
+# drift in either direction, plus an empty scheduled suite. Committed seed
+# corpora run deterministically in ordinary package tests (fuzz-regressions
+# standard); everything here is time-bounded random exploration.
+#
+# Tiers:
+#   pr        — mirrored in ci.yml's PR-gated fuzz-short job (hardening
+#               surfaces, 30s each) and nightly. Descriptive mirror today:
+#               ci.yml's step list is not yet manifest-driven; civalidate
+#               cross-check is wired when fuzz-short becomes manifest-driven
+#               (Task 15). Both lists agree now (8 targets).
+#   scheduled — nightly fuzz.yml only (broad extractor exploration, 60s each).
+
+targets:
+  - {package: internal/extract, target: FuzzExtractDocx, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzExtractXlsx, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzExtractPptx, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzExtractEpub, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzExtractEmail, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzExtractPdfGo, tier: scheduled, budget_seconds: 60}
+  - {package: internal/extract, target: FuzzFrontmatter, tier: pr, budget_seconds: 30}
+  - {package: internal/web, target: FuzzFrontmatter, tier: pr, budget_seconds: 30}
+  - {package: internal/ontology, target: FuzzFrontmatter, tier: pr, budget_seconds: 30}
+  - {package: internal/wiki, target: FuzzFrontmatter, tier: pr, budget_seconds: 30}
+  - {package: internal/compiler, target: FuzzFrontmatter, tier: pr, budget_seconds: 30}
+  - {package: internal/compiler, target: FuzzWikilink, tier: pr, budget_seconds: 30}
+  - {package: internal/compiler, target: FuzzAliasNormalize, tier: pr, budget_seconds: 30}
+  - {package: internal/compiler, target: FuzzCanonical, tier: pr, budget_seconds: 30}

--- a/ci/package-ownership.yaml
+++ b/ci/package-ownership.yaml
@@ -70,5 +70,76 @@ packages:
   - {path: pkg/sagewiki, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tests/pathological, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/civalidate, class: test-owned, owner: go-tests-current, roles: []}
+  - {path: tools/ciobserve, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/skillgen, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/testsummary, class: test-owned, owner: go-tests-current, roles: []}
+
+# Candidate Linux race shards (20260812-ci-quality-system Task 10). Boundaries
+# come from measured package race timings; the shadow DAG measures hosted wall
+# time and Milestone 6 rebalances one variable at a time. Every ordinary
+# package (test-owned + helper-library) appears in exactly one shard —
+# civalidate enforces coverage, duplication, and shadow-job presence.
+linux_race_shards:
+  workflow: CI Shadow
+  shards:
+    - id: linux-race-parity
+      packages: [internal/parity]
+    - id: linux-race-compiler
+      packages: [internal/compiler]
+    - id: linux-race-core
+      packages: [internal/api, internal/mcp, internal/llm, internal/extract, internal/extract/parsers]
+    - id: linux-race-platform
+      packages: [internal/web, pkg/engine, internal/serve, internal/vectors, internal/vectors/hnsw]
+    - id: linux-race-rest
+      packages:
+        - .
+        - cmd/sage-wiki
+        - internal/app
+        - internal/auth
+        - internal/capturefmt
+        - internal/cli
+        - internal/config
+        - internal/embed
+        - internal/export
+        - internal/fsutil
+        - internal/git
+        - internal/graph
+        - internal/graph/community
+        - internal/hub
+        - internal/hybrid
+        - internal/limits
+        - internal/linter
+        - internal/log
+        - internal/manifest
+        - internal/memory
+        - internal/metrics
+        - internal/mirror
+        - internal/mirror/s3
+        - internal/ontology
+        - internal/pack
+        - internal/pathsafe
+        - internal/prompts
+        - internal/query
+        - internal/scribe
+        - internal/search
+        - internal/skill
+        - internal/sourcedate
+        - internal/sqlitestore
+        - internal/storage
+        - internal/storage/postgres
+        - internal/store
+        - internal/storedial
+        - internal/storetest
+        - internal/traversaltest
+        - internal/trust
+        - internal/tui
+        - internal/tui/compile
+        - internal/wiki
+        - pkg/events
+        - pkg/provider/providerfake
+        - pkg/sagewiki
+        - tests/pathological
+        - tools/civalidate
+        - tools/ciobserve
+        - tools/skillgen
+        - tools/testsummary

--- a/ci/qualification.json
+++ b/ci/qualification.json
@@ -1,0 +1,10 @@
+{
+  "candidate_workflow": "CI Shadow",
+  "current_workflow": "CI",
+  "sample_count": 0,
+  "date_span_days": 0,
+  "status": "pending",
+  "reason": "Qualification window not yet started.",
+  "owner_disposition": "pending",
+  "generated_at": ""
+}

--- a/ci/service-contracts.yaml
+++ b/ci/service-contracts.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+
+# Dedicated service contracts (20260812-ci-quality-system Task 10).
+#
+# Each service selects ONLY env-gated contract tests by name — civalidate
+# discovers them with `go test -list` and fails on any count or name drift,
+# so a renamed or removed contract test turns the shadow job red instead of
+# silently shrinking coverage. Images and clients are pinned by immutable
+# sha256 digest/checksum; the shadow workflow must contain the same pins
+# (civalidate checks the workflow text), so hermeticity is asserted on facts,
+# not tags.
+#
+# internal/hub is deliberately NOT a PostgreSQL contract package: it has no
+# TEST_DATABASE_URL-gated tests (only a comment about a future pool-size
+# leg). Ordinary hub tests stay in the Linux race shards.
+
+services:
+  - id: postgres
+    workflow: CI Shadow
+    job: postgres-contract
+    image:
+      repository: pgvector/pgvector
+      tag: pg16
+      digest: "sha256:a36250871de0833b8757561c72f2477ef1ddd1101afa4e617fb552e0de514c6b"
+    env: TEST_DATABASE_URL
+    # -p 1: every pg package talks to the SAME database and drops/recreates
+    # schema, so parallel packages would race on shared tables.
+    parallel: 1
+    packages:
+      - internal/storage/postgres
+      - internal/storetest
+      - internal/wiki
+    # TestOpenWithoutPgvectorFailsActionably is excluded: it is gated on
+    # TEST_DATABASE_URL_NOVECTOR (a database without the extension), which
+    # neither the current nor the shadow job provides — it skips today and
+    # would be a vacuous selected test here.
+    selected_tests:
+      - TestPGGetChunksMeta
+      - TestCompileKeyStore_RoundTripPG
+      - TestMigrationV9CompileKeyColumns
+      - TestOpenOptionsNow_LandsInTimestamps
+      - TestPostgresStore_ClassifyPrimitives
+      - TestPGDerivedUnion
+      - TestPGDerivedGuardSeesWritesFromAnotherBackend
+      - TestPGSearchDFPrunesFrequentTerms
+      - TestPGSearchChunksDFPrunesFrequentTerms
+      - TestPGSearchColumnWeights
+      - TestOntologyStoreEmitsEdgeEvents
+      - TestMigrationV2QueueColumns
+      - TestMigrationV3EvidenceColumns
+      - TestMigrationV4AliasTable
+      - TestMigrationV5DerivedRelations
+      - TestMigrationV8Communities
+      - TestCurrentSchemaVersionTracksMigrations
+      - TestConformancePostgres
+      - TestReconcileBackendPostgres
+
+  - id: minio
+    workflow: CI Shadow
+    job: minio-contract
+    image:
+      repository: minio/minio
+      # Pinned by digest only; there is no floating tag. The workflow pulls
+      # minio/minio@sha256:... directly.
+      digest: "sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+    client:
+      name: mc
+      url: "https://dl.min.io/client/mc/release/linux-amd64/mc"
+      sha256: "01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891"
+    env: SAGE_TEST_MINIO
+    packages:
+      - internal/mirror
+    selected_tests:
+      - TestMinIO_RoundTrip
+      - TestMinIO_CorruptionDetects
+      - TestMinIO_EncryptionRoundTrip

--- a/ci/standards.yaml
+++ b/ci/standards.yaml
@@ -275,6 +275,51 @@ standards:
         coverage: {packages: [internal/parity], package_classes: [], package_roles: [], platform_contracts: [], paths: [testdata/golden/, testdata/fixtures/], generated_paths: []}
         diagnostics: {local_command: go test -count=1 ./internal/parity/, local_make_target: parity, hosted_artifact: parity-shadow-log, failure_artifact: replay-diff, formats: [text, diff]}
         qualification: {state: candidate, history: []}
+      - id: parity-repetition-candidate
+        status: nonblocking
+        command: CGO_ENABLED=0 go test -count=10 ./internal/parity/
+        triggers: [schedule, manual]
+        platforms: [linux]
+        job: {workflow: CI Diagnostics, id: parity-repetition, aggregate: false}
+        purpose: {met: [], evidence: "Repetition surfaces low-probability flakes; it is diagnostic evidence, not a merge verdict."}
+        authority: {met: [anti-vacuous, bounded, reproducible-or-diagnosable, owned], evidence: "A flake under repetition is evidence, never authority."}
+        anti_vacuity: Fixture and replay counts remain asserted on every repetition.
+        runtime: {bound_seconds: 1800, recent: null}
+        coverage: {packages: [internal/parity], package_classes: [], package_roles: [], platform_contracts: [], paths: [testdata/golden/, testdata/fixtures/], generated_paths: []}
+        diagnostics: {local_command: go test -count=10 ./internal/parity/, local_make_target: null, hosted_artifact: parity-repetition-log, failure_artifact: replay-diff, formats: [text, diff]}
+        qualification: {state: candidate, history: []}
+
+  - id: scheduled-full-os-suites
+    rationale: Full Windows and macOS suites beyond the PR shards remain diagnostic coverage, not merge authority.
+    owner: scheduled-diagnostics
+    fallback_owner: human-review
+    witnesses:
+      - id: full-suite-windows-candidate
+        status: nonblocking
+        command: CGO_ENABLED=0 go test -timeout 15m ./...
+        triggers: [schedule, manual]
+        platforms: [windows]
+        job: {workflow: CI Diagnostics, id: full-suite-windows, aggregate: false}
+        purpose: {met: [], evidence: "Scheduled full-OS coverage is diagnostic, not a candidate-merge property."}
+        authority: {met: [anti-vacuous, bounded, reproducible-or-diagnosable, owned], evidence: "Full-suite discovery must stay nonempty; failures are diagnostic evidence."}
+        anti_vacuity: An empty package list or a skipped suite is diagnostic-red.
+        runtime: {bound_seconds: 2700, recent: null}
+        coverage: {packages: [], package_classes: [test-owned, helper-library], package_roles: [], platform_contracts: [], paths: [], generated_paths: []}
+        diagnostics: {local_command: null, local_make_target: null, hosted_artifact: full-os-suite-log, failure_artifact: full-os-suite-log, formats: [text]}
+        qualification: {state: candidate, history: []}
+      - id: full-suite-macos-candidate
+        status: nonblocking
+        command: CGO_ENABLED=0 go test -timeout 15m ./...
+        triggers: [schedule, manual]
+        platforms: [darwin]
+        job: {workflow: CI Diagnostics, id: full-suite-macos, aggregate: false}
+        purpose: {met: [], evidence: "Scheduled full-OS coverage is diagnostic, not a candidate-merge property."}
+        authority: {met: [anti-vacuous, bounded, reproducible-or-diagnosable, owned], evidence: "Full-suite discovery must stay nonempty; failures are diagnostic evidence."}
+        anti_vacuity: An empty package list or a skipped suite is diagnostic-red.
+        runtime: {bound_seconds: 2700, recent: null}
+        coverage: {packages: [], package_classes: [test-owned, helper-library], package_roles: [], platform_contracts: [], paths: [], generated_paths: []}
+        diagnostics: {local_command: null, local_make_target: null, hosted_artifact: full-os-suite-log, failure_artifact: full-os-suite-log, formats: [text]}
+        qualification: {state: candidate, history: []}
 
   - id: fuzz-exploration
     rationale: Random exploration discovers crashers but does not provide deterministic merge authority.
@@ -301,12 +346,12 @@ standards:
         command: go test -run=NONE -fuzz=<target> -fuzztime=<bound> <package>
         triggers: [schedule, manual]
         platforms: [linux]
-        job: null
+        job: {workflow: fuzz, id: fuzz, aggregate: false}
         purpose: {met: [], evidence: "Random exploration is not a deterministic candidate-merge property."}
         authority: {met: [anti-vacuous, bounded, reproducible-or-diagnosable, owned], evidence: "Target inventory and crasher upload remain mandatory for the diagnostic."}
         anti_vacuity: Missing targets are diagnostic-red and crashers are retained as artifacts.
         runtime: {bound_seconds: 3600, recent: null}
-        coverage: {packages: [internal/extract, internal/web, internal/ontology, internal/wiki, internal/compiler], package_classes: [], package_roles: [], platform_contracts: [], paths: [], generated_paths: []}
+        coverage: {packages: [internal/extract, internal/web, internal/ontology, internal/wiki, internal/compiler], package_classes: [], package_roles: [], platform_contracts: [], paths: [ci/fuzz-targets.yaml], generated_paths: []}
         diagnostics: {local_command: "go test -run=NONE -fuzz=<target> -fuzztime=<bound> <package>", local_make_target: null, hosted_artifact: fuzz-crashers, failure_artifact: fuzz-crashers, formats: [text]}
         qualification: {state: candidate, history: []}
 
@@ -406,16 +451,16 @@ standards:
     witnesses:
       - id: performance-nightly-candidate
         status: nonblocking
-        command: <repository-benchmark-command>
+        command: bash scripts/spec06/warmcheck.sh
         triggers: [schedule, manual]
         platforms: [linux]
-        job: null
+        job: {workflow: CI Diagnostics, id: performance-warmcheck, aggregate: false}
         purpose: {met: [], evidence: "Host timing is not a reliable candidate-merge property."}
         authority: {met: [anti-vacuous, bounded, reproducible-or-diagnosable, owned], evidence: "Baseline count and environment identity are required for trend evidence."}
         anti_vacuity: Missing samples or environment identity is diagnostic-red.
-        runtime: {bound_seconds: 3600, recent: null}
-        coverage: {packages: [], package_classes: [], package_roles: [], platform_contracts: [], paths: [], generated_paths: []}
-        diagnostics: {local_command: <repository-benchmark-command>, local_make_target: null, hosted_artifact: benchmark-trend, failure_artifact: raw-benchmark-data, formats: [benchmark-data]}
+        runtime: {bound_seconds: 1200, recent: null}
+        coverage: {packages: [internal/vectors], package_classes: [], package_roles: [], platform_contracts: [], paths: [scripts/spec06/warmcheck.sh], generated_paths: []}
+        diagnostics: {local_command: bash scripts/spec06/warmcheck.sh, local_make_target: null, hosted_artifact: benchmark-trend, failure_artifact: raw-benchmark-data, formats: [benchmark-data]}
         qualification: {state: candidate, history: []}
 
   - id: frontend-contract
@@ -457,6 +502,19 @@ standards:
         coverage: {packages: [], package_classes: [], package_roles: [], platform_contracts: [], paths: [clients/], generated_paths: []}
         diagnostics: {local_command: <client-lockfile-unit-and-build-commands>, local_make_target: null, hosted_artifact: client-build-log, failure_artifact: client-build-log, formats: [text]}
         qualification: {state: candidate, history: []}
+      - id: clients-broad-nightly
+        status: nonblocking
+        command: client unit and typecheck suites from each lockfile
+        triggers: [schedule, manual]
+        platforms: [linux]
+        job: {workflow: CI Diagnostics, id: clients-broad, aggregate: false}
+        purpose: {met: [], evidence: "Scheduled broad client health is diagnostic, not a candidate-merge property."}
+        authority: {met: [anti-vacuous, actionable, bounded, reproducible-or-diagnosable, owned], evidence: "Nonzero test discovery and path-classifier self-tests remain mandatory."}
+        anti_vacuity: Zero test discovery or a skipped client is diagnostic-red.
+        runtime: {bound_seconds: 1800, recent: null}
+        coverage: {packages: [], package_classes: [], package_roles: [], platform_contracts: [], paths: [clients/], generated_paths: []}
+        diagnostics: {local_command: null, local_make_target: null, hosted_artifact: client-build-log, failure_artifact: client-build-log, formats: [text]}
+        qualification: {state: candidate, history: []}
 
   - id: examples
     rationale: Examples must stay offline and runnable, without turning experiments into merge authority.
@@ -491,6 +549,19 @@ standards:
         coverage: {packages: [examples/embed], package_classes: [example-smoke], package_roles: [], platform_contracts: [], paths: [examples/], generated_paths: []}
         diagnostics: {local_command: <offline-example-smoke-commands>, local_make_target: null, hosted_artifact: examples-log, failure_artifact: example-output, formats: [text]}
         qualification: {state: candidate, history: []}
+      - id: examples-broad-nightly
+        status: nonblocking
+        command: offline example smoke commands against the fixture server
+        triggers: [schedule, manual]
+        platforms: [linux]
+        job: {workflow: CI Diagnostics, id: examples-broad, aggregate: false}
+        purpose: {met: [], evidence: "Scheduled broad example health is diagnostic, not a candidate-merge property."}
+        authority: {met: [anti-vacuous, actionable, bounded, reproducible-or-diagnosable, owned], evidence: "Explicit inventory and offline execution remain mandatory."}
+        anti_vacuity: Zero examples or a live credential dependency is diagnostic-red.
+        runtime: {bound_seconds: 1800, recent: null}
+        coverage: {packages: [examples/embed], package_classes: [example-smoke], package_roles: [], platform_contracts: [], paths: [examples/], generated_paths: []}
+        diagnostics: {local_command: null, local_make_target: null, hosted_artifact: examples-log, failure_artifact: example-output, formats: [text]}
+        qualification: {state: candidate, history: []}
 
   - id: vulnerability-intelligence
     rationale: Mutable vulnerability intelligence informs maintenance and release disposition without impersonating candidate correctness.
@@ -510,6 +581,19 @@ standards:
         coverage: {packages: [], package_classes: [test-owned, compile-only, example-smoke, helper-library], package_roles: [], platform_contracts: [], paths: [go.mod, go.sum], generated_paths: []}
         diagnostics: {local_command: make vuln, local_make_target: vuln, hosted_artifact: vulnerability-report, failure_artifact: vulnerability-report, formats: [text]}
         qualification: {state: not-applicable, history: []}
+      - id: vulnerability-nightly-candidate
+        status: nonblocking
+        command: govulncheck ./...
+        triggers: [schedule, manual]
+        platforms: [linux]
+        job: {workflow: CI Diagnostics, id: vuln-scan, aggregate: false}
+        purpose: {met: [], evidence: "The mutable database is not a candidate-merge property."}
+        authority: {met: [anti-vacuous, actionable, bounded, reproducible-or-diagnosable, owned], evidence: "Tool and database identity are recorded; scan failure is not no findings."}
+        anti_vacuity: Tool failure and zero evidence are distinct from no vulnerabilities.
+        runtime: {bound_seconds: 1200, recent: null}
+        coverage: {packages: [], package_classes: [test-owned, compile-only, example-smoke, helper-library], package_roles: [], platform_contracts: [], paths: [go.mod, go.sum], generated_paths: []}
+        diagnostics: {local_command: make vuln, local_make_target: vuln, hosted_artifact: vulnerability-report, failure_artifact: vulnerability-report, formats: [text]}
+        qualification: {state: candidate, history: []}
 
   - id: translation-structure
     rationale: README translation structure and explicit lag waivers must remain mechanically valid.

--- a/docs/security.md
+++ b/docs/security.md
@@ -98,10 +98,14 @@ that assert security invariants only (no panic, no unbounded growth,
 deterministic output): `FuzzFrontmatter` (one per owning package —
 extract, web, ontology, wiki, compiler), `FuzzWikilink`,
 `FuzzAliasNormalize`, and `FuzzCanonical`, alongside the extractor
-`FuzzExtract{Docx,Xlsx,Pptx,Epub,Email,PdfGo}` targets. A PR-gated
-short pass runs every target for 30s and a nightly job runs longer; any
-crasher is committed to the corpus. See
-[CONTRIBUTING § Fuzzing](../CONTRIBUTING.md#fuzzing) for running them
+`FuzzExtract{Docx,Xlsx,Pptx,Epub,Email,PdfGo}` targets. All targets are
+recorded in the machine-readable inventory at
+[`ci/fuzz-targets.yaml`](../ci/fuzz-targets.yaml), validated fail-closed
+against the source tree. A PR-gated short pass runs the 8 hardening
+targets for 30s each (`fuzz-short` in ci.yml); the 6 extractor format
+targets run nightly only (fuzz.yml), where all 14 targets get
+time-bounded random exploration. Any crasher is committed to the corpus.
+See [CONTRIBUTING § Fuzzing](../CONTRIBUTING.md#fuzzing) for running them
 locally.
 
 ## Residual risks

--- a/scripts/ci/check-local-contract.sh
+++ b/scripts/ci/check-local-contract.sh
@@ -9,6 +9,7 @@ printf '%s\n' 'local-contract: checker self-tests'
 bash scripts/ci/check-format.sh --self-test
 bash scripts/ci/check-modules.sh --self-test
 bash scripts/ci/run-go-tests.sh --self-test
+bash scripts/ci/classify-client-paths.sh --self-test
 
 printf '%s\n' 'local-contract: format and module inputs'
 bash scripts/ci/check-format.sh
@@ -16,12 +17,16 @@ bash scripts/ci/check-modules.sh
 
 printf '%s\n' 'local-contract: responsibility manifests'
 go test ./tools/civalidate -count=1
-go run ./tools/civalidate \
-	--standards ci/standards.yaml \
-	--packages ci/package-ownership.yaml \
-	--platforms ci/platform-contracts.yaml \
-	--workflow .github/workflows/ci.yml \
-	--makefile Makefile
+for wf in ci ci-shadow fuzz ci-diagnostics; do
+	go run ./tools/civalidate \
+		--standards ci/standards.yaml \
+		--packages ci/package-ownership.yaml \
+		--platforms ci/platform-contracts.yaml \
+		--services ci/service-contracts.yaml \
+		--fuzz-targets ci/fuzz-targets.yaml \
+		--workflow ".github/workflows/$wf.yml" \
+		--makefile Makefile
+done
 
 printf '%s\n' 'local-contract: determinism self-test and scan'
 bash scripts/check-determinism.sh --self-test

--- a/scripts/ci/classify-client-paths.sh
+++ b/scripts/ci/classify-client-paths.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# classify-client-paths.sh — decide whether a set of changed paths is relevant
+# to the client/example contracts (20260812-ci-quality-system Task 11).
+#
+# Usage:
+#   classify-client-paths.sh            read changed paths from stdin (one per
+#                                       line, e.g. `git diff --name-only`);
+#                                       exit 0 = relevant, 1 = not relevant,
+#                                       2 = usage/parse error (fail closed).
+#   classify-client-paths.sh --self-test  run the contract cases; exit 0/1.
+#
+# Fail-closed contract: an API-contract change (api/openapi.yaml, internal/api,
+# internal/mcp, cmd) MUST classify relevant — a classifier that misses it would
+# silently skip the client contract tests on exactly the changes that break
+# clients. Ambiguous or unreadable input exits 2, never "not relevant".
+set -euo pipefail
+
+is_relevant() { # one path -> return 0 if client/example-relevant
+	case "$1" in
+	clients/* | examples/*) return 0 ;;
+	scripts/p4-fixture-server.sh) return 0 ;;
+	api/openapi.yaml) return 0 ;;
+	internal/* | cmd/*) return 0 ;;
+	.github/workflows/clients.yml | .github/workflows/ci-diagnostics.yml) return 0 ;;
+	scripts/ci/classify-client-paths.sh) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+classify() { # stdin paths -> exit 0 relevant / 1 not / 2 error
+	local seen=0 relevant=1 line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# trim surrounding whitespace; skip blank lines
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -z "$line" ]] && continue
+		seen=1
+		if is_relevant "$line"; then
+			relevant=0
+		fi
+	done
+	if [[ "$seen" -eq 0 ]]; then
+		# No paths at all is ambiguous (not "irrelevant") — fail closed.
+		return 2
+	fi
+	return "$relevant"
+}
+
+self_test() {
+	local fail=0
+	t() { # name want_exit paths...
+		local name="$1" want="$2"
+		shift 2
+		local got
+		if printf '%s\n' "$@" | classify; then
+			got=0
+		else
+			got=$?
+		fi
+		if [[ "$got" != "$want" ]]; then
+			echo "SELF-TEST FAIL: $name (exit $got, want $want)" >&2
+			fail=1
+		else
+			echo "ok: $name"
+		fi
+	}
+
+	t "client source change" 0 "clients/python/src/sagewiki/__init__.py"
+	t "typescript client change" 0 "clients/typescript/src/index.ts"
+	t "example change" 0 "examples/langgraph/main.py"
+	t "api contract change must not be missed" 0 "api/openapi.yaml"
+	t "server api change must not be missed" 0 "internal/api/handlers_read.go"
+	t "mcp tool change must not be missed" 0 "internal/mcp/tools_write.go"
+	t "cli change must not be missed" 0 "cmd/sage-wiki/main.go"
+	t "fixture server change" 0 "scripts/p4-fixture-server.sh"
+	t "mixed relevant and irrelevant" 0 "README.md" "clients/python/pyproject.toml"
+	t "docs only is not relevant" 1 "README.md" "docs/security.md"
+	t "unrelated go module file is not relevant" 1 "go.mod" ".github/workflows/docker.yml"
+	t "empty input fails closed" 2 ""
+
+	[[ "$fail" -eq 0 ]] && echo "SELF-TEST PASS" || exit 1
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+	self_test
+	exit $?
+fi
+
+classify

--- a/tools/ciobserve/main.go
+++ b/tools/ciobserve/main.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// JobObservation is a single job within a workflow run.
+type JobObservation struct {
+	Name           string  `json:"name"`
+	Status         string  `json:"status"`
+	StartedAt      string  `json:"started_at"`
+	CompletedAt    string  `json:"completed_at"`
+	QueueSeconds   float64 `json:"queue_seconds,omitempty"`
+	RuntimeSeconds float64 `json:"runtime_seconds"`
+	Conclusion     string  `json:"conclusion"`
+	RunnerOS       string  `json:"runner_os"`
+}
+
+// RunObservation is a complete workflow run with its jobs.
+type RunObservation struct {
+	Workflow     string           `json:"workflow"`
+	RunID        int64            `json:"run_id"`
+	Event        string           `json:"event"`
+	Attempt      int              `json:"attempt"`
+	HeadSHA      string           `json:"head_sha"`
+	HeadBranch   string           `json:"head_branch"`
+	CheckoutSHA  string           `json:"checkout_sha"`
+	CreatedAt    string           `json:"created_at"`
+	Status       string           `json:"status"`
+	Conclusion   string           `json:"conclusion"`
+	Jobs         []JobObservation `json:"jobs"`
+	FirstFailure *JobObservation  `json:"first_failure,omitempty"`
+}
+
+// Divergence records a mismatch between current and candidate outcomes on the same source tree.
+type Divergence struct {
+	HeadSHA         string `json:"head_sha"`
+	CurrentResult   string `json:"current_result"`
+	CandidateResult string `json:"candidate_result"`
+	Explanation     string `json:"explanation,omitempty"`
+}
+
+// QualificationRecord is the persisted qualification verdict.
+type QualificationRecord struct {
+	CandidateWorkflow string       `json:"candidate_workflow"`
+	CurrentWorkflow   string       `json:"current_workflow"`
+	SampleCount       int          `json:"sample_count"`
+	DateSpanDays      float64      `json:"date_span_days"`
+	EarliestRun       string       `json:"earliest_run"`
+	LatestRun         string       `json:"latest_run"`
+	Status            string       `json:"status"`
+	Reason            string       `json:"reason,omitempty"`
+	P50Seconds        float64      `json:"p50_seconds"`
+	P95Seconds        float64      `json:"p95_seconds"`
+	RunnerOccupancy   float64      `json:"runner_occupancy_seconds"`
+	Divergences       []Divergence `json:"divergences,omitempty"`
+	Mutations         []string     `json:"mutations,omitempty"`
+	OwnerDisposition  string       `json:"owner_disposition"`
+	GeneratedAt       string       `json:"generated_at"`
+}
+
+// QualificationOptions controls the qualification thresholds.
+type QualificationOptions struct {
+	MinimumRuns   int
+	MinimumDays   int
+	MaxP95Seconds float64
+}
+
+// wallTime returns the runtime in seconds for a run (max job completed - min job started).
+func (r RunObservation) wallTime() float64 {
+	if len(r.Jobs) == 0 {
+		return 0
+	}
+	var starts, ends []time.Time
+	for _, job := range r.Jobs {
+		s, err1 := time.Parse(time.RFC3339, job.StartedAt)
+		e, err2 := time.Parse(time.RFC3339, job.CompletedAt)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		starts = append(starts, s)
+		ends = append(ends, e)
+	}
+	if len(starts) == 0 {
+		return 0
+	}
+	minStart := starts[0]
+	maxEnd := ends[0]
+	for _, t := range starts[1:] {
+		if t.Before(minStart) {
+			minStart = t
+		}
+	}
+	for _, t := range ends[1:] {
+		if t.After(maxEnd) {
+			maxEnd = t
+		}
+	}
+	return maxEnd.Sub(minStart).Seconds()
+}
+
+func evaluateQualification(runs []RunObservation, opts QualificationOptions) QualificationRecord {
+	rec := QualificationRecord{
+		CurrentWorkflow:  "CI",
+		OwnerDisposition: "pending",
+		GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Group runs by workflow, then match by head_sha.
+	currentBySHA := map[string]RunObservation{}
+	candidateBySHA := map[string]RunObservation{}
+	candidateWfName := ""
+	for _, run := range runs {
+		if run.Workflow == "CI" {
+			currentBySHA[run.HeadSHA] = run
+		} else {
+			candidateBySHA[run.HeadSHA] = run
+			if candidateWfName == "" {
+				candidateWfName = run.Workflow
+			}
+		}
+	}
+	rec.CandidateWorkflow = candidateWfName
+
+	// Matched pairs: head_sha present in both workflows, both completed.
+	type matchedPair struct {
+		sha       string
+		current   RunObservation
+		candidate RunObservation
+	}
+	var pairs []matchedPair
+	for sha, current := range currentBySHA {
+		candidate, exists := candidateBySHA[sha]
+		if !exists {
+			continue
+		}
+		if current.Status != "completed" || candidate.Status != "completed" {
+			continue
+		}
+		pairs = append(pairs, matchedPair{sha: sha, current: current, candidate: candidate})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		return pairs[i].current.CreatedAt < pairs[j].current.CreatedAt
+	})
+
+	rec.SampleCount = len(pairs)
+	if len(pairs) > 0 {
+		rec.EarliestRun = pairs[0].current.CreatedAt
+		rec.LatestRun = pairs[len(pairs)-1].current.CreatedAt
+		if earliest, err := time.Parse(time.RFC3339, rec.EarliestRun); err == nil {
+			if latest, err := time.Parse(time.RFC3339, rec.LatestRun); err == nil {
+				rec.DateSpanDays = latest.Sub(earliest).Hours() / 24
+			}
+		}
+	}
+
+	// Check run count.
+	if rec.SampleCount < opts.MinimumRuns {
+		rec.Status = "insufficient"
+		rec.Reason = fmt.Sprintf("sample count %d below minimum %d", rec.SampleCount, opts.MinimumRuns)
+		return rec
+	}
+
+	// Check date span.
+	if rec.DateSpanDays < float64(opts.MinimumDays) {
+		rec.Status = "insufficient"
+		rec.Reason = fmt.Sprintf("date span %.1f days below minimum %d", rec.DateSpanDays, opts.MinimumDays)
+		return rec
+	}
+
+	// Check for identical-tree divergence (before success checks: a candidate
+	// failure where the current succeeded IS the divergence we look for).
+	for _, p := range pairs {
+		if p.current.Conclusion != p.candidate.Conclusion {
+			rec.Divergences = append(rec.Divergences, Divergence{
+				HeadSHA:         p.sha,
+				CurrentResult:   p.current.Conclusion,
+				CandidateResult: p.candidate.Conclusion,
+			})
+		}
+	}
+	if len(rec.Divergences) > 0 {
+		rec.Status = "divergent"
+		rec.Reason = fmt.Sprintf("%d unexplained identical-tree divergence(s)", len(rec.Divergences))
+		return rec
+	}
+
+	// Check for vacuous candidate jobs, require success, and collect wall times.
+	var wallTimes []float64
+	var totalOccupancy float64
+	for _, p := range pairs {
+		if len(p.candidate.Jobs) == 0 {
+			rec.Status = "insufficient"
+			rec.Reason = "candidate run " + p.sha + " has no jobs (vacuous)"
+			return rec
+		}
+		if p.candidate.Conclusion != "success" {
+			rec.Status = "insufficient"
+			rec.Reason = "candidate run " + p.sha + " did not succeed (" + p.candidate.Conclusion + ")"
+			return rec
+		}
+		if p.current.Conclusion != "success" {
+			rec.Status = "insufficient"
+			rec.Reason = "current run " + p.sha + " did not succeed (" + p.current.Conclusion + ")"
+			return rec
+		}
+		wt := p.candidate.wallTime()
+		if wt > 0 {
+			wallTimes = append(wallTimes, wt)
+		}
+		for _, job := range p.candidate.Jobs {
+			totalOccupancy += job.RuntimeSeconds
+		}
+		if p.candidate.Event == "" {
+			rec.Status = "insufficient"
+			rec.Reason = "candidate run " + p.sha + " has no event metadata"
+			return rec
+		}
+	}
+
+	// Compute p50/p95.
+	rec.P50Seconds = percentile(wallTimes, 0.50)
+	rec.P95Seconds = percentile(wallTimes, 0.95)
+	rec.RunnerOccupancy = totalOccupancy / float64(len(pairs))
+
+	// Check p95 bound.
+	if rec.P95Seconds > opts.MaxP95Seconds {
+		rec.Status = "insufficient"
+		rec.Reason = fmt.Sprintf("p95 %.0fs exceeds bound %.0fs", rec.P95Seconds, opts.MaxP95Seconds)
+		return rec
+	}
+
+	rec.Status = "qualified"
+	rec.OwnerDisposition = "qualified"
+	rec.Reason = ""
+	return rec
+}
+
+func percentile(values []float64, p float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	idx := int(math.Ceil(p*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func loadFromFixtures(dir string) ([]RunObservation, error) {
+	var all []RunObservation
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var runs []RunObservation
+		if err := json.Unmarshal(data, &runs); err != nil {
+			// Try single object.
+			var single RunObservation
+			if err2 := json.Unmarshal(data, &single); err2 != nil {
+				return nil, fmt.Errorf("%s: %w", entry.Name(), err)
+			}
+			runs = []RunObservation{single}
+		}
+		all = append(all, runs...)
+	}
+	return all, nil
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("ciobserve", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	fixturesDir := flags.String("fixtures", "", "directory of JSON run fixtures to evaluate")
+	outputPath := flags.String("output", "", "write qualification JSON to this path")
+	minRuns := flags.Int("minimum-runs", 20, "minimum matched run pairs for qualification")
+	minDays := flags.Int("minimum-days", 7, "minimum date span in days for qualification")
+	maxP95 := flags.Float64("max-p95-seconds", 480, "maximum p95 wall time in seconds")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	if *fixturesDir == "" {
+		fmt.Fprintln(stderr, "--fixtures is required")
+		return 2
+	}
+
+	runs, err := loadFromFixtures(*fixturesDir)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if len(runs) == 0 {
+		fmt.Fprintln(stderr, "no runs loaded from fixtures")
+		return 2
+	}
+
+	opts := QualificationOptions{
+		MinimumRuns:   *minRuns,
+		MinimumDays:   *minDays,
+		MaxP95Seconds: *maxP95,
+	}
+	rec := evaluateQualification(runs, opts)
+
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+
+	if *outputPath != "" {
+		if err := os.WriteFile(*outputPath, data, 0o644); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+	} else {
+		fmt.Fprintln(stdout, string(data))
+	}
+
+	if rec.Status == "qualified" {
+		return 0
+	}
+	return 1
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/tools/ciobserve/main_test.go
+++ b/tools/ciobserve/main_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func makeRun(workflow, sha, event, conclusion string, created time.Time, jobSeconds float64) RunObservation {
+	return RunObservation{
+		Workflow:    workflow,
+		RunID:       created.Unix(),
+		Event:       event,
+		Attempt:     1,
+		HeadSHA:     sha,
+		HeadBranch:  "main",
+		CheckoutSHA: sha,
+		CreatedAt:   created.UTC().Format(time.RFC3339),
+		Status:      "completed",
+		Conclusion:  conclusion,
+		Jobs: []JobObservation{{
+			Name:           workflow + "-job",
+			Status:         "completed",
+			Conclusion:     conclusion,
+			StartedAt:      created.UTC().Format(time.RFC3339),
+			CompletedAt:    created.Add(time.Duration(jobSeconds) * time.Second).UTC().Format(time.RFC3339),
+			RuntimeSeconds: jobSeconds,
+			RunnerOS:       "ubuntu-latest",
+		}},
+	}
+}
+
+func makePair(sha, event string, day int, currentOK, candidateOK bool, secs float64) []RunObservation {
+	cc := "success"
+	if !currentOK {
+		cc = "failure"
+	}
+	ct := "success"
+	if !candidateOK {
+		ct = "failure"
+	}
+	t := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC).AddDate(0, 0, day)
+	return []RunObservation{
+		makeRun("CI", sha, event, cc, t, secs),
+		makeRun("CI Shadow", sha, event, ct, t.Add(time.Minute), secs),
+	}
+}
+
+func TestQualification(t *testing.T) {
+	opts := QualificationOptions{MinimumRuns: 20, MinimumDays: 7, MaxP95Seconds: 480}
+
+	// Helper: build N matched pairs spanning `days` days.
+	buildPairs := func(n, days int, allOK bool, p95Secs float64) []RunObservation {
+		var runs []RunObservation
+		for i := 0; i < n; i++ {
+			day := i * days / max(n-1, 1)
+			sha := "sha" + string(rune('a'+i))
+			runs = append(runs, makePair(sha, "pull_request", day, allOK, allOK, p95Secs*0.9)...)
+		}
+		return runs
+	}
+
+	tests := []struct {
+		name     string
+		runs     []RunObservation
+		want     string
+		wantCode int // 0 qualified, 1 insufficient/divergent
+	}{
+		{
+			name: "qualified",
+			runs: buildPairs(20, 7, true, 300),
+			want: "qualified",
+		},
+		{
+			name: "insufficient run count",
+			runs: buildPairs(5, 7, true, 300),
+			want: "insufficient",
+		},
+		{
+			name: "insufficient date span",
+			runs: buildPairs(20, 3, true, 300),
+			want: "insufficient",
+		},
+		{
+			name: "divergent identical tree",
+			runs: func() []RunObservation {
+				runs := buildPairs(20, 7, true, 300)
+				// Make the 10th pair divergent: current success, candidate failure
+				runs[19].Conclusion = "failure" // CI Shadow run for pair 9
+				return runs
+			}(),
+			want: "divergent",
+		},
+		{
+			name: "vacuous candidate jobs",
+			runs: func() []RunObservation {
+				runs := buildPairs(20, 7, true, 300)
+				// Empty the jobs of one candidate run
+				runs[19].Jobs = nil
+				return runs
+			}(),
+			want: "insufficient",
+		},
+		{
+			name: "p95 over bound",
+			runs: buildPairs(20, 7, true, 600),
+			want: "insufficient",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := evaluateQualification(tt.runs, opts)
+			if rec.Status != tt.want {
+				t.Fatalf("status = %q (%s), want %q", rec.Status, rec.Reason, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunFixtures(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "qualification.json")
+
+	// Write a small fixture set: 2 matched pairs (insufficient).
+	fixture := makePair("sha-a", "pull_request", 0, true, true, 200)
+	fixture = append(fixture, makePair("sha-b", "pull_request", 1, true, true, 220)...)
+	data, err := json.Marshal(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "runs.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytesLike
+	code := run([]string{"--fixtures", dir, "--output", out, "--minimum-runs", "20", "--minimum-days", "7"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (insufficient); stderr=%s", code, stderr.String())
+	}
+
+	rec, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var qr QualificationRecord
+	if err := json.Unmarshal(rec, &qr); err != nil {
+		t.Fatal(err)
+	}
+	if qr.Status != "insufficient" {
+		t.Fatalf("status = %q, want insufficient", qr.Status)
+	}
+	if qr.SampleCount != 2 {
+		t.Fatalf("sample_count = %d, want 2", qr.SampleCount)
+	}
+}
+
+func TestP50P95(t *testing.T) {
+	times := []float64{100, 200, 300, 400, 500}
+	p50 := percentile(times, 0.50)
+	p95 := percentile(times, 0.95)
+	if p50 != 300 {
+		t.Fatalf("p50 = %v, want 300", p50)
+	}
+	if p95 != 500 {
+		t.Fatalf("p95 = %v, want 500", p95)
+	}
+}
+
+type bytesLike struct {
+	b []byte
+}
+
+func (b *bytesLike) Write(p []byte) (int, error) { b.b = append(b.b, p...); return len(p), nil }
+func (b *bytesLike) String() string              { return string(b.b) }

--- a/tools/ciobserve/testdata/example-runs.json
+++ b/tools/ciobserve/testdata/example-runs.json
@@ -1,0 +1,64 @@
+[
+  {
+    "workflow": "CI",
+    "run_id": 1001,
+    "event": "pull_request",
+    "attempt": 1,
+    "head_sha": "fixture-sha-001",
+    "head_branch": "feature/example",
+    "checkout_sha": "merge-sha-001",
+    "created_at": "2026-08-13T10:00:00Z",
+    "status": "completed",
+    "conclusion": "success",
+    "jobs": [
+      {"name": "build", "status": "completed", "conclusion": "success", "started_at": "2026-08-13T10:00:30Z", "completed_at": "2026-08-13T10:01:30Z", "runtime_seconds": 60, "runner_os": "ubuntu-latest"},
+      {"name": "ci-required", "status": "completed", "conclusion": "success", "started_at": "2026-08-13T10:08:00Z", "completed_at": "2026-08-13T10:08:05Z", "runtime_seconds": 5, "runner_os": "ubuntu-latest"}
+    ]
+  },
+  {
+    "workflow": "CI Shadow",
+    "run_id": 2001,
+    "event": "pull_request",
+    "attempt": 1,
+    "head_sha": "fixture-sha-001",
+    "head_branch": "feature/example",
+    "checkout_sha": "merge-sha-001",
+    "created_at": "2026-08-13T10:00:31Z",
+    "status": "completed",
+    "conclusion": "success",
+    "jobs": [
+      {"name": "linux-race-parity", "status": "completed", "conclusion": "success", "started_at": "2026-08-13T10:00:30Z", "completed_at": "2026-08-13T10:06:00Z", "runtime_seconds": 330, "runner_os": "ubuntu-latest"},
+      {"name": "postgres-contract", "status": "completed", "conclusion": "success", "started_at": "2026-08-13T10:00:30Z", "completed_at": "2026-08-13T10:02:00Z", "runtime_seconds": 90, "runner_os": "ubuntu-latest"}
+    ]
+  },
+  {
+    "workflow": "CI",
+    "run_id": 1002,
+    "event": "pull_request",
+    "attempt": 1,
+    "head_sha": "fixture-sha-002",
+    "head_branch": "feature/another",
+    "checkout_sha": "merge-sha-002",
+    "created_at": "2026-08-14T12:00:00Z",
+    "status": "completed",
+    "conclusion": "success",
+    "jobs": [
+      {"name": "build", "status": "completed", "conclusion": "success", "started_at": "2026-08-14T12:00:30Z", "completed_at": "2026-08-14T12:01:30Z", "runtime_seconds": 60, "runner_os": "ubuntu-latest"}
+    ]
+  },
+  {
+    "workflow": "CI Shadow",
+    "run_id": 2002,
+    "event": "pull_request",
+    "attempt": 1,
+    "head_sha": "fixture-sha-002",
+    "head_branch": "feature/another",
+    "checkout_sha": "merge-sha-002",
+    "created_at": "2026-08-14T12:00:31Z",
+    "status": "completed",
+    "conclusion": "success",
+    "jobs": [
+      {"name": "linux-race-parity", "status": "completed", "conclusion": "success", "started_at": "2026-08-14T12:00:30Z", "completed_at": "2026-08-14T12:05:00Z", "runtime_seconds": 270, "runner_os": "ubuntu-latest"}
+    ]
+  }
+]

--- a/tools/civalidate/main.go
+++ b/tools/civalidate/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -59,6 +61,17 @@ const (
 	ProblemPlatformUnowned         ProblemCode        = "platform-unowned"
 	ProblemPlatformStale           ProblemCode        = "platform-stale"
 	ProblemPlatformParse           ProblemCode        = "platform-parse"
+	ProblemShardEmpty              ProblemCode        = "shard-empty"
+	ProblemShardDuplicate          ProblemCode        = "shard-duplicate"
+	ProblemShardMissing            ProblemCode        = "shard-missing"
+	ProblemShardUnowned            ProblemCode        = "shard-unowned"
+	ProblemServiceSelectorEmpty    ProblemCode        = "service-selector-empty"
+	ProblemServiceTestDrift        ProblemCode        = "service-test-drift"
+	ProblemServicePinMissing       ProblemCode        = "service-pin-missing"
+	ProblemShadowJobMissing        ProblemCode        = "shadow-job-missing"
+	ProblemFuzzTargetUnowned       ProblemCode        = "fuzz-target-unowned"
+	ProblemFuzzTargetStale         ProblemCode        = "fuzz-target-stale"
+	ProblemFuzzScheduledEmpty      ProblemCode        = "fuzz-scheduled-empty"
 	PlatformSignalFilenameSuffix   PlatformSignalKind = "filename-suffix"
 	PlatformSignalBuildExpression  PlatformSignalKind = "build-expression"
 	PlatformSignalRuntimeGOOS      PlatformSignalKind = "runtime-goos"
@@ -170,9 +183,66 @@ type PackageOwnership struct {
 }
 
 type PackageOwnershipManifest struct {
-	SchemaVersion int                `yaml:"schema_version"`
-	Module        string             `yaml:"module"`
-	Packages      []PackageOwnership `yaml:"packages"`
+	SchemaVersion   int                `yaml:"schema_version"`
+	Module          string             `yaml:"module"`
+	Packages        []PackageOwnership `yaml:"packages"`
+	LinuxRaceShards *LinuxRaceShards   `yaml:"linux_race_shards"`
+}
+
+type Shard struct {
+	ID       string   `yaml:"id"`
+	Packages []string `yaml:"packages"`
+}
+
+type LinuxRaceShards struct {
+	Workflow string  `yaml:"workflow"`
+	Shards   []Shard `yaml:"shards"`
+}
+
+type ServiceImage struct {
+	Repository string `yaml:"repository"`
+	Tag        string `yaml:"tag"`
+	Digest     string `yaml:"digest"`
+}
+
+type ServiceClient struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	SHA256 string `yaml:"sha256"`
+}
+
+type ServiceContract struct {
+	ID            string         `yaml:"id"`
+	Workflow      string         `yaml:"workflow"`
+	Job           string         `yaml:"job"`
+	Image         ServiceImage   `yaml:"image"`
+	Client        *ServiceClient `yaml:"client"`
+	Env           string         `yaml:"env"`
+	Packages      []string       `yaml:"packages"`
+	SelectedTests []string       `yaml:"selected_tests"`
+	Parallel      int            `yaml:"parallel"`
+}
+
+type ServiceContractsManifest struct {
+	SchemaVersion int               `yaml:"schema_version"`
+	Services      []ServiceContract `yaml:"services"`
+}
+
+type FuzzTarget struct {
+	Package       string `yaml:"package"`
+	Target        string `yaml:"target"`
+	Tier          string `yaml:"tier"`
+	BudgetSeconds int    `yaml:"budget_seconds"`
+}
+
+type FuzzTargetsManifest struct {
+	SchemaVersion int          `yaml:"schema_version"`
+	Targets       []FuzzTarget `yaml:"targets"`
+}
+
+type DiscoveredFuzzTarget struct {
+	Package string
+	Target  string
 }
 
 type PlatformContract struct {
@@ -209,6 +279,8 @@ type Manifests struct {
 	Standards StandardsManifest
 	Packages  PackageOwnershipManifest
 	Platforms PlatformContractsManifest
+	Services  ServiceContractsManifest
+	Fuzz      FuzzTargetsManifest
 }
 
 type WorkflowJob struct {
@@ -228,16 +300,22 @@ type DiscoveredPlatformSignal struct {
 type RepositoryFacts struct {
 	GoPackages          map[string][]string
 	Workflow            WorkflowFacts
+	WorkflowRaw         string
 	MakeTargets         map[string]struct{}
 	DeterminismPackages []string
 	PlatformSignals     []DiscoveredPlatformSignal
 	PlatformParseErrors []string
 	ExistingPaths       map[string]struct{}
+	ExpectedWorkflows   map[string]struct{}
+	ServiceTests        map[string][]string
+	FuzzTargets         []DiscoveredFuzzTarget
 }
 
 var (
-	idPattern  = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
-	ownerTiers = setOf(
+	idPattern       = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	shaPattern      = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	checksumPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	ownerTiers      = setOf(
 		"merge-required-ci", "pr-advisory", "scheduled-diagnostics",
 		"release-certification", "local-pre-push", "human-review",
 	)
@@ -253,6 +331,7 @@ var (
 		string(PlatformSignalPlatformImport), string(PlatformSignalReviewedGeneric),
 	)
 	diagnosticFormats = setOf("text", "diff", "go-test-json", "github-annotation", "sarif", "service-logs", "review-record", "provenance", "benchmark-data")
+	fuzzTiers         = setOf("pr", "scheduled")
 	goosNames         = setOf("aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "ios", "js", "linux", "netbsd", "openbsd", "plan9", "solaris", "wasip1", "windows", "unix")
 	filenameGOOSNames = setOf("aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "ios", "js", "linux", "netbsd", "openbsd", "plan9", "solaris", "wasip1", "windows")
 	goarchNames       = setOf("386", "amd64", "arm", "arm64", "loong64", "mips", "mipsle", "mips64", "mips64le", "ppc64", "ppc64le", "riscv64", "s390x", "wasm")
@@ -270,8 +349,16 @@ func parsePlatformContracts(name string, data []byte) (PlatformContractsManifest
 	return parseManifest[PlatformContractsManifest](name, data)
 }
 
+func parseServiceContracts(name string, data []byte) (ServiceContractsManifest, error) {
+	return parseManifest[ServiceContractsManifest](name, data)
+}
+
+func parseFuzzTargets(name string, data []byte) (FuzzTargetsManifest, error) {
+	return parseManifest[FuzzTargetsManifest](name, data)
+}
+
 func parseManifest[T interface {
-	StandardsManifest | PackageOwnershipManifest | PlatformContractsManifest
+	StandardsManifest | PackageOwnershipManifest | PlatformContractsManifest | ServiceContractsManifest | FuzzTargetsManifest
 }](name string, data []byte) (T, error) {
 	var out T
 	if len(bytes.TrimSpace(data)) == 0 {
@@ -296,7 +383,7 @@ func parseManifest[T interface {
 }
 
 func manifestVersion[T interface {
-	StandardsManifest | PackageOwnershipManifest | PlatformContractsManifest
+	StandardsManifest | PackageOwnershipManifest | PlatformContractsManifest | ServiceContractsManifest | FuzzTargetsManifest
 }](m T) int {
 	switch v := any(m).(type) {
 	case StandardsManifest:
@@ -304,6 +391,10 @@ func manifestVersion[T interface {
 	case PackageOwnershipManifest:
 		return v.SchemaVersion
 	case PlatformContractsManifest:
+		return v.SchemaVersion
+	case ServiceContractsManifest:
+		return v.SchemaVersion
+	case FuzzTargetsManifest:
 		return v.SchemaVersion
 	default:
 		return 0
@@ -369,6 +460,7 @@ func validateStatic(m Manifests) Problems {
 	}
 
 	packagePaths := map[string]struct{}{}
+	packageClass := map[string]PackageClass{}
 	for i, pkg := range m.Packages.Packages {
 		path := fmt.Sprintf("packages[%d]", i)
 		require(&problems, path+".path", pkg.Path)
@@ -377,6 +469,7 @@ func validateStatic(m Manifests) Problems {
 			problems.add(ProblemDuplicateID, path+".path", "duplicate package "+pkg.Path)
 		}
 		packagePaths[pkg.Path] = struct{}{}
+		packageClass[pkg.Path] = pkg.Class
 		if _, exists := witnessIDs[pkg.Owner]; len(witnessIDs) > 0 && !exists {
 			problems.add(ProblemDanglingReference, path+".owner", "unknown witness "+pkg.Owner)
 		}
@@ -384,6 +477,10 @@ func validateStatic(m Manifests) Problems {
 			checkEnum(&problems, fmt.Sprintf("%s.roles[%d]", path, ri), string(role), packageRoles)
 		}
 	}
+
+	validateShardsStatic(&problems, m, packagePaths, packageClass)
+	validateServicesStatic(&problems, m, packagePaths)
+	validateFuzzStatic(&problems, m, packagePaths)
 
 	contractIDs := map[string]struct{}{}
 	focused := map[string]int{}
@@ -499,20 +596,22 @@ func validateRepository(m Manifests, facts RepositoryFacts) Problems {
 	}
 
 	requiredJobs := map[string]struct{}{}
+	known := knownWorkflowNames(m, facts)
 	for _, standard := range m.Standards.Standards {
 		for _, witness := range standard.Witnesses {
 			if witness.Job != nil {
-				if witness.Job.Workflow != facts.Workflow.Name {
-					problems.add(ProblemWorkflowMismatch, "workflow.name", fmt.Sprintf("witness %s references workflow %s, found %s", witness.ID, witness.Job.Workflow, facts.Workflow.Name))
-				}
-				if _, exists := facts.Workflow.Jobs[witness.Job.ID]; !exists {
-					problems.add(ProblemWorkflowJobMissing, "workflow.jobs", "missing workflow job "+witness.Job.ID)
-				}
-				if witness.Status == "required" {
-					if witness.Job.Aggregate {
-						requiredJobs[witness.Job.ID] = struct{}{}
-					} else {
-						problems.add(ProblemAggregateMissing, "standards.witnesses."+witness.ID, "required workflow witness is not declared aggregate-owned")
+				if _, declared := known[witness.Job.Workflow]; !declared {
+					problems.add(ProblemWorkflowMismatch, "workflow.name", fmt.Sprintf("witness %s references undeclared workflow %s", witness.ID, witness.Job.Workflow))
+				} else if witness.Job.Workflow == facts.Workflow.Name {
+					if _, exists := facts.Workflow.Jobs[witness.Job.ID]; !exists {
+						problems.add(ProblemWorkflowJobMissing, "workflow.jobs", "missing workflow job "+witness.Job.ID)
+					}
+					if witness.Status == "required" {
+						if witness.Job.Aggregate {
+							requiredJobs[witness.Job.ID] = struct{}{}
+						} else {
+							problems.add(ProblemAggregateMissing, "standards.witnesses."+witness.ID, "required workflow witness is not declared aggregate-owned")
+						}
 					}
 				}
 			}
@@ -524,8 +623,12 @@ func validateRepository(m Manifests, facts RepositoryFacts) Problems {
 		}
 	}
 	for _, aggregate := range m.Standards.Aggregates {
+		if _, declared := known[aggregate.Workflow]; !declared {
+			problems.add(ProblemWorkflowMismatch, "workflow.name", fmt.Sprintf("aggregate references undeclared workflow %s", aggregate.Workflow))
+			continue
+		}
 		if aggregate.Workflow != facts.Workflow.Name {
-			problems.add(ProblemWorkflowMismatch, "workflow.name", fmt.Sprintf("aggregate references workflow %s, found %s", aggregate.Workflow, facts.Workflow.Name))
+			continue
 		}
 		job, exists := facts.Workflow.Jobs[aggregate.Job]
 		if !exists {
@@ -542,6 +645,83 @@ func validateRepository(m Manifests, facts RepositoryFacts) Problems {
 			if _, exists := requiredJobs[id]; !exists {
 				problems.add(ProblemAggregateExtra, "workflow.jobs."+aggregate.Job, "aggregate includes undeclared job "+id)
 			}
+		}
+	}
+
+	if shards := m.Packages.LinuxRaceShards; shards != nil {
+		if _, declared := known[shards.Workflow]; !declared {
+			problems.add(ProblemWorkflowMismatch, "linux_race_shards.workflow", "shards reference undeclared workflow "+shards.Workflow)
+		} else if shards.Workflow == facts.Workflow.Name {
+			for _, shard := range shards.Shards {
+				if _, exists := facts.Workflow.Jobs[shard.ID]; !exists {
+					problems.add(ProblemShadowJobMissing, "workflow.jobs", "missing shard job "+shard.ID)
+				}
+			}
+		}
+	}
+	for _, service := range m.Services.Services {
+		if _, declared := known[service.Workflow]; !declared {
+			problems.add(ProblemWorkflowMismatch, "services."+service.ID, "service references undeclared workflow "+service.Workflow)
+			continue
+		}
+		if service.Workflow != facts.Workflow.Name {
+			continue
+		}
+		if _, exists := facts.Workflow.Jobs[service.Job]; !exists {
+			problems.add(ProblemShadowJobMissing, "workflow.jobs", "missing service job "+service.Job)
+		}
+		if !strings.Contains(facts.WorkflowRaw, service.Image.Digest) {
+			problems.add(ProblemServicePinMissing, "workflow.jobs."+service.Job, "workflow does not use the pinned image digest for "+service.ID)
+		}
+		if service.Client != nil && !strings.Contains(facts.WorkflowRaw, service.Client.SHA256) {
+			problems.add(ProblemServicePinMissing, "workflow.jobs."+service.Job, "workflow does not use the pinned client checksum for "+service.ID)
+		}
+	}
+	if facts.ServiceTests != nil {
+		for _, service := range m.Services.Services {
+			selected := sliceSet(service.SelectedTests)
+			found := sliceSet(facts.ServiceTests[service.ID])
+			for _, test := range service.SelectedTests {
+				if _, exists := found[test]; !exists {
+					problems.add(ProblemServiceTestDrift, "services."+service.ID, "selected test not discovered: "+test)
+				}
+			}
+			for _, test := range facts.ServiceTests[service.ID] {
+				if _, exists := selected[test]; !exists {
+					problems.add(ProblemServiceTestDrift, "services."+service.ID, "discovered test not selected: "+test)
+				}
+			}
+			if len(service.SelectedTests) > 0 && len(facts.ServiceTests[service.ID]) == 0 {
+				problems.add(ProblemServiceTestDrift, "services."+service.ID, "service test discovery returned no tests")
+			}
+		}
+	}
+
+	if facts.FuzzTargets != nil {
+		inventory := map[string]struct{}{}
+		scheduled := 0
+		for _, target := range m.Fuzz.Targets {
+			inventory[target.Package+"|"+target.Target] = struct{}{}
+			if target.Tier == "scheduled" {
+				scheduled++
+			}
+		}
+		for _, target := range facts.FuzzTargets {
+			if _, exists := inventory[target.Package+"|"+target.Target]; !exists {
+				problems.add(ProblemFuzzTargetUnowned, "fuzz_targets", "source fuzz target missing from inventory: "+target.Package+" "+target.Target)
+			}
+		}
+		source := map[string]struct{}{}
+		for _, target := range facts.FuzzTargets {
+			source[target.Package+"|"+target.Target] = struct{}{}
+		}
+		for _, target := range m.Fuzz.Targets {
+			if _, exists := source[target.Package+"|"+target.Target]; !exists {
+				problems.add(ProblemFuzzTargetStale, "fuzz_targets", "inventory fuzz target no longer in source: "+target.Package+" "+target.Target)
+			}
+		}
+		if len(m.Fuzz.Targets) > 0 && scheduled == 0 {
+			problems.add(ProblemFuzzScheduledEmpty, "fuzz_targets", "scheduled fuzz suite is empty")
 		}
 	}
 
@@ -609,6 +789,117 @@ func validateRepository(m Manifests, facts RepositoryFacts) Problems {
 	}
 	problems.sort()
 	return problems
+}
+
+func knownWorkflowNames(m Manifests, facts RepositoryFacts) map[string]struct{} {
+	names := map[string]struct{}{facts.Workflow.Name: {}}
+	for name := range facts.ExpectedWorkflows {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func validateShardsStatic(problems *Problems, m Manifests, packagePaths map[string]struct{}, packageClass map[string]PackageClass) {
+	shards := m.Packages.LinuxRaceShards
+	if shards == nil {
+		return
+	}
+	require(problems, "linux_race_shards.workflow", shards.Workflow)
+	shardIDs := map[string]struct{}{}
+	covered := map[string]struct{}{}
+	for i, shard := range shards.Shards {
+		path := fmt.Sprintf("linux_race_shards.shards[%d]", i)
+		require(problems, path+".id", shard.ID)
+		if _, exists := shardIDs[shard.ID]; exists {
+			problems.add(ProblemDuplicateID, path+".id", "duplicate shard "+shard.ID)
+		}
+		shardIDs[shard.ID] = struct{}{}
+		if len(shard.Packages) == 0 {
+			problems.add(ProblemShardEmpty, path+".packages", "shard "+shard.ID+" has no packages")
+		}
+		for _, pkg := range shard.Packages {
+			if _, exists := covered[pkg]; exists {
+				problems.add(ProblemShardDuplicate, path+".packages", "package in more than one shard: "+pkg)
+			}
+			covered[pkg] = struct{}{}
+			class, exists := packageClass[pkg]
+			if len(packagePaths) > 0 && !exists {
+				problems.add(ProblemShardUnowned, path+".packages", "shard package is not owned: "+pkg)
+				continue
+			}
+			if class != "test-owned" && class != "helper-library" {
+				problems.add(ProblemShardUnowned, path+".packages", "shard package is not ordinary test-owned code: "+pkg)
+			}
+		}
+	}
+	if len(packagePaths) > 0 {
+		for pkg, class := range packageClass {
+			if class != "test-owned" && class != "helper-library" {
+				continue
+			}
+			if _, exists := covered[pkg]; !exists {
+				problems.add(ProblemShardMissing, "linux_race_shards", "ordinary package is in no shard: "+pkg)
+			}
+		}
+	}
+}
+
+func validateServicesStatic(problems *Problems, m Manifests, packagePaths map[string]struct{}) {
+	serviceIDs := map[string]struct{}{}
+	for i, service := range m.Services.Services {
+		path := fmt.Sprintf("services[%d]", i)
+		require(problems, path+".id", service.ID)
+		if _, exists := serviceIDs[service.ID]; exists {
+			problems.add(ProblemDuplicateID, path+".id", "duplicate service "+service.ID)
+		}
+		serviceIDs[service.ID] = struct{}{}
+		require(problems, path+".workflow", service.Workflow)
+		require(problems, path+".job", service.Job)
+		require(problems, path+".env", service.Env)
+		require(problems, path+".image.repository", service.Image.Repository)
+		if !shaPattern.MatchString(service.Image.Digest) {
+			problems.add(ProblemServicePinMissing, path+".image.digest", "service image is not pinned by sha256 digest")
+		}
+		if service.Client != nil {
+			require(problems, path+".client.name", service.Client.Name)
+			require(problems, path+".client.url", service.Client.URL)
+			if !checksumPattern.MatchString(service.Client.SHA256) {
+				problems.add(ProblemServicePinMissing, path+".client.sha256", "service client is not pinned by sha256 checksum")
+			}
+		}
+		if len(service.Packages) == 0 {
+			problems.add(ProblemServiceSelectorEmpty, path+".packages", "service has no packages")
+		}
+		for _, pkg := range service.Packages {
+			if _, exists := packagePaths[pkg]; len(packagePaths) > 0 && !exists {
+				problems.add(ProblemDanglingReference, path+".packages", "unknown package "+pkg)
+			}
+		}
+		if len(service.SelectedTests) == 0 {
+			problems.add(ProblemServiceSelectorEmpty, path+".selected_tests", "service selector is empty (tests would silently skip)")
+		}
+	}
+}
+
+func validateFuzzStatic(problems *Problems, m Manifests, packagePaths map[string]struct{}) {
+	pairs := map[string]struct{}{}
+	for i, target := range m.Fuzz.Targets {
+		path := fmt.Sprintf("fuzz_targets[%d]", i)
+		require(problems, path+".package", target.Package)
+		require(problems, path+".target", target.Target)
+		checkEnum(problems, path+".tier", target.Tier, fuzzTiers)
+		if target.BudgetSeconds <= 0 {
+			problems.add(ProblemMissingField, path+".budget_seconds", "fuzz target budget must be positive")
+		}
+		pair := target.Package + "|" + target.Target
+		if _, exists := pairs[pair]; exists {
+			problems.add(ProblemDuplicateID, path, "duplicate fuzz target "+pair)
+		}
+		pairs[pair] = struct{}{}
+		if _, exists := packagePaths[target.Package]; len(packagePaths) > 0 && !exists && target.Package != "" {
+			problems.add(ProblemDanglingReference, path+".package", "unknown package "+target.Package)
+		}
+	}
 }
 
 func listGoPackages(ctx context.Context, root string, platforms []string) (map[string][]string, error) {
@@ -812,14 +1103,62 @@ func scanGoFile(path string, data []byte) (map[PlatformSignalKind]struct{}, erro
 	return kinds, nil
 }
 
-func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+var fuzzFuncPattern = regexp.MustCompile(`^func (Fuzz[A-Za-z0-9_]+)\(`)
+
+func scanFuzzTargets(fsys fs.FS) ([]DiscoveredFuzzTarget, error) {
+	var targets []DiscoveredFuzzTarget
+	err := fs.WalkDir(fsys, ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if path != "." && shouldSkipDir(entry.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		dir := filepath.ToSlash(filepath.Dir(path))
+		for _, line := range strings.Split(string(data), "\n") {
+			match := fuzzFuncPattern.FindStringSubmatch(strings.TrimSpace(line))
+			if match != nil {
+				targets = append(targets, DiscoveredFuzzTarget{Package: dir, Target: match[1]})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].Package != targets[j].Package {
+			return targets[i].Package < targets[j].Package
+		}
+		return targets[i].Target < targets[j].Target
+	})
+	return targets, nil
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("civalidate", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	standardsPath := flags.String("standards", "ci/standards.yaml", "standards manifest")
 	packagesPath := flags.String("packages", "ci/package-ownership.yaml", "package ownership manifest")
 	platformsPath := flags.String("platforms", "ci/platform-contracts.yaml", "platform contracts manifest")
+	servicesPath := flags.String("services", "ci/service-contracts.yaml", "service contracts manifest")
+	fuzzTargetsPath := flags.String("fuzz-targets", "ci/fuzz-targets.yaml", "fuzz targets manifest")
 	workflowPath := flags.String("workflow", ".github/workflows/ci.yml", "workflow file")
 	makefilePath := flags.String("makefile", "Makefile", "Makefile")
+	printShard := flags.String("print-shard", "", "print the go test package list for a shard and exit")
+	printPlatformPackages := flags.String("print-platform-packages", "", "print the focused contract package list for a GOOS and exit")
+	printServiceRun := flags.String("print-service-run", "", "print the focused go test invocation parts for a service and exit")
+	printFuzzTargetsJSON := flags.String("print-fuzz-targets-json", "", "print fuzz targets for a tier (pr, scheduled, or all) as JSON and exit")
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
@@ -834,6 +1173,16 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	platformsData, err := os.ReadFile(*platformsPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	servicesData, err := os.ReadFile(*servicesPath)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	fuzzData, err := os.ReadFile(*fuzzTargetsPath)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 2
@@ -853,10 +1202,32 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	manifests := Manifests{Standards: standards, Packages: packages, Platforms: platformContracts}
+	services, err := parseServiceContracts(*servicesPath, servicesData)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	fuzz, err := parseFuzzTargets(*fuzzTargetsPath, fuzzData)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	manifests := Manifests{Standards: standards, Packages: packages, Platforms: platformContracts, Services: services, Fuzz: fuzz}
+
+	switch {
+	case *printShard != "":
+		return runPrintShard(manifests, *printShard, stdout, stderr)
+	case *printPlatformPackages != "":
+		return runPrintPlatformPackages(manifests, *printPlatformPackages, stdout, stderr)
+	case *printServiceRun != "":
+		return runPrintServiceRun(manifests, *printServiceRun, stdout, stderr)
+	case *printFuzzTargetsJSON != "":
+		return runPrintFuzzTargetsJSON(manifests, *printFuzzTargetsJSON, stdout, stderr)
+	}
+
 	problems := validateStatic(manifests)
 	if len(problems) == 0 {
-		facts, factErr := collectRepositoryFacts(ctx, manifests, *workflowPath, *makefilePath)
+		facts, factErr := collectRepositoryFacts(context.Background(), manifests, *workflowPath, *makefilePath)
 		if factErr != nil {
 			fmt.Fprintln(stderr, factErr)
 			return 2
@@ -869,8 +1240,157 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) int {
 		}
 		return 1
 	}
-	fmt.Fprintf(stdout, "civalidate: OK (%d standards, %d packages, %d platform contracts)\n", len(standards.Standards), len(packages.Packages), len(platformContracts.Contracts))
+	fmt.Fprintf(stdout, "civalidate: OK (%d standards, %d packages, %d platform contracts, %d services)\n", len(standards.Standards), len(packages.Packages), len(platformContracts.Contracts), len(services.Services))
 	return 0
+}
+
+func goTestPath(path string) string {
+	if path == "." {
+		return "."
+	}
+	return "./" + path
+}
+
+func runPrintShard(m Manifests, id string, stdout, stderr io.Writer) int {
+	shards := m.Packages.LinuxRaceShards
+	if shards == nil {
+		fmt.Fprintln(stderr, "linux_race_shards is not declared")
+		return 1
+	}
+	for _, shard := range shards.Shards {
+		if shard.ID != id {
+			continue
+		}
+		if len(shard.Packages) == 0 {
+			fmt.Fprintf(stderr, "shard %s has no packages\n", id)
+			return 1
+		}
+		paths := make([]string, 0, len(shard.Packages))
+		for _, pkg := range shard.Packages {
+			paths = append(paths, goTestPath(pkg))
+		}
+		fmt.Fprintln(stdout, strings.Join(paths, " "))
+		return 0
+	}
+	fmt.Fprintf(stderr, "shard %s not found\n", id)
+	return 1
+}
+
+func runPrintPlatformPackages(m Manifests, goos string, stdout, stderr io.Writer) int {
+	seen := map[string]struct{}{}
+	var paths []string
+	for _, contract := range m.Platforms.Contracts {
+		if contract.GOOS != goos {
+			continue
+		}
+		if _, exists := seen[contract.Package]; exists {
+			continue
+		}
+		seen[contract.Package] = struct{}{}
+		paths = append(paths, goTestPath(contract.Package))
+	}
+	if len(paths) == 0 {
+		fmt.Fprintf(stderr, "no focused contracts for GOOS %s\n", goos)
+		return 1
+	}
+	fmt.Fprintln(stdout, strings.Join(paths, " "))
+	return 0
+}
+
+func runPrintServiceRun(m Manifests, id string, stdout, stderr io.Writer) int {
+	for _, service := range m.Services.Services {
+		if service.ID != id {
+			continue
+		}
+		if len(service.SelectedTests) == 0 || len(service.Packages) == 0 {
+			fmt.Fprintf(stderr, "service %s has an empty selector\n", id)
+			return 1
+		}
+		paths := make([]string, 0, len(service.Packages))
+		for _, pkg := range service.Packages {
+			paths = append(paths, goTestPath(pkg))
+		}
+		parts := []string{"-run", "^(" + strings.Join(service.SelectedTests, "|") + ")$"}
+		if service.Parallel > 0 {
+			parts = append(parts, "-p", strconv.Itoa(service.Parallel))
+		}
+		parts = append(parts, "-count=1")
+		parts = append(parts, paths...)
+		fmt.Fprintln(stdout, strings.Join(parts, " "))
+		return 0
+	}
+	fmt.Fprintf(stderr, "service %s not found\n", id)
+	return 1
+}
+
+type fuzzTargetJSON struct {
+	Package string `json:"package"`
+	Target  string `json:"target"`
+	Budget  string `json:"budget"`
+}
+
+func runPrintFuzzTargetsJSON(m Manifests, tier string, stdout, stderr io.Writer) int {
+	if tier != "all" {
+		if _, exists := fuzzTiers[tier]; !exists {
+			fmt.Fprintf(stderr, "unknown fuzz tier %q (want pr, scheduled, or all)\n", tier)
+			return 1
+		}
+	}
+	out := []fuzzTargetJSON{}
+	for _, target := range m.Fuzz.Targets {
+		if tier != "all" && target.Tier != tier {
+			continue
+		}
+		out = append(out, fuzzTargetJSON{
+			Package: target.Package,
+			Target:  target.Target,
+			Budget:  strconv.Itoa(target.BudgetSeconds) + "s",
+		})
+	}
+	if len(out) == 0 {
+		fmt.Fprintf(stderr, "no fuzz targets for tier %s\n", tier)
+		return 1
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	fmt.Fprintln(stdout, string(data))
+	return 0
+}
+
+var testNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func discoverServiceTests(ctx context.Context, m Manifests) (map[string][]string, error) {
+	out := map[string][]string{}
+	for _, service := range m.Services.Services {
+		if len(service.SelectedTests) == 0 || len(service.Packages) == 0 {
+			continue
+		}
+		selector := "^(" + strings.Join(service.SelectedTests, "|") + ")$"
+		found := map[string]struct{}{}
+		for _, pkg := range service.Packages {
+			cmd := exec.CommandContext(ctx, "go", "test", "-list", selector, goTestPath(pkg))
+			data, err := cmd.Output()
+			if err != nil {
+				return nil, fmt.Errorf("service %s: test discovery for %s: %w", service.ID, pkg, err)
+			}
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if testNamePattern.MatchString(line) {
+					found[line] = struct{}{}
+				}
+			}
+		}
+		names := make([]string, 0, len(found))
+		for name := range found {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		out[service.ID] = names
+	}
+	return out, nil
 }
 
 func collectRepositoryFacts(ctx context.Context, m Manifests, workflowPath, makefilePath string) (RepositoryFacts, error) {
@@ -903,13 +1423,42 @@ func collectRepositoryFacts(ctx context.Context, m Manifests, workflowPath, make
 		return RepositoryFacts{}, err
 	}
 	signals, scanErr := scanPlatformSignals(os.DirFS("."))
+	fuzzTargets, fuzzErr := scanFuzzTargets(os.DirFS("."))
+	if fuzzErr != nil {
+		return RepositoryFacts{}, fmt.Errorf("fuzz target scan: %w", fuzzErr)
+	}
+	serviceTests, err := discoverServiceTests(ctx, m)
+	if err != nil {
+		return RepositoryFacts{}, err
+	}
+	expectedWorkflows := map[string]struct{}{}
+	if entries, dirErr := os.ReadDir(".github/workflows"); dirErr == nil {
+		for _, entry := range entries {
+			if entry.IsDir() || (!strings.HasSuffix(entry.Name(), ".yml") && !strings.HasSuffix(entry.Name(), ".yaml")) {
+				continue
+			}
+			data, readErr := os.ReadFile(filepath.Join(".github/workflows", entry.Name()))
+			if readErr != nil {
+				continue
+			}
+			if wf, parseErr := parseWorkflow(entry.Name(), data); parseErr == nil && wf.Name != "" {
+				expectedWorkflows[wf.Name] = struct{}{}
+			} else if name := workflowNameOnly(data); name != "" {
+				expectedWorkflows[name] = struct{}{}
+			}
+		}
+	}
 	facts := RepositoryFacts{
 		GoPackages:          packages,
 		Workflow:            workflow,
+		WorkflowRaw:         string(workflowData),
 		MakeTargets:         makeTargets,
 		DeterminismPackages: determinismPackages,
 		PlatformSignals:     signals,
 		ExistingPaths:       map[string]struct{}{},
+		ExpectedWorkflows:   expectedWorkflows,
+		ServiceTests:        serviceTests,
+		FuzzTargets:         fuzzTargets,
 	}
 	if scanErr != nil {
 		facts.PlatformParseErrors = []string{scanErr.Error()}
@@ -932,7 +1481,7 @@ func collectRepositoryFacts(ctx context.Context, m Manifests, workflowPath, make
 }
 
 func main() {
-	os.Exit(run(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
 func mappingRoot(node *yaml.Node) (*yaml.Node, error) {
@@ -940,6 +1489,26 @@ func mappingRoot(node *yaml.Node) (*yaml.Node, error) {
 		return nil, errors.New("expected one mapping document")
 	}
 	return node.Content[0], nil
+}
+
+// workflowNameOnly extracts the top-level `name:` from a workflow document
+// without requiring a `jobs:` mapping. It is used only to build the
+// known-workflow-name set, where a parseable-but-jobs-less file must still
+// contribute its name instead of silently dropping out (which would turn a
+// legitimate cross-workflow reference into a false workflow-mismatch).
+func workflowNameOnly(data []byte) string {
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return ""
+	}
+	root, err := mappingRoot(&node)
+	if err != nil {
+		return ""
+	}
+	if value := mappingValue(root, "name"); value != nil {
+		return value.Value
+	}
+	return ""
 }
 
 func mappingValue(node *yaml.Node, key string) *yaml.Node {

--- a/tools/civalidate/main_test.go
+++ b/tools/civalidate/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -72,6 +75,34 @@ packages:
     class: test-owned
     owner: generated-drift-current
     roles: []
+linux_race_shards:
+  workflow: CI Shadow
+  shards:
+    - id: linux-race-alpha
+      packages: [., internal/manifest]
+    - id: linux-race-beta
+      packages: [pkg/engine, tools/skillgen]
+`
+
+const validServices = `
+schema_version: 1
+services:
+  - id: fixture-db
+    workflow: CI Shadow
+    job: fixture-db-contract
+    image: {repository: pgvector/pgvector, tag: pg16, digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+    env: TEST_DATABASE_URL
+    packages: [internal/manifest]
+    selected_tests: [TestConcurrentManifestUpdates]
+    parallel: 1
+  - id: fixture-object
+    workflow: CI Shadow
+    job: fixture-object-contract
+    image: {repository: minio/minio, tag: latest, digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+    client: {name: mc, url: "https://dl.min.io/client/mc/release/linux-amd64/mc", sha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+    env: SAGE_TEST_MINIO
+    packages: [internal/manifest]
+    selected_tests: [TestConcurrentManifestUpdates]
 `
 
 const validPlatforms = `
@@ -249,7 +280,7 @@ func TestOwnership(t *testing.T) {
 		{
 			name: "duplicate package",
 			edit: func(s string) string {
-				return s + "  - path: .\n    class: test-owned\n    owner: generated-drift-current\n    roles: []\n"
+				return strings.Replace(s, "linux_race_shards:\n", "  - path: .\n    class: test-owned\n    owner: generated-drift-current\n    roles: []\nlinux_race_shards:\n", 1)
 			},
 			code: ProblemDuplicateID,
 		},
@@ -388,6 +419,7 @@ func TestRepositoryValidation(t *testing.T) {
 		},
 		MakeTargets:         map[string]struct{}{},
 		DeterminismPackages: nil,
+		ExpectedWorkflows:   map[string]struct{}{"CI Shadow": {}},
 		PlatformSignals: []DiscoveredPlatformSignal{
 			{Path: "internal/manifest/lock.go", Kind: PlatformSignalRuntimeGOOS},
 		},
@@ -630,6 +662,25 @@ func TestPlatformRuntimeSignalUsesImportedName(t *testing.T) {
 	}
 }
 
+func TestWorkflowNameOnly(t *testing.T) {
+	if name := workflowNameOnly([]byte("name: CI Shadow\non: push\n")); name != "CI Shadow" {
+		t.Fatalf("workflowNameOnly = %q, want CI Shadow", name)
+	}
+	if name := workflowNameOnly([]byte("jobs: {}\n")); name != "" {
+		t.Fatalf("workflowNameOnly = %q, want empty", name)
+	}
+	if name := workflowNameOnly([]byte("not: [valid")); name != "" {
+		t.Fatalf("workflowNameOnly = %q, want empty on malformed input", name)
+	}
+}
+
+const validFuzzTargets = `
+schema_version: 1
+targets:
+  - {package: internal/manifest, target: FuzzWidget, tier: pr, budget_seconds: 30}
+  - {package: pkg/engine, target: FuzzGadget, tier: scheduled, budget_seconds: 60}
+`
+
 func parseValidManifests(t *testing.T) Manifests {
 	t.Helper()
 	standards, err := parseStandards("standards.yaml", []byte(validStandards))
@@ -644,7 +695,507 @@ func parseValidManifests(t *testing.T) Manifests {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return Manifests{Standards: standards, Packages: packages, Platforms: platforms}
+	services, err := parseServiceContracts("service-contracts.yaml", []byte(validServices))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fuzz, err := parseFuzzTargets("fuzz-targets.yaml", []byte(validFuzzTargets))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Manifests{Standards: standards, Packages: packages, Platforms: platforms, Services: services, Fuzz: fuzz}
+}
+
+func TestFuzzTargetsStatic(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(string) string
+		code ProblemCode
+	}{
+		{
+			name: "duplicate package target pair",
+			edit: func(s string) string {
+				return s + "  - {package: internal/manifest, target: FuzzWidget, tier: scheduled, budget_seconds: 60}\n"
+			},
+			code: ProblemDuplicateID,
+		},
+		{
+			name: "unknown tier",
+			edit: func(s string) string {
+				return strings.Replace(s, "tier: pr", "tier: always", 1)
+			},
+			code: ProblemUnknownEnum,
+		},
+		{
+			name: "zero budget",
+			edit: func(s string) string {
+				return strings.Replace(s, "budget_seconds: 30", "budget_seconds: 0", 1)
+			},
+			code: ProblemMissingField,
+		},
+		{
+			name: "unowned fuzz package",
+			edit: func(s string) string {
+				return strings.Replace(s, "package: internal/manifest", "package: package/does-not-exist", 1)
+			},
+			code: ProblemDanglingReference,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests := parseValidManifests(t)
+			fuzz, err := parseFuzzTargets("fuzz-targets.yaml", []byte(tt.edit(validFuzzTargets)))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			manifests.Fuzz = fuzz
+			assertProblemCode(t, validateStatic(manifests), tt.code)
+		})
+	}
+}
+
+func TestFuzzInventory(t *testing.T) {
+	base := func() RepositoryFacts {
+		return RepositoryFacts{
+			GoPackages: map[string][]string{
+				"linux": {
+					"github.com/xoai/sage-wiki",
+					"github.com/xoai/sage-wiki/internal/manifest",
+					"github.com/xoai/sage-wiki/pkg/engine",
+					"github.com/xoai/sage-wiki/tools/skillgen",
+				},
+			},
+			Workflow: WorkflowFacts{
+				Name: "CI",
+				Jobs: map[string]WorkflowJob{
+					"skill-drift": {},
+					"ci-required": {Needs: []string{"skill-drift"}},
+				},
+			},
+			ExpectedWorkflows: map[string]struct{}{"CI Shadow": {}},
+			MakeTargets:       map[string]struct{}{},
+			FuzzTargets: []DiscoveredFuzzTarget{
+				{Package: "internal/manifest", Target: "FuzzWidget"},
+				{Package: "pkg/engine", Target: "FuzzGadget"},
+			},
+			PlatformSignals: []DiscoveredPlatformSignal{
+				{Path: "internal/manifest/lock.go", Kind: PlatformSignalRuntimeGOOS},
+			},
+			ExistingPaths: map[string]struct{}{
+				"skills/":                   {},
+				"internal/web/dist/":        {},
+				"internal/manifest/lock.go": {},
+			},
+		}
+	}
+	if problems := validateRepository(parseValidManifests(t), base()); len(problems) != 0 {
+		t.Fatalf("valid fuzz inventory: %#v", problems)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Manifests, *RepositoryFacts)
+		code   ProblemCode
+	}{
+		{
+			name: "source fuzz target added without inventory",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				facts.FuzzTargets = append(facts.FuzzTargets, DiscoveredFuzzTarget{Package: "internal/manifest", Target: "FuzzSurprise"})
+			},
+			code: ProblemFuzzTargetUnowned,
+		},
+		{
+			name: "removed target kept in inventory",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				facts.FuzzTargets = facts.FuzzTargets[:1]
+			},
+			code: ProblemFuzzTargetStale,
+		},
+		{
+			name: "empty scheduled suite",
+			mutate: func(manifests *Manifests, facts *RepositoryFacts) {
+				manifests.Fuzz.Targets[1].Tier = "pr"
+				facts.FuzzTargets = facts.FuzzTargets[:1]
+			},
+			code: ProblemFuzzScheduledEmpty,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests := parseValidManifests(t)
+			facts := cloneRepositoryFacts(base())
+			tt.mutate(&manifests, &facts)
+			assertProblemCode(t, validateRepository(manifests, facts), tt.code)
+		})
+	}
+}
+
+func TestScanFuzzTargets(t *testing.T) {
+	fsys := fstest.MapFS{
+		"internal/widget/fuzz_test.go":  {Data: []byte("package widget\n\nimport \"testing\"\n\nfunc FuzzAlpha(f *testing.F) {}\n\nfunc TestBeta(t *testing.T) {}\n")},
+		"internal/widget/other_test.go": {Data: []byte("package widget\n\nfunc FuzzGamma(f *testing.F) {}\n")},
+		"internal/plain/plain.go":       {Data: []byte("package plain\n")},
+	}
+	targets, err := scanFuzzTargets(fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]struct{}{
+		"internal/widget|FuzzAlpha": {},
+		"internal/widget|FuzzGamma": {},
+	}
+	if len(targets) != len(want) {
+		t.Fatalf("targets = %#v, want %v", targets, want)
+	}
+	for _, target := range targets {
+		if _, exists := want[target.Package+"|"+target.Target]; !exists {
+			t.Fatalf("unexpected target %#v", target)
+		}
+	}
+}
+
+func TestPrintFuzzTargetsJSON(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	common := []string{
+		"--standards", write("standards.yaml", validStandards),
+		"--packages", write("package-ownership.yaml", validOwnership),
+		"--platforms", write("platform-contracts.yaml", validPlatforms),
+		"--services", write("service-contracts.yaml", validServices),
+		"--fuzz-targets", write("fuzz-targets.yaml", validFuzzTargets),
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := run(append(common, "--print-fuzz-targets-json", "scheduled"), &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"package":"pkg/engine"`) || !strings.Contains(stdout.String(), `"target":"FuzzGadget"`) || !strings.Contains(stdout.String(), `"budget":"60s"`) {
+		t.Fatalf("print-fuzz-targets-json = %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "FuzzWidget") {
+		t.Fatalf("scheduled filter leaked pr targets: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := run(append(common, "--print-fuzz-targets-json", "bogus"), &stdout, &stderr); code == 0 {
+		t.Fatal("unknown tier accepted")
+	}
+}
+
+func TestShards(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(string) string
+		code ProblemCode
+	}{
+		{
+			name: "empty shard packages",
+			edit: func(s string) string {
+				return strings.Replace(s, "packages: [., internal/manifest]", "packages: []", 1)
+			},
+			code: ProblemShardEmpty,
+		},
+		{
+			name: "ordinary package duplicated across shards",
+			edit: func(s string) string {
+				return strings.Replace(s, "packages: [pkg/engine, tools/skillgen]", "packages: [pkg/engine, tools/skillgen, internal/manifest]", 1)
+			},
+			code: ProblemShardDuplicate,
+		},
+		{
+			name: "ordinary package missing from every shard",
+			edit: func(s string) string {
+				return strings.Replace(s, "packages: [pkg/engine, tools/skillgen]", "packages: [pkg/engine]", 1)
+			},
+			code: ProblemShardMissing,
+		},
+		{
+			name: "shard package is unowned",
+			edit: func(s string) string {
+				return strings.Replace(s, "packages: [pkg/engine, tools/skillgen]", "packages: [pkg/engine, tools/skillgen, package/does-not-exist]", 1)
+			},
+			code: ProblemShardUnowned,
+		},
+		{
+			name: "duplicate shard id",
+			edit: func(s string) string {
+				return strings.Replace(s, "id: linux-race-beta", "id: linux-race-alpha", 1)
+			},
+			code: ProblemDuplicateID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests := parseValidManifests(t)
+			packages, err := parsePackageOwnership("package-ownership.yaml", []byte(tt.edit(validOwnership)))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			manifests.Packages = packages
+			assertProblemCode(t, validateStatic(manifests), tt.code)
+		})
+	}
+}
+
+func TestServiceContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		edit func(string) string
+		code ProblemCode
+	}{
+		{
+			name: "skipped service selector",
+			edit: func(s string) string {
+				return strings.Replace(s, "selected_tests: [TestConcurrentManifestUpdates]\n    parallel: 1", "selected_tests: []\n    parallel: 1", 1)
+			},
+			code: ProblemServiceSelectorEmpty,
+		},
+		{
+			name: "service test count drifts",
+			edit: func(s string) string {
+				return strings.Replace(s, "selected_tests: [TestConcurrentManifestUpdates]\n    parallel: 1", "selected_tests: [TestConcurrentManifestUpdates, TestMissingFromDiscovery]\n    parallel: 1", 1)
+			},
+			code: ProblemServiceTestDrift,
+		},
+		{
+			name: "unpinned service image",
+			edit: func(s string) string {
+				return strings.Replace(s, `digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`, `digest: ""`, 1)
+			},
+			code: ProblemServicePinMissing,
+		},
+		{
+			name: "malformed image digest",
+			edit: func(s string) string {
+				return strings.Replace(s, `digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`, `digest: "sha256:short"`, 1)
+			},
+			code: ProblemServicePinMissing,
+		},
+		{
+			name: "unpinned service client",
+			edit: func(s string) string {
+				return strings.Replace(s, `sha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"`, `sha256: ""`, 1)
+			},
+			code: ProblemServicePinMissing,
+		},
+		{
+			name: "duplicate service id",
+			edit: func(s string) string {
+				return strings.Replace(s, "id: fixture-object", "id: fixture-db", 1)
+			},
+			code: ProblemDuplicateID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests := parseValidManifests(t)
+			services, err := parseServiceContracts("service-contracts.yaml", []byte(tt.edit(validServices)))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			manifests.Services = services
+			problems := validateStatic(manifests)
+			if tt.code == ProblemServiceTestDrift {
+				facts := baseShadowFacts(t)
+				problems = append(problems, validateRepository(manifests, facts)...)
+			}
+			assertProblemCode(t, problems, tt.code)
+		})
+	}
+}
+
+func baseShadowFacts(t *testing.T) RepositoryFacts {
+	t.Helper()
+	return RepositoryFacts{
+		GoPackages: map[string][]string{
+			"linux": {
+				"github.com/xoai/sage-wiki",
+				"github.com/xoai/sage-wiki/internal/manifest",
+				"github.com/xoai/sage-wiki/pkg/engine",
+				"github.com/xoai/sage-wiki/tools/skillgen",
+			},
+		},
+		Workflow: WorkflowFacts{
+			Name: "CI Shadow",
+			Jobs: map[string]WorkflowJob{
+				"linux-race-alpha":        {},
+				"linux-race-beta":         {},
+				"fixture-db-contract":     {},
+				"fixture-object-contract": {},
+			},
+		},
+		WorkflowRaw: "image: pgvector/pgvector@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+			"minio/minio@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+			"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n",
+		ExpectedWorkflows: map[string]struct{}{"CI": {}},
+		MakeTargets:       map[string]struct{}{},
+		ServiceTests: map[string][]string{
+			"fixture-db":     {"TestConcurrentManifestUpdates"},
+			"fixture-object": {"TestConcurrentManifestUpdates"},
+		},
+		PlatformSignals: []DiscoveredPlatformSignal{
+			{Path: "internal/manifest/lock.go", Kind: PlatformSignalRuntimeGOOS},
+		},
+		ExistingPaths: map[string]struct{}{
+			"skills/":                   {},
+			"internal/web/dist/":        {},
+			"internal/manifest/lock.go": {},
+		},
+	}
+}
+
+func TestShadowWorkflowValidation(t *testing.T) {
+	facts := baseShadowFacts(t)
+	manifests := parseValidManifests(t)
+	if problems := validateRepository(manifests, facts); len(problems) != 0 {
+		t.Fatalf("valid shadow facts: %#v", problems)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Manifests, *RepositoryFacts)
+		code   ProblemCode
+	}{
+		{
+			name: "shard job missing from shadow workflow",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				delete(facts.Workflow.Jobs, "linux-race-beta")
+			},
+			code: ProblemShadowJobMissing,
+		},
+		{
+			name: "service job missing from shadow workflow",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				delete(facts.Workflow.Jobs, "fixture-db-contract")
+			},
+			code: ProblemShadowJobMissing,
+		},
+		{
+			name: "shadow workflow omits the pinned image",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				facts.WorkflowRaw = "no pins here"
+			},
+			code: ProblemServicePinMissing,
+		},
+		{
+			name: "service discovery finds a different test set",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				facts.ServiceTests["fixture-db"] = []string{"TestSomethingElse"}
+			},
+			code: ProblemServiceTestDrift,
+		},
+		{
+			name: "service discovery is empty",
+			mutate: func(_ *Manifests, facts *RepositoryFacts) {
+				facts.ServiceTests["fixture-object"] = nil
+			},
+			code: ProblemServiceTestDrift,
+		},
+		{
+			name: "shadow references an unknown workflow",
+			mutate: func(manifests *Manifests, _ *RepositoryFacts) {
+				manifests.Services.Services[0].Workflow = "CI Shadw"
+			},
+			code: ProblemWorkflowMismatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifests := parseValidManifests(t)
+			facts := cloneRepositoryFacts(baseShadowFacts(t))
+			tt.mutate(&manifests, &facts)
+			assertProblemCode(t, validateRepository(manifests, facts), tt.code)
+		})
+	}
+
+	t.Run("current-workflow references are skipped when validating shadow", func(t *testing.T) {
+		manifests := parseValidManifests(t)
+		facts := cloneRepositoryFacts(baseShadowFacts(t))
+		facts.ExpectedWorkflows = map[string]struct{}{"CI": {}}
+		problems := validateRepository(manifests, facts)
+		for _, problem := range problems {
+			if problem.Code == ProblemWorkflowMismatch || problem.Code == ProblemWorkflowJobMissing || problem.Code == ProblemAggregateMissing {
+				t.Fatalf("CI references must not fail shadow validation: %#v", problems)
+			}
+		}
+	})
+}
+
+func TestPrintModes(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	standards := write("standards.yaml", validStandards)
+	ownership := write("package-ownership.yaml", validOwnership)
+	platforms := write("platform-contracts.yaml", validPlatforms)
+	services := write("service-contracts.yaml", validServices)
+	common := []string{
+		"--standards", standards,
+		"--packages", ownership,
+		"--platforms", platforms,
+		"--services", services,
+		"--fuzz-targets", write("fuzz-targets.yaml", validFuzzTargets),
+	}
+
+	t.Run("print-shard", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run(append(common, "--print-shard", "linux-race-alpha"), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != ". ./internal/manifest" {
+			t.Fatalf("print-shard = %q", got)
+		}
+	})
+
+	t.Run("print-shard unknown", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run(append(common, "--print-shard", "linux-race-missing"), &stdout, &stderr); code == 0 {
+			t.Fatal("unknown shard accepted")
+		}
+	})
+
+	t.Run("print-platform-packages", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run(append(common, "--print-platform-packages", "windows"), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "./internal/manifest" {
+			t.Fatalf("print-platform-packages = %q", got)
+		}
+	})
+
+	t.Run("print-platform-packages empty goos", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		if code := run(append(common, "--print-platform-packages", "aix"), &stdout, &stderr); code == 0 {
+			t.Fatal("empty platform package list accepted")
+		}
+	})
+
+	t.Run("print-service-run", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := run(append(common, "--print-service-run", "fixture-db"), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit = %d, stderr=%q", code, stderr.String())
+		}
+		got := strings.TrimSpace(stdout.String())
+		if !strings.Contains(got, "-run ^(TestConcurrentManifestUpdates)$") || !strings.Contains(got, "-p 1") || !strings.Contains(got, "./internal/manifest") {
+			t.Fatalf("print-service-run = %q", got)
+		}
+	})
 }
 
 func cloneRepositoryFacts(in RepositoryFacts) RepositoryFacts {
@@ -669,6 +1220,21 @@ func cloneRepositoryFacts(in RepositoryFacts) RepositoryFacts {
 	for path := range in.ExistingPaths {
 		out.ExistingPaths[path] = struct{}{}
 	}
+	out.ExpectedWorkflows = nil
+	if in.ExpectedWorkflows != nil {
+		out.ExpectedWorkflows = make(map[string]struct{}, len(in.ExpectedWorkflows))
+		for name := range in.ExpectedWorkflows {
+			out.ExpectedWorkflows[name] = struct{}{}
+		}
+	}
+	out.ServiceTests = nil
+	if in.ServiceTests != nil {
+		out.ServiceTests = make(map[string][]string, len(in.ServiceTests))
+		for id, tests := range in.ServiceTests {
+			out.ServiceTests[id] = append([]string(nil), tests...)
+		}
+	}
+	out.FuzzTargets = append([]DiscoveredFuzzTarget(nil), in.FuzzTargets...)
 	return out
 }
 


### PR DESCRIPTION
Milestone 3 (Tasks 10-12) of the CI quality system initiative. Builds the advisory shadow DAG alongside current required CI with zero changes to merge authority.

## What ships

**Task 10 — Shadow DAG:** Five rebalanced Linux race shards (parity isolated from the 8.9m critical path), focused Windows/macOS contract jobs, pinned PostgreSQL/MinIO service contracts (sha256 digest + client checksum), and a manifest-driven `ci-shadow.yml` advisory workflow. civalidate gained shard coverage validation, service contract discovery, and multi-workflow support.

**Task 11 — Scheduled diagnostics:** `ci/fuzz-targets.yaml` inventories all 14 fuzz targets (validated fail-closed against source); `fuzz.yml` rewritten inventory-driven; new `ci-diagnostics.yml` runs scheduled full OS suites, parity repetition, performance warmcheck, fail-closed vuln scan, and broad client/example diagnostics. Client path classifier with fail-closed self-test added to `clients.yml`. Docs corrected: 6 extractor targets are nightly-only, not on PRs.

**Task 12 — Qualification observer:** `tools/ciobserve` evaluates CI vs CI Shadow matched pairs against qualification thresholds (>= 20 runs, >= 7 days, zero divergence, p95 <= 480s, non-vacuous). Six mutation witnesses cover every rejection case. `ci-observe.yml` collects metrics daily.

## Safety

- **ci.yml unchanged** — CI required aggregate byte-for-byte identical
- All diagnostic workflows are advisory: no aggregate, not in CI required, cannot block merges
- Branch protection unchanged (readback: exactly CI required, app 15368, strict, admin-enforced)

## Verification

- `make ci` green (full non-race suite + lint-new 0 issues)
- All five workflows validate via civalidate (24 standards, 71 packages)
- actionlint clean on all workflows
- civalidate suite + race green; ciobserve tests green (6 qualification cases)
- Per-task independent reviews: Tasks 10, 11, 12 all PASS

## Checklist

- [x] `make ci` passes — and `make ci-race` for concurrency-sensitive changes
- [ ] Hosted `CI required` is green on the latest PR SHA
- [x] User-facing changes documented (CONTRIBUTING, docs/security.md)
- [x] Tests added or updated for the change