### PR TITLE
fix(ci): docker-tag waits for the tag's CI before proof verification

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,6 +107,34 @@ jobs:
         id: tag-sha
         run: echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
+      # The tag push starts THIS job and the tag's CI run at the same
+      # moment; the proof verifier below must not run until that CI run
+      # has reported (it fails closed when no completed "CI required"
+      # check exists yet — v0.2.9 and v0.2.10 both raced it green-CI-red-
+      # proof). Poll the exact-SHA check-runs until "CI required" is
+      # completed; red conclusions are left to the verifier, preserving
+      # fail-closed semantics.
+      - name: Wait for the tag's CI run to report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 2700)) # 45 min: CI's long pole ~15 min + queue margin
+          while :; do
+            state="$(gh api "repos/${{ github.repository }}/commits/${{ steps.tag-sha.outputs.sha }}/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "CI required") | .status] | first // ""')"
+            if [ "$state" = "completed" ]; then
+              echo "CI required is completed; proceeding to proof verification."
+              exit 0
+            fi
+            if [ $SECONDS -ge $deadline ]; then
+              echo "::error::Timed out after 45 min waiting for the tag's CI run (last CI-required state: '${state:-none}')."
+              exit 1
+            fi
+            echo "CI required not yet reported (state: '${state:-none}'); waiting 30s..."
+            sleep 30
+          done
+
       - name: Verify exact-SHA CI proof
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

Both v0.2.9 and v0.2.10 Docker tag jobs failed the exact-SHA proof verifier ~1 minute after the tag push — before the tag's own CI run had produced a completed `CI required` check-run. The verifier is behaving correctly (fail closed on no evidence); the ordering was wrong. Both releases passed on manual rerun once CI reported, and v0.2.10's images are published.

## Fix

A bounded `Wait for the tag's CI run to report` step in the `docker-tag` job, before the verifier: polls `commits/{sha}/check-runs` every 30s until a `CI required` check has `status=completed`, 45-minute deadline (CI's long pole is ~15 min plus queue margin). Red conclusions are deliberately left to the unchanged verifier — fail-closed semantics preserved; only the race window is closed.

`docker-main` already sequences via `workflow_run` (fires only after CI completes) and needs no change.

Validated: the polling expression returns `completed/success` immediately against the live API for the v0.2.10 SHA; bash -n + YAML parse clean.