### PR TITLE
fix(ci): unrot ciproof valid-waiver fixture date

### DIFF
--- a/tools/ciproof/main_test.go
+++ b/tools/ciproof/main_test.go
@@ -217,7 +217,7 @@ func TestProof(t *testing.T) {
 					Reason:           "Runner capacity outage caused red; confirmed not a code regression.",
 					IncidentLink:     "https://github.com/xoai/sage-wiki/issues/200",
 					SHA:              validSHA,
-					ExpiresAt:        "2026-08-20T00:00:00Z",
+					ExpiresAt:        "2036-08-20T00:00:00Z", // far-future: a "valid" fixture must not date-rot
 					OriginalEvidence: "CI required failed due to runner timeout, not code defect.",
 				}
 				return f


### PR DESCRIPTION
Main has been red since 2026-08-21: the "valid emergency waiver for red SHA" fixture in `tools/ciproof/main_test.go` carried `ExpiresAt: 2026-08-20T00:00:00Z`, which expired and turned `TestProof/valid_emergency_waiver_for_red_SHA` — and with it the Test rest shard and the CI required aggregate — red on every run regardless of the code under test.

One-line fix: bump the VALID-case fixture to 2036-08-20 (a "valid" fixture must not date-rot). The neighboring expired-waiver case keeps its past date — that is what it tests.

Verified locally: `go test ./tools/ciproof/` green; failure reproduced on clean main beforehand.

Unblocks #169.