### PR TITLE
feat(ci): exact-SHA proof verifier and Docker publication gate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,20 @@
 name: Docker
 
+# Exact-SHA publication gate (20260812-ci-quality-system Milestone 5).
+#
+# Main images are built only AFTER a successful main-push CI run, and the
+# proof verifier (tools/ciproof) enumerates every CI attempt for the exact
+# SHA — a green rerun cannot erase a prior red. Tag images require the same
+# proof. The verifier runs before checkout-for-build, login, or push.
+#
+# workflow_run uses the publisher definition from the default branch, so the
+# first post-merge main run is the first end-to-end execution of this trigger.
+
 on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   push:
-    branches: [main]
     tags: ["v*"]
 
 permissions:
@@ -10,31 +22,59 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  docker-main:
+    name: Docker (main, exact-SHA proof)
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
+      # Proof verification BEFORE any artifact checkout, build, login, or push.
+      - name: Verify exact-SHA CI proof
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          sparse-checkout: |
+            tools/ciproof
+            go.mod
+            go.sum
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run proof verifier (fail closed on any red attempt)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          go run ./tools/ciproof \
+            --repository "${{ github.repository }}" \
+            --sha "${{ github.event.workflow_run.head_sha }}" \
+            --output /tmp/proof.json
+          cat /tmp/proof.json
+
+      # Only after proof: full checkout of the trusted main SHA.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
-      # GHCR login — uses the built-in GITHUB_TOKEN, no secrets needed
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Docker Hub login — requires DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Generate tags:
-      #   push to main  → :latest, :sha-abc1234
-      #   push tag v1.0 → :v1.0, :latest, :sha-abc1234
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -42,7 +82,80 @@ jobs:
             ghcr.io/${{ github.repository }}
             ${{ secrets.DOCKERHUB_USERNAME }}/sage-wiki
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-tag:
+    name: Docker (tag, exact-SHA proof)
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag commit SHA
+        id: tag-sha
+        run: echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify exact-SHA CI proof
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag-sha.outputs.sha }}
+          sparse-checkout: |
+            tools/ciproof
+            go.mod
+            go.sum
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run proof verifier (fail closed on any red attempt)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          go run ./tools/ciproof \
+            --repository "${{ github.repository }}" \
+            --sha "${{ steps.tag-sha.outputs.sha }}" \
+            --output /tmp/proof.json
+          cat /tmp/proof.json
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag-sha.outputs.sha }}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/sage-wiki
+          tags: |
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=sha,prefix=sha-

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ sage/
 /sage-wiki
 /civalidate
 /ciobserve
+/ciproof
 /testsummary
 bin/
 

--- a/ci/package-ownership.yaml
+++ b/ci/package-ownership.yaml
@@ -71,6 +71,7 @@ packages:
   - {path: tests/pathological, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/civalidate, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/ciobserve, class: test-owned, owner: go-tests-current, roles: []}
+  - {path: tools/ciproof, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/skillgen, class: test-owned, owner: go-tests-current, roles: []}
   - {path: tools/testsummary, class: test-owned, owner: go-tests-current, roles: []}
 
@@ -141,5 +142,6 @@ linux_race_shards:
         - tests/pathological
         - tools/civalidate
         - tools/ciobserve
+        - tools/ciproof
         - tools/skillgen
         - tools/testsummary

--- a/ci/publication-policy.yaml
+++ b/ci/publication-policy.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+
+# Publication policy (20260812-ci-quality-system Milestone 5).
+#
+# Every publication surface (Docker, release, client) must consume a successful
+# exact-SHA quality proof before any write-capable step. The proof verifier
+# (tools/ciproof) resolves the authoritative CI push run for the exact SHA,
+# enumerates all attempts (a rerun never erases a red attempt), and verifies
+# the latest attempt's CI required check from app 15368.
+#
+# workflow_run publication uses the publisher definition from the default
+# branch — the first post-merge main run is the first end-to-end execution.
+
+ci_authority:
+  workflow: CI
+  context: CI required
+  app_id: 15368
+  workflow_file: .github/workflows/ci.yml
+
+publications:
+  - id: docker-main
+    trigger: workflow_run
+    workflow: CI
+    checkout_ref: workflow_run.head_sha
+    proof_required: true
+    write_steps_after_proof: [login, build-push]
+
+  - id: docker-tag
+    trigger: tag
+    proof_required: true
+    write_steps_after_proof: [login, build-push]
+
+  - id: release-tag
+    trigger: tag
+    proof_required: true
+    write_steps_after_proof: [cross-build, release-create]
+
+  - id: client-python
+    trigger: manual
+    proof_required: true
+    version_sync_required: true
+    write_steps_after_proof: [build, publish]
+
+  - id: client-typescript
+    trigger: manual
+    proof_required: true
+    version_sync_required: true
+    write_steps_after_proof: [build, publish]
+
+emergency_waiver:
+  required_fields: [approver, reason, incident_link, sha, expires_at, original_evidence]
+  max_duration_hours: 168

--- a/tools/ciproof/main.go
+++ b/tools/ciproof/main.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type ProofFixture struct {
+	SHA              string         `json:"sha"`
+	MainReachable    bool           `json:"main_reachable"`
+	Runs             []RunFixture   `json:"runs"`
+	Waiver           *WaiverFixture `json:"waiver,omitempty"`
+	ExpectedAppID    int64          `json:"expected_app_id"`
+	ExpectedContext  string         `json:"expected_context"`
+	ExpectedWorkflow string         `json:"expected_workflow"`
+}
+
+type RunFixture struct {
+	ID                int64            `json:"id"`
+	Event             string           `json:"event"`
+	HeadSHA           string           `json:"head_sha"`
+	HeadBranch        string           `json:"head_branch"`
+	Name              string           `json:"name"`
+	Path              string           `json:"path"`
+	Status            string           `json:"status"`
+	Conclusion        string           `json:"conclusion"`
+	CreatedAt         string           `json:"created_at"`
+	Attempts          []AttemptFixture `json:"attempts"`
+	LatestAttemptJobs []JobFixture     `json:"latest_attempt_jobs"`
+}
+
+type AttemptFixture struct {
+	RunAttempt int    `json:"run_attempt"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type JobFixture struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"`
+	AppID      int64  `json:"app_id"`
+}
+
+type WaiverFixture struct {
+	Approver         string `json:"approver"`
+	Reason           string `json:"reason"`
+	IncidentLink     string `json:"incident_link"`
+	SHA              string `json:"sha"`
+	ExpiresAt        string `json:"expires_at"`
+	OriginalEvidence string `json:"original_evidence"`
+}
+
+type ProofResult struct {
+	Valid  bool   `json:"valid"`
+	Reason string `json:"reason,omitempty"`
+	SHA    string `json:"sha"`
+	RunID  int64  `json:"run_id,omitempty"`
+	Waived bool   `json:"waived,omitempty"`
+}
+
+func evaluateProof(f ProofFixture) ProofResult {
+	result := ProofResult{SHA: f.SHA}
+	if !f.MainReachable {
+		result.Reason = fmt.Sprintf("SHA %s is unreachable from protected main", f.SHA)
+		return result
+	}
+	appID := f.ExpectedAppID
+	if appID == 0 {
+		appID = 15368
+	}
+	wfName := f.ExpectedWorkflow
+	if wfName == "" {
+		wfName = "CI"
+	}
+	ctxName := f.ExpectedContext
+	if ctxName == "" {
+		ctxName = "CI required"
+	}
+	var matching []RunFixture
+	for _, r := range f.Runs {
+		if r.Event == "push" && r.HeadBranch == "main" && r.HeadSHA == f.SHA && r.Name == wfName {
+			matching = append(matching, r)
+		}
+	}
+	if len(matching) == 0 {
+		result.Reason = "no matching CI push run for SHA " + f.SHA
+		return result
+	}
+	if len(matching) > 1 {
+		result.Reason = fmt.Sprintf("ambiguous: %d matching CI push run IDs for SHA %s", len(matching), f.SHA)
+		return result
+	}
+	run := matching[0]
+	result.RunID = run.ID
+	for _, attempt := range run.Attempts {
+		if attempt.Conclusion != "success" {
+			baseReason := fmt.Sprintf("run %d attempt %d has non-success conclusion %q (reruns do not erase prior evidence)", run.ID, attempt.RunAttempt, attempt.Conclusion)
+			if f.Waiver != nil {
+				if waiverValid(f.Waiver, f.SHA) {
+					result.Valid = true
+					result.Waived = true
+					result.Reason = fmt.Sprintf("granted by emergency waiver from %s: %s (original evidence: %s)", f.Waiver.Approver, f.Waiver.Reason, f.Waiver.OriginalEvidence)
+					return result
+				}
+				result.Reason = baseReason + "; waiver " + waiverRejection(f.Waiver, f.SHA)
+			} else {
+				result.Reason = baseReason
+			}
+			return result
+		}
+	}
+	if run.Status != "completed" {
+		result.Reason = fmt.Sprintf("run %d status is %q, not completed", run.ID, run.Status)
+		return result
+	}
+	var ciRequired []JobFixture
+	for _, job := range run.LatestAttemptJobs {
+		if job.Name == ctxName && job.Conclusion == "success" && job.AppID == appID {
+			ciRequired = append(ciRequired, job)
+		}
+	}
+	if len(ciRequired) == 0 {
+		result.Reason = fmt.Sprintf("run %d latest attempt has no successful %s job from app %d", run.ID, ctxName, appID)
+		return result
+	}
+	if len(ciRequired) > 1 {
+		result.Reason = fmt.Sprintf("run %d latest attempt has %d matching %s jobs (expected exactly 1)", run.ID, len(ciRequired), ctxName)
+		return result
+	}
+	result.Valid = true
+	return result
+}
+
+func waiverValid(w *WaiverFixture, sha string) bool {
+	if w.Approver == "" || w.Reason == "" || w.IncidentLink == "" || w.SHA == "" || w.ExpiresAt == "" || w.OriginalEvidence == "" {
+		return false
+	}
+	if w.SHA != sha {
+		return false
+	}
+	expires, err := time.Parse(time.RFC3339, w.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return !time.Now().UTC().After(expires)
+}
+
+func waiverRejection(w *WaiverFixture, sha string) string {
+	if w.Approver == "" || w.Reason == "" || w.IncidentLink == "" || w.SHA == "" || w.ExpiresAt == "" || w.OriginalEvidence == "" {
+		return "incomplete (missing required fields)"
+	}
+	if w.SHA != sha {
+		return "wrong SHA"
+	}
+	expires, err := time.Parse(time.RFC3339, w.ExpiresAt)
+	if err != nil {
+		return "invalid expiry format"
+	}
+	if time.Now().UTC().After(expires) {
+		return "expired"
+	}
+	return "invalid"
+}
+
+type ghRun struct {
+	ID         int64  `json:"id"`
+	Event      string `json:"event"`
+	HeadSHA    string `json:"head_sha"`
+	HeadBranch string `json:"head_branch"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	CreatedAt  string `json:"created_at"`
+	RunAttempt int    `json:"run_attempt"`
+}
+
+type ghAttempt struct {
+	RunAttempt int    `json:"run_attempt"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type ghJob struct {
+	Name       string `json:"name"`
+	Conclusion string `json:"conclusion"`
+	AppID      *int64 `json:"check_suite_app_id,omitempty"`
+}
+
+type ghAttemptsResp struct {
+	Attempts []ghAttempt `json:"workflow_runs"`
+}
+
+type ghRunsResp struct {
+	Runs []ghRun `json:"workflow_runs"`
+}
+
+type ghJobsResp struct {
+	Jobs []ghJob `json:"jobs"`
+}
+
+func ghAPI(repo, apiPath string) ([]byte, error) {
+	cmd := exec.Command("gh", "api", "repos/"+repo+"/"+apiPath, "-q", ".")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api %s: %w", apiPath, err)
+	}
+	return out, nil
+}
+
+func loadFromAPI(repo, sha string) (ProofFixture, error) {
+	if _, err := ghAPI(repo, "compare/main..."+sha); err != nil {
+		return ProofFixture{}, fmt.Errorf("SHA %s is not reachable from main: %w", sha, err)
+	}
+	data, err := ghAPI(repo, "actions/runs?head_sha="+sha+"&event=push&per_page=50")
+	if err != nil {
+		return ProofFixture{}, err
+	}
+	var runsResp ghRunsResp
+	if err := json.Unmarshal(data, &runsResp); err != nil {
+		return ProofFixture{}, fmt.Errorf("parse runs: %w", err)
+	}
+	fixture := ProofFixture{SHA: sha, MainReachable: true}
+	for _, r := range runsResp.Runs {
+		if r.Name != "CI" {
+			continue
+		}
+		aData, err := ghAPI(repo, fmt.Sprintf("actions/runs/%d/attempts", r.ID))
+		if err != nil {
+			continue
+		}
+		var aResp ghAttemptsResp
+		if err := json.Unmarshal(aData, &aResp); err != nil {
+			continue
+		}
+		var attempts []AttemptFixture
+		for _, a := range aResp.Attempts {
+			attempts = append(attempts, AttemptFixture(a))
+		}
+		latestAttempt := r.RunAttempt
+		if latestAttempt == 0 {
+			latestAttempt = 1
+		}
+		jData, err := ghAPI(repo, fmt.Sprintf("actions/runs/%d/attempts/%d/jobs", r.ID, latestAttempt))
+		if err != nil {
+			jData, _ = ghAPI(repo, fmt.Sprintf("actions/runs/%d/jobs", r.ID))
+		}
+		var jResp ghJobsResp
+		if err := json.Unmarshal(jData, &jResp); err != nil {
+			continue
+		}
+		var jobs []JobFixture
+		for _, j := range jResp.Jobs {
+			appID := int64(0)
+			if j.AppID != nil {
+				appID = *j.AppID
+			}
+			jobs = append(jobs, JobFixture{Name: j.Name, Conclusion: j.Conclusion, AppID: appID})
+		}
+		fixture.Runs = append(fixture.Runs, RunFixture{
+			ID:                r.ID,
+			Event:             r.Event,
+			HeadSHA:           r.HeadSHA,
+			HeadBranch:        r.HeadBranch,
+			Name:              r.Name,
+			Path:              r.Path,
+			Status:            r.Status,
+			Conclusion:        r.Conclusion,
+			CreatedAt:         r.CreatedAt,
+			Attempts:          attempts,
+			LatestAttemptJobs: jobs,
+		})
+	}
+	return fixture, nil
+}
+
+func loadFixture(path string) (ProofFixture, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ProofFixture{}, err
+	}
+	var f ProofFixture
+	if err := json.Unmarshal(data, &f); err != nil {
+		return ProofFixture{}, fmt.Errorf("%s: %w", filepath.Base(path), err)
+	}
+	return f, nil
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("ciproof", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	fixturesDir := flags.String("fixtures", "", "directory of JSON proof fixtures")
+	shaFlag := flags.String("sha", "", "SHA to prove")
+	outputPath := flags.String("output", "", "write proof JSON to this path")
+	repository := flags.String("repository", "", "query the live GitHub API for this repo")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if *shaFlag == "" {
+		fmt.Fprintln(stderr, "--sha is required")
+		return 2
+	}
+	var fixture ProofFixture
+	if *repository != "" {
+		f, err := loadFromAPI(*repository, *shaFlag)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		fixture = f
+	} else if *fixturesDir != "" {
+		entries, err := os.ReadDir(*fixturesDir)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+		found := false
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+				continue
+			}
+			f, err := loadFixture(filepath.Join(*fixturesDir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			if f.SHA == *shaFlag {
+				fixture = f
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Fprintf(stderr, "no fixture for SHA %s in %s\n", *shaFlag, *fixturesDir)
+			return 2
+		}
+	} else {
+		fmt.Fprintln(stderr, "--fixtures or --repository is required")
+		return 2
+	}
+	result := evaluateProof(fixture)
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if *outputPath != "" {
+		if err := os.WriteFile(*outputPath, append(data, '\n'), 0o644); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 2
+		}
+	} else {
+		fmt.Fprintln(stdout, string(data))
+	}
+	if result.Valid {
+		return 0
+	}
+	return 1
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/tools/ciproof/main_test.go
+++ b/tools/ciproof/main_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const validSHA = "58166c18e49aceed83651388e1108bd381b683aa"
+
+func makeFixture(name string) ProofFixture {
+	return ProofFixture{
+		SHA:              validSHA,
+		MainReachable:    true,
+		ExpectedAppID:    15368,
+		ExpectedContext:  "CI required",
+		ExpectedWorkflow: "CI",
+	}
+}
+
+func validRun(sha string) RunFixture {
+	return RunFixture{
+		ID:         1001,
+		Event:      "push",
+		HeadSHA:    sha,
+		HeadBranch: "main",
+		Name:       "CI",
+		Path:       ".github/workflows/ci.yml",
+		Status:     "completed",
+		Conclusion: "success",
+		CreatedAt:  "2026-08-13T00:53:16Z",
+		Attempts: []AttemptFixture{
+			{RunAttempt: 1, Status: "completed", Conclusion: "success"},
+		},
+		LatestAttemptJobs: []JobFixture{
+			{Name: "CI required", Conclusion: "success", AppID: 15368},
+		},
+	}
+}
+
+func TestProof(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      func() ProofFixture
+		wantValid  bool
+		wantReason string
+	}{
+		{
+			name:      "valid proof",
+			build:     func() ProofFixture { f := makeFixture("valid"); f.Runs = []RunFixture{validRun(validSHA)}; return f },
+			wantValid: true,
+		},
+		{
+			name:       "absent proof — no matching runs",
+			build:      func() ProofFixture { f := makeFixture("absent"); return f },
+			wantValid:  false,
+			wantReason: "no matching",
+		},
+		{
+			name: "pending attempt blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("pending")
+				r := validRun(validSHA)
+				r.Status = "in_progress"
+				r.Attempts[0].Status = "in_progress"
+				r.Attempts[0].Conclusion = ""
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "non-success",
+		},
+		{
+			name: "initial red then rerun green blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("rerun")
+				r := validRun(validSHA)
+				r.Attempts = []AttemptFixture{
+					{RunAttempt: 1, Status: "completed", Conclusion: "failure"},
+					{RunAttempt: 2, Status: "completed", Conclusion: "success"},
+				}
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "non-success",
+		},
+		{
+			name: "cancelled attempt blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("cancelled")
+				r := validRun(validSHA)
+				r.Attempts[0].Conclusion = "cancelled"
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "non-success",
+		},
+		{
+			name: "wrong SHA blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-sha")
+				r := validRun("wrong1234567890")
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "no matching",
+		},
+		{
+			name: "wrong branch blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-branch")
+				r := validRun(validSHA)
+				r.HeadBranch = "develop"
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "no matching",
+		},
+		{
+			name: "wrong event blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-event")
+				r := validRun(validSHA)
+				r.Event = "pull_request"
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "no matching",
+		},
+		{
+			name: "wrong workflow blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-workflow")
+				r := validRun(validSHA)
+				r.Name = "Other"
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "no matching",
+		},
+		{
+			name: "wrong app ID blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-app")
+				r := validRun(validSHA)
+				r.LatestAttemptJobs[0].AppID = 99999
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "CI required",
+		},
+		{
+			name: "wrong context name blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("wrong-context")
+				r := validRun(validSHA)
+				r.LatestAttemptJobs[0].Name = "build"
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "CI required",
+		},
+		{
+			name: "duplicate matching run IDs blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("duplicate")
+				r1 := validRun(validSHA)
+				r2 := validRun(validSHA)
+				r2.ID = 1002
+				f.Runs = []RunFixture{r1, r2}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "ambiguous",
+		},
+		{
+			name: "unreachable SHA blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("unreachable")
+				f.MainReachable = false
+				f.Runs = []RunFixture{validRun(validSHA)}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "unreachable",
+		},
+		{
+			name: "missing CI required job blocks proof",
+			build: func() ProofFixture {
+				f := makeFixture("missing-job")
+				r := validRun(validSHA)
+				r.LatestAttemptJobs = []JobFixture{}
+				f.Runs = []RunFixture{r}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "CI required",
+		},
+		{
+			name: "valid emergency waiver for red SHA",
+			build: func() ProofFixture {
+				f := makeFixture("waiver")
+				r := validRun(validSHA)
+				r.Attempts[0].Conclusion = "failure"
+				f.Runs = []RunFixture{r}
+				f.Waiver = &WaiverFixture{
+					Approver:         "xoai",
+					Reason:           "Runner capacity outage caused red; confirmed not a code regression.",
+					IncidentLink:     "https://github.com/xoai/sage-wiki/issues/200",
+					SHA:              validSHA,
+					ExpiresAt:        "2026-08-20T00:00:00Z",
+					OriginalEvidence: "CI required failed due to runner timeout, not code defect.",
+				}
+				return f
+			},
+			wantValid: true,
+		},
+		{
+			name: "expired waiver does not grant authority",
+			build: func() ProofFixture {
+				f := makeFixture("waiver-expired")
+				r := validRun(validSHA)
+				r.Attempts[0].Conclusion = "failure"
+				f.Runs = []RunFixture{r}
+				f.Waiver = &WaiverFixture{
+					Approver:         "xoai",
+					Reason:           "expired",
+					IncidentLink:     "https://example.com",
+					SHA:              validSHA,
+					ExpiresAt:        "2020-01-01T00:00:00Z",
+					OriginalEvidence: "old",
+				}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "expired",
+		},
+		{
+			name: "waiver missing required fields does not grant authority",
+			build: func() ProofFixture {
+				f := makeFixture("waiver-incomplete")
+				r := validRun(validSHA)
+				r.Attempts[0].Conclusion = "failure"
+				f.Runs = []RunFixture{r}
+				f.Waiver = &WaiverFixture{
+					Approver:  "xoai",
+					ExpiresAt: "2026-08-20T00:00:00Z",
+				}
+				return f
+			},
+			wantValid:  false,
+			wantReason: "incomplete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := tt.build()
+			result := evaluateProof(fixture)
+			if result.Valid != tt.wantValid {
+				t.Fatalf("valid = %v (%s), want %v", result.Valid, result.Reason, tt.wantValid)
+			}
+			if !tt.wantValid && tt.wantReason != "" {
+				if !contains(result.Reason, tt.wantReason) {
+					t.Fatalf("reason = %q, want substring %q", result.Reason, tt.wantReason)
+				}
+			}
+		})
+	}
+}
+
+func TestRunFixtures(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "proof.json")
+
+	// Write the valid fixture to testdata for the CLI.
+	validFixture := makeFixture("valid")
+	validFixture.Runs = []RunFixture{validRun(validSHA)}
+	data, _ := json.Marshal(validFixture)
+	if err := os.WriteFile(filepath.Join(dir, "valid.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytesBuf
+	code := run([]string{"--fixtures", dir, "--sha", validSHA, "--output", out}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+
+	proofData, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pr ProofResult
+	if err := json.Unmarshal(proofData, &pr); err != nil {
+		t.Fatal(err)
+	}
+	if !pr.Valid {
+		t.Fatalf("proof result = %+v, want valid", pr)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || findSub(s, sub))
+}
+
+func findSub(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+type bytesBuf struct{ b []byte }
+
+func (b *bytesBuf) Write(p []byte) (int, error) { b.b = append(b.b, p...); return len(p), nil }
+func (b *bytesBuf) String() string              { return string(b.b) }

--- a/tools/ciproof/testdata/valid.json
+++ b/tools/ciproof/testdata/valid.json
@@ -1,0 +1,34 @@
+{
+  "sha": "58166c18e49aceed83651388e1108bd381b683aa",
+  "main_reachable": true,
+  "expected_app_id": 15368,
+  "expected_context": "CI required",
+  "expected_workflow": "CI",
+  "runs": [
+    {
+      "id": 1001,
+      "event": "push",
+      "head_sha": "58166c18e49aceed83651388e1108bd381b683aa",
+      "head_branch": "main",
+      "name": "CI",
+      "path": ".github/workflows/ci.yml",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-08-13T00:53:16Z",
+      "attempts": [
+        {
+          "run_attempt": 1,
+          "status": "completed",
+          "conclusion": "success"
+        }
+      ],
+      "latest_attempt_jobs": [
+        {
+          "name": "CI required",
+          "conclusion": "success",
+          "app_id": 15368
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Milestone 5 (Tasks 17-19, partial) of the CI quality system initiative. Closes the production risk of Docker publishing from an unverified main SHA.

## What ships

**tools/ciproof** — read-only exact-SHA proof verifier. Resolves the authoritative CI push run for an immutable SHA, enumerates every attempt (a green rerun never erases a prior red), and verifies the latest attempt has exactly one successful `CI required` job from app 15368. 18 adversarial fixture cases cover every rejection class + valid proof + emergency waivers (valid, expired, incomplete). Live API mode queries `gh api` for real run/attempt/job data.

**ci/publication-policy.yaml** — declares the CI authority and every publication surface that must consume proof before write authority.

**docker.yml** — REMOVED the independent `push: branches: [main]` trigger. Main images now build only after a completed CI `workflow_run`, gated by the proof verifier before any checkout-for-build, login, or push. Tag images require the same proof.

## Security

- The proof verifier runs BEFORE any write-capable step (login, build, push)
- `workflow_run` checks out `head_sha` — never untrusted PR code with publish secrets
- A green rerun cannot bypass a prior red attempt (every attempt enumerated)
- Emergency waivers require explicit approver, reason, incident link, SHA, expiry, and original evidence

## What remains (Tasks 20-21)

- Gate release.yml and client publish workflows behind the same proof
- Verify publication fail-closed behavior end-to-end on first main run

## Checklist

- [x] `make ci` passes (format, modules, builds, vet, lint, responsibility, determinism, generated, translations, non-race suite)
- [ ] Hosted `CI required` is green on the latest PR SHA
- [x] Tests added (18 proof fixture cases)
- [x] User-facing changes documented