### PR TITLE
chore: cut 0.2.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## [Unreleased]
 
+## 0.2.9 — 2026-08-14
+
 ### Fixed
+
+- **Go 1.26.6 security toolchain.** `go.mod` now pins Go 1.26.6 for builds,
+  addressing GO-2026-6218 (CVE-2026-56860, quadratic-time URL path
+  resolution) and GO-2026-6090 (CVE-2026-56862, TLS KeyUpdate denial of
+  service).
 
 - **Bounded source context for high-fanout concepts (#146).** `buildSourceContext`
   now caps the total assembled source context to a configurable token budget
@@ -83,7 +90,7 @@
   merging — a policy gate today, mechanical once branch protection requires
   the check on `main`.
 
-## [0.2.8] — 2026-08-05
+## 0.2.8 — 2026-08-05
 
 ### Fixed
 
@@ -97,7 +104,7 @@
 
 ### Added
 
-## [0.2.7] — 2026-08-05
+## 0.2.7 — 2026-08-05
 
 ### Added
 


### PR DESCRIPTION
## Summary

- promote all post-v0.2.8 changelog entries into the dated `0.2.9` section
- include the Go 1.26.6 security-toolchain fixes from #158
- normalize the 0.2.7 and 0.2.8 headings to the documented extractable format

## Release verification

- `bash scripts/extract-changelog.sh v0.2.9 CHANGELOG.md` returns the complete non-empty release notes
- v0.2.7 and v0.2.8 extraction also return non-empty notes
- `make ci` passes locally
- independent release artifact review: 0 critical / 0 major / 0 substantive / 0 cosmetic

## Checklist

- [x] `make ci` passes on this branch
- [x] Hosted `CI required` is green on the latest PR SHA
- [x] README is unchanged; no translation update is required
- [x] User-facing changes are documented in the dated CHANGELOG section
- [x] Existing feature tests passed before release preparation

## For maintainers

- [x] CI has run and passed on this PR

This PR only prepares the release commit. The `v0.2.9` tag will not be pushed until a separate approval checkpoint.