### PR TITLE
fix(extract): propagate configured source type through binary extractors (#168)

### DIFF
--- a/internal/extract/email.go
+++ b/internal/extract/email.go
@@ -9,7 +9,7 @@ import (
 )
 
 // extractEmail extracts text from an .eml email file.
-func extractEmail(path string) (*SourceContent, error) {
+func extractEmail(path, sourceType string) (*SourceContent, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract email: %w", err)
@@ -23,7 +23,7 @@ func extractEmail(path string) (*SourceContent, error) {
 		data, _ := io.ReadAll(f)
 		return &SourceContent{
 			Path: path,
-			Type: "article",
+			Type: orDefaultType(sourceType, "article"),
 			Text: string(data),
 		}, nil
 	}
@@ -51,7 +51,7 @@ func extractEmail(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "article",
+		Type: orDefaultType(sourceType, "article"),
 		Text: strings.TrimSpace(text.String()),
 	}, nil
 }

--- a/internal/extract/epub.go
+++ b/internal/extract/epub.go
@@ -9,7 +9,7 @@ import (
 )
 
 // extractEpub extracts text from an EPUB file (ZIP containing XHTML chapters).
-func extractEpub(path string) (*SourceContent, error) {
+func extractEpub(path, sourceType string) (*SourceContent, error) {
 	r, err := zip.OpenReader(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract epub: %w", err)
@@ -58,7 +58,7 @@ func extractEpub(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "article",
+		Type: orDefaultType(sourceType, "article"),
 		Text: extracted,
 	}, nil
 }

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -34,6 +34,18 @@ type ExtractOpts struct {
 	ParsersEnabled  bool // must be true AND ExternalParsers non-nil to use external parsers
 }
 
+// orDefaultType resolves the effective source type: the caller-configured
+// type wins; an empty/"auto" type falls back to the format's historical
+// default. Issue #168 — binary extractors used to hardcode the default and
+// silently discard sources[].type, so type-specific summarize prompts and
+// source_type frontmatter never saw it.
+func orDefaultType(sourceType, formatDefault string) string {
+	if sourceType == "" || sourceType == "auto" {
+		return formatDefault
+	}
+	return sourceType
+}
+
 // Extract reads and extracts text from a source file.
 // Optional ExtractOpts can provide external parser support.
 func Extract(path string, sourceType string, opts ...ExtractOpts) (*SourceContent, error) {
@@ -43,19 +55,19 @@ func Extract(path string, sourceType string, opts ...ExtractOpts) (*SourceConten
 	case ext == ".md":
 		return extractMarkdown(path, sourceType)
 	case ext == ".pdf":
-		return extractPDF(path)
+		return extractPDF(path, sourceType)
 	case ext == ".docx":
-		return extractDocx(path)
+		return extractDocx(path, sourceType)
 	case ext == ".xlsx":
-		return extractXlsx(path)
+		return extractXlsx(path, sourceType)
 	case ext == ".pptx":
-		return extractPptx(path)
+		return extractPptx(path, sourceType)
 	case ext == ".csv":
-		return extractCSV(path)
+		return extractCSV(path, sourceType)
 	case ext == ".epub":
-		return extractEpub(path)
+		return extractEpub(path, sourceType)
 	case ext == ".eml" || ext == ".msg":
-		return extractEmail(path)
+		return extractEmail(path, sourceType)
 	case isImageFile(ext):
 		return extractImage(path)
 	case ext == ".txt" || ext == ".log" || ext == ".vtt" || ext == ".srt":

--- a/internal/extract/extract_test.go
+++ b/internal/extract/extract_test.go
@@ -60,6 +60,94 @@ func TestExtractCode(t *testing.T) {
 	}
 }
 
+// Issue #168: the configured source type (sources[].type) must survive
+// extraction for EVERY format, not just markdown/text — the summarize pass
+// picks prompts/summarize-<type>.md and writes source_type from
+// content.Type, so a hardcoded type here silently discards the user's
+// prompt override. Regression: pdf/docx/xlsx/pptx/csv/epub/eml all
+// hardcoded their detected type.
+func TestExtractPropagatesConfiguredType(t *testing.T) {
+	csvSeed := []byte("name,value\nalpha,1\nbeta,2\n")
+	fixtures := []struct {
+		name         string
+		ext          string
+		seed         []byte
+		defaultType  string
+		configuredTy string
+	}{
+		{"pdf", ".pdf", seedsPdf()[0], "paper", "governance"},
+		{"docx", ".docx", seedsDocx()[0], "article", "governance"},
+		{"xlsx", ".xlsx", seedsXlsx()[0], "dataset", "metrics"},
+		{"pptx", ".pptx", seedsPptx()[0], "article", "slides"},
+		{"csv", ".csv", csvSeed, "dataset", "metrics"},
+		{"epub", ".epub", seedsEpub()[0], "article", "book"},
+		{"eml", ".eml", seedsEmail()[0], "article", "correspondence"},
+	}
+
+	for _, fx := range fixtures {
+		t.Run(fx.name+" configured type wins", func(t *testing.T) {
+			path := writeFuzzInput(t, fx.seed, fx.ext)
+			sc, err := Extract(path, fx.configuredTy)
+			if err != nil {
+				t.Fatalf("Extract(%s): %v", fx.ext, err)
+			}
+			if sc.Type != fx.configuredTy {
+				t.Errorf("Extract(%s, %q).Type = %q, want configured type %q",
+					fx.ext, fx.configuredTy, sc.Type, fx.configuredTy)
+			}
+		})
+		t.Run(fx.name+" empty type falls back to format default", func(t *testing.T) {
+			path := writeFuzzInput(t, fx.seed, fx.ext)
+			sc, err := Extract(path, "")
+			if err != nil {
+				t.Fatalf("Extract(%s): %v", fx.ext, err)
+			}
+			if sc.Type != fx.defaultType {
+				t.Errorf("Extract(%s, \"\").Type = %q, want default %q",
+					fx.ext, sc.Type, fx.defaultType)
+			}
+		})
+		t.Run(fx.name+" auto falls back to format default", func(t *testing.T) {
+			path := writeFuzzInput(t, fx.seed, fx.ext)
+			sc, err := Extract(path, "auto")
+			if err != nil {
+				t.Fatalf("Extract(%s): %v", fx.ext, err)
+			}
+			if sc.Type != fx.defaultType {
+				t.Errorf("Extract(%s, \"auto\").Type = %q, want default %q",
+					fx.ext, sc.Type, fx.defaultType)
+			}
+		})
+	}
+}
+
+// Functional types stay pinned regardless of configured type: "image" gates
+// the vision pipeline (IsImageSource) and "code" has its own summarize path —
+// overriding them would misroute the source, not restyle its prompt.
+func TestExtractFunctionalTypesStayPinned(t *testing.T) {
+	dir := t.TempDir()
+
+	imgPath := filepath.Join(dir, "pic.png")
+	os.WriteFile(imgPath, []byte("\x89PNG\r\n\x1a\n"), 0644)
+	sc, err := Extract(imgPath, "governance")
+	if err != nil {
+		t.Fatalf("Extract(.png): %v", err)
+	}
+	if sc.Type != "image" {
+		t.Errorf("image Type = %q, want pinned \"image\"", sc.Type)
+	}
+
+	codePath := filepath.Join(dir, "main.go")
+	os.WriteFile(codePath, []byte("package main\nfunc main() {}"), 0644)
+	sc, err = Extract(codePath, "governance")
+	if err != nil {
+		t.Fatalf("Extract(.go): %v", err)
+	}
+	if sc.Type != "code" {
+		t.Errorf("code Type = %q, want pinned \"code\"", sc.Type)
+	}
+}
+
 func TestChunkIfNeededSmall(t *testing.T) {
 	content := &SourceContent{
 		Text: "Short text that fits in one chunk.",

--- a/internal/extract/fuzz_test.go
+++ b/internal/extract/fuzz_test.go
@@ -38,7 +38,7 @@ func epubHeader(name string) int {
 	return 30 + len(filepath.Base(name))
 }
 
-type extractFn func(path string) (*SourceContent, error)
+type extractFn func(path, sourceType string) (*SourceContent, error)
 
 func fuzzZipExtractor(f *testing.F, fn extractFn, ext string, seeds [][]byte, perEntryHeader func(name string) int) {
 	f.Helper()
@@ -51,7 +51,7 @@ func fuzzZipExtractor(f *testing.F, fn extractFn, ext string, seeds [][]byte, pe
 		if perEntryHeader != nil {
 			slack = headerBound(data, perEntryHeader)
 		}
-		sc, err := fn(path)
+		sc, err := fn(path, "")
 		if err != nil {
 			return // errors are not invariant violations
 		}
@@ -83,7 +83,7 @@ func FuzzExtractEmail(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		path := writeFuzzInput(t, data, ".eml")
-		sc, err := extractEmail(path)
+		sc, err := extractEmail(path, "")
 		if err != nil {
 			return
 		}
@@ -104,7 +104,7 @@ func FuzzExtractPdfGo(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		path := writeFuzzInput(t, data, ".pdf")
-		sc, err := extractPDFGo(path)
+		sc, err := extractPDFGo(path, "")
 		if err != nil {
 			return
 		}

--- a/internal/extract/limits_test.go
+++ b/internal/extract/limits_test.go
@@ -228,7 +228,7 @@ func TestExtractDocx_DeclaredBomb(t *testing.T) {
 	zeros := make([]byte, 60<<20) // 60 MB, compresses to ~KB
 	path := buildZip(t, map[string][]byte{"word/document.xml": zeros})
 
-	_, err := extractDocx(path)
+	_, err := extractDocx(path, "")
 	var zle *ZipLimitError
 	if !errors.As(err, &zle) {
 		t.Fatalf("expected ZipLimitError, got %v", err)
@@ -248,7 +248,7 @@ func TestExtractXlsx_AggregateBomb(t *testing.T) {
 	}
 	path := buildZip(t, entries)
 
-	_, err := extractXlsx(path)
+	_, err := extractXlsx(path, "")
 	var zle *ZipLimitError
 	if !errors.As(err, &zle) {
 		t.Fatalf("expected ZipLimitError, got %v", err)
@@ -275,7 +275,7 @@ func TestExtractDocx_LyingHeader_Rejected(t *testing.T) {
 	// declared size, so depending on flate's fill boundaries the outcome is
 	// either an extraction error OR a ≤1KB truncated result; both are safe.
 	// (An err!=nil assertion would be implementation-defined — Gate-3 i1.)
-	sc, _ := extractDocx(path)
+	sc, _ := extractDocx(path, "")
 	if sc != nil && len(sc.Text) > 2048 {
 		t.Errorf("inflated content returned (%d bytes) despite lying header", len(sc.Text))
 	}
@@ -293,7 +293,7 @@ func TestExtractDocx_UnmatchedMediaIgnored(t *testing.T) {
 		"word/document.xml": small,
 		"media/image1.png":  media,
 	})
-	sc, err := extractDocx(good)
+	sc, err := extractDocx(good, "")
 	if err != nil {
 		t.Fatalf("unmatched media part must not trip caps: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestExtractDocx_UnmatchedMediaIgnored(t *testing.T) {
 		"word/document.xml": media, // same payload, but MATCHED
 		"media/image1.png":  small,
 	})
-	_, err = extractDocx(bomb)
+	_, err = extractDocx(bomb, "")
 	var zle *ZipLimitError
 	if !errors.As(err, &zle) {
 		t.Fatalf("matched over-cap entry must error: %v", err)
@@ -319,7 +319,7 @@ func TestExtractDocx_UnmatchedMediaIgnored(t *testing.T) {
 func TestExtractors_SmallFixturesRegression(t *testing.T) {
 	t.Run("docx", func(t *testing.T) {
 		path := buildZip(t, map[string][]byte{"word/document.xml": validDocxEntry(t, "alpha beta gamma")})
-		sc, err := extractDocx(path)
+		sc, err := extractDocx(path, "")
 		if err != nil || !strings.Contains(sc.Text, "alpha beta gamma") {
 			t.Errorf("docx: sc=%+v err=%v", sc, err)
 		}
@@ -330,7 +330,7 @@ func TestExtractors_SmallFixturesRegression(t *testing.T) {
 			"xl/worksheets/sheet1.xml": []byte(`<worksheet><sheetData><row><c><v>cell</v></c></row></sheetData></worksheet>`),
 			"xl/worksheets/sheet2.xml": []byte(`<worksheet><sheetData><row><c><v>cell2</v></c></row></sheetData></worksheet>`),
 		})
-		sc, err := extractXlsx(path)
+		sc, err := extractXlsx(path, "")
 		if err != nil || !strings.Contains(sc.Text, "shared one") {
 			t.Errorf("xlsx: sc=%+v err=%v", sc, err)
 		}
@@ -339,7 +339,7 @@ func TestExtractors_SmallFixturesRegression(t *testing.T) {
 		path := buildZip(t, map[string][]byte{
 			"ppt/slides/slide1.xml": []byte(`<p:sld xmlns:p="x"><p:cSld><p:spTree><p:sp><p:txBody><a:p xmlns:a="y"><a:r><a:t>slide text</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>`),
 		})
-		sc, err := extractPptx(path)
+		sc, err := extractPptx(path, "")
 		if err != nil || !strings.Contains(sc.Text, "slide text") {
 			t.Errorf("pptx: sc=%+v err=%v", sc, err)
 		}
@@ -348,7 +348,7 @@ func TestExtractors_SmallFixturesRegression(t *testing.T) {
 		path := buildZip(t, map[string][]byte{
 			"OPS/chapter1.xhtml": []byte(`<html><body><p><t>chapter content here</t></p></body></html>`),
 		})
-		sc, err := extractEpub(path)
+		sc, err := extractEpub(path, "")
 		if err != nil || !strings.Contains(sc.Text, "chapter content here") {
 			t.Errorf("epub: sc=%+v err=%v", sc, err)
 		}

--- a/internal/extract/office.go
+++ b/internal/extract/office.go
@@ -13,7 +13,7 @@ import (
 )
 
 // extractDocx extracts text from a .docx file (ZIP containing word/document.xml).
-func extractDocx(path string) (*SourceContent, error) {
+func extractDocx(path, sourceType string) (*SourceContent, error) {
 	r, err := zip.OpenReader(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract docx: %w", err)
@@ -51,13 +51,13 @@ func extractDocx(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "article",
+		Type: orDefaultType(sourceType, "article"),
 		Text: extracted,
 	}, nil
 }
 
 // extractXlsx extracts text from a .xlsx file (ZIP containing xl/sharedStrings.xml + sheets).
-func extractXlsx(path string) (*SourceContent, error) {
+func extractXlsx(path, sourceType string) (*SourceContent, error) {
 	r, err := zip.OpenReader(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract xlsx: %w", err)
@@ -122,13 +122,13 @@ func extractXlsx(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "dataset",
+		Type: orDefaultType(sourceType, "dataset"),
 		Text: extracted,
 	}, nil
 }
 
 // extractPptx extracts text from a .pptx file (ZIP containing ppt/slides/slide*.xml).
-func extractPptx(path string) (*SourceContent, error) {
+func extractPptx(path, sourceType string) (*SourceContent, error) {
 	r, err := zip.OpenReader(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract pptx: %w", err)
@@ -171,13 +171,13 @@ func extractPptx(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "article",
+		Type: orDefaultType(sourceType, "article"),
 		Text: extracted,
 	}, nil
 }
 
 // extractCSV reads a CSV file and formats as readable text.
-func extractCSV(path string) (*SourceContent, error) {
+func extractCSV(path, sourceType string) (*SourceContent, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("extract csv: %w", err)
@@ -215,7 +215,7 @@ func extractCSV(path string) (*SourceContent, error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "dataset",
+		Type: orDefaultType(sourceType, "dataset"),
 		Text: strings.TrimSpace(text.String()),
 	}, nil
 }

--- a/internal/extract/pdf.go
+++ b/internal/extract/pdf.go
@@ -15,18 +15,18 @@ import (
 // extractPDF extracts text from a PDF file.
 // Tries pdftotext (poppler) first for better font/encoding support,
 // falls back to the pure Go library if pdftotext is not available.
-func extractPDF(path string) (*SourceContent, error) {
+func extractPDF(path, sourceType string) (*SourceContent, error) {
 	// Try pdftotext first
 	if text := extractPDFPoppler(path); text != "" {
 		return &SourceContent{
 			Path: path,
-			Type: "paper",
+			Type: orDefaultType(sourceType, "paper"),
 			Text: text,
 		}, nil
 	}
 
 	// Fallback to Go library
-	return extractPDFGo(path)
+	return extractPDFGo(path, sourceType)
 }
 
 // extractPDFPoppler uses pdftotext (poppler) for extraction.
@@ -52,7 +52,7 @@ func extractPDFPoppler(path string) string {
 // "malformed PDF", "unexpected keyword", EOF — so message-matching is
 // fragile). All panics are recovered AND logged at Warn (nothing is
 // silent; a bug in our own code remains visible in logs).
-func extractPDFGo(path string) (_ *SourceContent, err error) {
+func extractPDFGo(path, sourceType string) (_ *SourceContent, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Warn("extract pdf: recovered library panic", "path", path, "panic", r)
@@ -101,7 +101,7 @@ func extractPDFGo(path string) (_ *SourceContent, err error) {
 
 	return &SourceContent{
 		Path: path,
-		Type: "paper",
+		Type: orDefaultType(sourceType, "paper"),
 		Text: extracted,
 	}, nil
 }


### PR DESCRIPTION
Fixes #168

## Problem

With a custom `sources[].type` (e.g. `governance`), detection was correct (manifest, `--dry-run`) but the summarize pass always rendered the built-in `summarize-paper` prompt for PDFs and wrote `source_type: paper` — the configured type never reached prompt selection or frontmatter.

## Root cause

`extract.Extract(path, sourceType)` dropped `sourceType` at dispatch for every binary format: `extractPDF`/`extractDocx`/`extractXlsx`/`extractPptx`/`extractCSV`/`extractEpub`/`extractEmail` hardcoded their detected type ("paper"/"article"/"dataset"). Downstream, `summarize.go` selects `summarize_<content.Type>` and writes `source_type: <content.Type>` from that field. Markdown/plaintext/external extractors already honored the parameter — which is why the reporter's markdown control test worked.

Sibling of #79, one layer down: that fix repaired detection (`TypeForPath` in `diff.go`); this repairs extraction.

## Fix

Thread `sourceType` through the seven binary extractors via `orDefaultType` (`""`/`"auto"` → historical per-format default: paper/article/dataset). `image`/`code` stay pinned — they are functional routing types (`IsImageSource` gates the vision pipeline), not prompt styling.

## Tests

- `TestExtractPropagatesConfiguredType`: 7 formats × configured/empty/auto (red before, green after)
- `TestExtractFunctionalTypesStayPinned`: image/code pins hold under a configured type
- Fuzz + limits call sites updated for the new signatures
- Full suite green (pre-existing, unrelated `tools/ciproof` date-rot failure reproduced on clean main — fixture waiver expired 2026-08-20)