### PR TITLE
fix: bump Go toolchain to 1.26.6 (GO-2026-6218, GO-2026-6090)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/xoai/sage-wiki
 
 go 1.26
+toolchain go1.26.6
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
One-line fix: adds `toolchain go1.26.6` to go.mod to resolve two Go stdlib vulnerabilities published today.

**GO-2026-6218** (CVE-2026-56860): `net/url` quadratic-time path resolution with `..` segments. Fixed in go1.26.6.
**GO-2026-6090** (CVE-2026-56862): `crypto/tls` KeyUpdate DoS. Fixed in go1.26.6.

The advisory vuln scan was already designed for this scenario (`continue-on-error: true`). The toolchain directive ensures all environments resolve to the patched version immediately, rather than waiting for setup-go cache rotation.